### PR TITLE
fix(db): complete Prisma migration history (groups, activities, user fields)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 
 # idea files
 .idea
+.env*

--- a/prisma/migrations/20260617210000_add_groups_activities_and_user_fields/migration.sql
+++ b/prisma/migrations/20260617210000_add_groups_activities_and_user_fields/migration.sql
@@ -1,0 +1,71 @@
+-- CreateEnum
+CREATE TYPE "MemberRole" AS ENUM ('FADDER', 'FADDERBARN');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "hasPaid" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "klasse" TEXT,
+ADD COLUMN     "phone" TEXT,
+ADD COLUMN     "studieretning" TEXT;
+
+-- CreateTable
+CREATE TABLE "FadderGruppe" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FadderGruppe_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FadderGruppeMember" (
+    "id" TEXT NOT NULL,
+    "role" "MemberRole" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+    "gruppeId" TEXT NOT NULL,
+
+    CONSTRAINT "FadderGruppeMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Activity" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "date" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GroupMessage" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authorId" TEXT NOT NULL,
+    "gruppeId" TEXT NOT NULL,
+
+    CONSTRAINT "GroupMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FadderGruppeMember_userId_gruppeId_key" ON "FadderGruppeMember"("userId", "gruppeId");
+
+-- AddForeignKey
+ALTER TABLE "FadderGruppeMember" ADD CONSTRAINT "FadderGruppeMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FadderGruppeMember" ADD CONSTRAINT "FadderGruppeMember_gruppeId_fkey" FOREIGN KEY ("gruppeId") REFERENCES "FadderGruppe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupMessage" ADD CONSTRAINT "GroupMessage_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupMessage" ADD CONSTRAINT "GroupMessage_gruppeId_fkey" FOREIGN KEY ("gruppeId") REFERENCES "FadderGruppe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+


### PR DESCRIPTION
## Problem
The migration history only contained `20260309170534_user_verification`, which creates **Post, User (partial), Session, Account, Verification**. But `schema.prisma` had drifted ahead — `FadderGruppe`, `FadderGruppeMember`, `Activity`, `GroupMessage` tables and the `phone`/`hasPaid`/`isAdmin`/`klasse`/`studieretning` `User` columns were added via `prisma db push` without a migration.

As a result, a fresh `prisma migrate deploy` produces an **incomplete schema** — this actually broke the first test deploy (sign-up 500: `column User.phone does not exist`; `table Activity does not exist`).

## Fix
Adds catch-up migration `20260617210000_add_groups_activities_and_user_fields` that creates the 4 missing tables (+ FKs) and 5 missing `User` columns.

## Verification
- Replaying the **full** migration history on a clean Postgres reproduces `schema.prisma` with **zero drift** (`prisma migrate diff` → empty).
- The live test DB reports `migrate status` → **up to date**.
- Sign-up / session flow confirmed working on the test deployment after the schema sync.

Also adds `.env*` to `.gitignore` (added automatically by the Vercel/Neon integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)