### PR TITLE
feat(auth): replace better-auth with TIHLDE login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,10 @@
 # When adding additional environment variables, the schema in "/src/env.js"
 # should be updated accordingly.
 
-# Better Auth
-# You can generate a new secret on the command line with:
-# npx @better-auth/cli secret
-BETTER_AUTH_SECRET=""
+# TIHLDE auth
+# Login is delegated to TIHLDE's Lepton API. Defaults to production; override
+# only if pointing at a different TIHLDE backend.
+TIHLDE_API_URL="https://api.tihlde.org"
 
 # Vipps ePayment — get all values from https://portal.vipps.no
 VIPPS_CLIENT_ID=""

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
         "@trpc/next": "11.8.1",
         "@trpc/react-query": "11.8.1",
         "@trpc/server": "11.8.1",
-        "better-auth": "^1.4.18",
         "class-variance-authority": "^0.7.1",
         "lucide-react": "^0.544.0",
         "next": "^16.1.1",
@@ -51,24 +50,6 @@
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
-
-    "@better-auth/core": ["@better-auth/core@1.5.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "better-call": "1.3.2", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA=="],
-
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "drizzle-orm": ">=0.41.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-HAi9xAP40oDt48QZeYBFTcmg3vt1Jik90GwoRIfangd7VGbxesIIDBJSnvwMbZ52GBIc6+V4FRw9lasNiNrPfw=="],
-
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "kysely": "^0.27.0 || ^0.28.0" } }, "sha512-LmHffIVnqbfsxcxckMOoE8MwibWrbVFch+kwPKJ5OFDFv6lin75ufN7ZZ7twH0IMPLT/FcgzaRjP8jRrXRef9g=="],
-
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0" } }, "sha512-4X0j1/2L+nsgmObjmy9xEGUFWUv38Qjthp558fwS3DAp6ueWWyCaxaD6VJZ7m5qPNMrsBStO5WGP8CmJTEWm7g=="],
-
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "mongodb": "^6.0.0 || ^7.0.0" } }, "sha512-P1J9ljL5X5k740I8Rx1esPWNgWYPdJR5hf2CY7BwDSrQFPUHuzeCg0YhtEEP55niNateTXhBqGAcy0fVOeamZg=="],
-
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-CliDd78CXHzzwQIXhCdwGr5Ml53i6JdCHWV7PYwTIJz9EAm6qb2RVBdpP3nqEfNjINGM22A6gfleCgCdZkTIZg=="],
-
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.5.5", "", { "dependencies": { "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.5.5" } }, "sha512-1+lklxArn4IMHuU503RcPdXrSG2tlXt4jnGG3omolmspQ7tktg/Y9XO/yAkYDurtvMn1xJ8X1Ov01Ji/r5s9BQ=="],
-
-    "@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
-
-    "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -170,8 +151,6 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.6", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g=="],
-
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@next/env": ["@next/env@16.2.0", "", {}, "sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA=="],
@@ -193,10 +172,6 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-DRrNJKW+/eimrZgdhVN1uvkN1OI4j6Lpefwr44jKQ0YQzztlmOBUUzHuV5GxOMPK3nmodAYElUVCY8ZXo/IWeA=="],
-
-    "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
-
-    "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -354,10 +329,6 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
-
-    "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
-
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.1", "@typescript-eslint/type-utils": "8.57.1", "@typescript-eslint/utils": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.57.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.57.1", "@typescript-eslint/types": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw=="],
@@ -460,15 +431,9 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.9", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg=="],
 
-    "better-auth": ["better-auth@1.5.5", "", { "dependencies": { "@better-auth/core": "1.5.5", "@better-auth/drizzle-adapter": "1.5.5", "@better-auth/kysely-adapter": "1.5.5", "@better-auth/memory-adapter": "1.5.5", "@better-auth/mongo-adapter": "1.5.5", "@better-auth/prisma-adapter": "1.5.5", "@better-auth/telemetry": "1.5.5", "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.2", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.11", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg=="],
-
-    "better-call": ["better-call@1.3.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw=="],
-
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
-    "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
     "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
 
@@ -742,8 +707,6 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
-
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -759,8 +722,6 @@
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
-    "kysely": ["kysely@0.28.14", "", {}, "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
@@ -804,8 +765,6 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
-
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
@@ -814,15 +773,9 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "mongodb": ["mongodb@7.1.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg=="],
-
-    "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.1", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
@@ -930,8 +883,6 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
-
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
@@ -945,8 +896,6 @@
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
-
-    "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -969,8 +918,6 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
-
-    "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
@@ -1014,8 +961,6 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
-
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
@@ -1052,10 +997,6 @@
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
-    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
-
-    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
-
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -1071,8 +1012,6 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1143,8 +1082,6 @@
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@trpc/next": "11.8.1",
     "@trpc/react-query": "11.8.1",
     "@trpc/server": "11.8.1",
-    "better-auth": "^1.4.18",
     "class-variance-authority": "^0.7.1",
     "lucide-react": "^0.544.0",
     "next": "^16.1.1",

--- a/prisma/migrations/20260617210000_add_groups_activities_and_user_fields/migration.sql
+++ b/prisma/migrations/20260617210000_add_groups_activities_and_user_fields/migration.sql
@@ -1,0 +1,71 @@
+-- CreateEnum
+CREATE TYPE "MemberRole" AS ENUM ('FADDER', 'FADDERBARN');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "hasPaid" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "klasse" TEXT,
+ADD COLUMN     "phone" TEXT,
+ADD COLUMN     "studieretning" TEXT;
+
+-- CreateTable
+CREATE TABLE "FadderGruppe" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FadderGruppe_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FadderGruppeMember" (
+    "id" TEXT NOT NULL,
+    "role" "MemberRole" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+    "gruppeId" TEXT NOT NULL,
+
+    CONSTRAINT "FadderGruppeMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Activity" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "date" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GroupMessage" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authorId" TEXT NOT NULL,
+    "gruppeId" TEXT NOT NULL,
+
+    CONSTRAINT "GroupMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FadderGruppeMember_userId_gruppeId_key" ON "FadderGruppeMember"("userId", "gruppeId");
+
+-- AddForeignKey
+ALTER TABLE "FadderGruppeMember" ADD CONSTRAINT "FadderGruppeMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FadderGruppeMember" ADD CONSTRAINT "FadderGruppeMember_gruppeId_fkey" FOREIGN KEY ("gruppeId") REFERENCES "FadderGruppe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupMessage" ADD CONSTRAINT "GroupMessage_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupMessage" ADD CONSTRAINT "GroupMessage_gruppeId_fkey" FOREIGN KEY ("gruppeId") REFERENCES "FadderGruppe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/migrations/20260617213000_tihlde_auth/migration.sql
+++ b/prisma/migrations/20260617213000_tihlde_auth/migration.sql
@@ -1,0 +1,20 @@
+-- DropForeignKey
+ALTER TABLE "Account" DROP CONSTRAINT "Account_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "tihldeToken" TEXT;
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "emailVerified",
+ADD COLUMN     "tihldeUserId" TEXT NOT NULL,
+ALTER COLUMN "email" DROP NOT NULL;
+
+-- DropTable
+DROP TABLE "Account";
+
+-- DropTable
+DROP TABLE "Verification";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_tihldeUserId_key" ON "User"("tihldeUserId");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,10 +28,12 @@ model Post {
 }
 
 model User {
+    // tihldeUserId is the TIHLDE account identifier (Lepton `user_id`) and the
+    // stable link between a TIHLDE account and this app's user record.
     id            String    @id @default(cuid())
+    tihldeUserId  String    @unique
     name          String
-    email         String    @unique
-    emailVerified Boolean   @default(false)
+    email         String?   @unique
     image         String?
     phone         String?
     klasse        String?
@@ -42,7 +44,6 @@ model User {
     createdAt     DateTime  @default(now())
     updatedAt     DateTime  @updatedAt
     sessions      Session[]
-    accounts      Account[]
     posts         Post[]
     memberships   FadderGruppeMember[]
     groupMessages GroupMessage[]
@@ -91,39 +92,16 @@ model GroupMessage {
 }
 
 model Session {
-    id        String   @id @default(cuid())
-    expiresAt DateTime
-    token     String   @unique
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
-    ipAddress String?
-    userAgent String?
-    userId    String
-    user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-}
-
-model Account {
-    id                    String    @id @default(cuid())
-    accountId             String
-    providerId            String
-    userId                String
-    user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-    accessToken           String?
-    refreshToken          String?
-    idToken               String?
-    accessTokenExpiresAt  DateTime?
-    refreshTokenExpiresAt DateTime?
-    scope                 String?
-    password              String?
-    createdAt             DateTime  @default(now())
-    updatedAt             DateTime  @updatedAt
-}
-
-model Verification {
-    id         String   @id @default(cuid())
-    identifier String
-    value      String
-    expiresAt  DateTime
-    createdAt  DateTime @default(now())
-    updatedAt  DateTime @updatedAt
+    // Opaque app session. `tihldeToken` stores the TIHLDE API token so we can
+    // call Lepton on the user's behalf (e.g. refresh their profile).
+    id          String   @id @default(cuid())
+    expiresAt   DateTime
+    token       String   @unique
+    tihldeToken String?
+    createdAt   DateTime @default(now())
+    updatedAt   DateTime @updatedAt
+    ipAddress   String?
+    userAgent   String?
+    userId      String
+    user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/app/(authenticated)/admin/grupper-tab.tsx
+++ b/src/app/(authenticated)/admin/grupper-tab.tsx
@@ -358,7 +358,7 @@ function AddMemberForm({
 }: {
   gruppeId: string;
   role: "FADDER" | "FADDERBARN";
-  availableUsers: { id: string; name: string; email: string }[];
+  availableUsers: { id: string; name: string; email: string | null }[];
   onAdd: (userId: string) => void;
   onCancel: () => void;
   isPending: boolean;
@@ -369,7 +369,7 @@ function AddMemberForm({
   const filtered = availableUsers.filter(
     (u) =>
       u.name.toLowerCase().includes(search.toLowerCase()) ||
-      u.email.toLowerCase().includes(search.toLowerCase()),
+      (u.email?.toLowerCase().includes(search.toLowerCase()) ?? false),
   );
 
   return (

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -55,7 +55,7 @@ export function UsersTab() {
   const filteredVerified = verifiedUsers.filter(
     (u) =>
       u.name.toLowerCase().includes(search.toLowerCase()) ||
-      u.email.toLowerCase().includes(search.toLowerCase()),
+      (u.email?.toLowerCase().includes(search.toLowerCase()) ?? false),
   );
 
   if (isLoading) {

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,0 @@
-import { auth } from "~/server/auth";
-import { toNextJsHandler } from "better-auth/next-js";
-
-export const { GET, POST } = toNextJsHandler(auth);

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,85 @@
+import { cookies, headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  createSession,
+} from "~/server/auth/config";
+import { db } from "~/server/db";
+import {
+  TihldeAuthError,
+  mapProfile,
+  tihldeGetMe,
+  tihldeLogin,
+} from "~/server/auth/tihlde";
+
+const bodySchema = z.object({
+  user_id: z.string().min(1, "Brukernavn er påkrevd."),
+  password: z.string().min(1, "Passord er påkrevd."),
+});
+
+export async function POST(request: Request) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Fyll inn brukernavn og passord." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // 1. Validate credentials against TIHLDE and fetch the profile.
+    const token = await tihldeLogin(parsed.data.user_id, parsed.data.password);
+    const profile = await tihldeGetMe(token);
+    const mapped = mapProfile(profile);
+
+    // 2. Upsert the local user, keyed by TIHLDE user_id. App-specific flags
+    //    (isAdmin, hasPaid, isVerified) are owned by us and never overwritten.
+    const user = await db.user.upsert({
+      where: { tihldeUserId: mapped.tihldeUserId },
+      create: mapped,
+      update: {
+        name: mapped.name,
+        email: mapped.email,
+        image: mapped.image,
+        studieretning: mapped.studieretning,
+        klasse: mapped.klasse,
+      },
+    });
+
+    // 3. Mint our own session and set the httpOnly cookie.
+    const hdrs = await headers();
+    const { token: sessionToken, expiresAt } = await createSession({
+      userId: user.id,
+      tihldeToken: token,
+      ipAddress:
+        hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+      userAgent: hdrs.get("user-agent"),
+    });
+
+    const cookieStore = await cookies();
+    cookieStore.set(SESSION_COOKIE, sessionToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: SESSION_MAX_AGE,
+      expires: expiresAt,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    if (err instanceof TihldeAuthError) {
+      // 401/403 from TIHLDE → surface the (Norwegian) detail to the user.
+      const status = err.status === 401 || err.status === 403 ? 401 : 502;
+      return NextResponse.json({ error: err.message }, { status });
+    }
+    console.error("[auth/login] unexpected error", err);
+    return NextResponse.json(
+      { error: "Noe gikk galt ved innlogging." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { SESSION_COOKIE, deleteSession } from "~/server/auth/config";
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE)?.value;
+
+  if (token) {
+    await deleteSession(token);
+  }
+  cookieStore.delete(SESSION_COOKIE);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -9,18 +9,10 @@ import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { authClient } from "~/lib/auth-client";
 
-type View = "login" | "register";
-
 export default function RegistreringPage() {
-  const [view, setView] = useState<View>("login");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-
-  const switchView = (next: View) => {
-    setError(null);
-    setView(next);
-  };
 
   const handleLogin = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -28,56 +20,13 @@ export default function RegistreringPage() {
     setLoading(true);
 
     const formData = new FormData(e.currentTarget);
-    const email = formData.get("email") as string;
+    const userId = (formData.get("user_id") as string)?.trim();
     const password = formData.get("password") as string;
 
-    const { error } = await authClient.signIn.email({ email, password });
+    const { error } = await authClient.signIn(userId, password);
 
     if (error) {
-      setError(error.message ?? "Noe gikk galt ved innlogging.");
-      setLoading(false);
-      return;
-    }
-
-    router.push("/");
-    router.refresh();
-  };
-
-  const handleRegister = async (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setError(null);
-    setLoading(true);
-
-    const formData = new FormData(e.currentTarget);
-    const name = formData.get("name") as string;
-    const email = formData.get("email") as string;
-    const password = formData.get("password") as string;
-    const confirmPassword = formData.get("confirmPassword") as string;
-    const klasse = formData.get("klasse") as string;
-    const studieretning = formData.get("studieretning") as string;
-
-    if (password !== confirmPassword) {
-      setError("Passordene stemmer ikke overens.");
-      setLoading(false);
-      return;
-    }
-
-    if (!klasse) {
-      setError("Velg hvilket klassetrinn du er på.");
-      setLoading(false);
-      return;
-    }
-
-    if (!studieretning) {
-      setError("Velg din studieretning.");
-      setLoading(false);
-      return;
-    }
-
-    const { error } = await authClient.signUp.email({ name, email, password, klasse, studieretning });
-
-    if (error) {
-      setError(error.message ?? "Noe gikk galt ved registrering.");
+      setError(error);
       setLoading(false);
       return;
     }
@@ -95,34 +44,51 @@ export default function RegistreringPage() {
       }}
     >
       <main className="flex flex-1 items-center justify-center px-4 py-8">
-      <div className="w-full max-w-xl">
-        <Card>
-          {view === "login" ? (
+        <div className="w-full max-w-xl">
+          <Card>
             <form onSubmit={handleLogin} style={{ padding: "3rem" }}>
-              <div style={{ marginBottom: "1.5rem", display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <div
+                style={{
+                  marginBottom: "1.5rem",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.5rem",
+                }}
+              >
                 <CardTitle className="text-3xl font-bold">Logg inn</CardTitle>
                 <CardDescription>
-                  Logg inn med ditt TIHLDE brukernavn og passord
+                  Logg inn med ditt TIHLDE-brukernavn og passord
                 </CardDescription>
               </div>
 
               {error && (
-                <div className="bg-destructive/10 text-destructive rounded-md px-4 py-3 text-sm" style={{ marginBottom: "1.5rem" }}>
+                <div
+                  className="bg-destructive/10 text-destructive rounded-md px-4 py-3 text-sm"
+                  style={{ marginBottom: "1.5rem" }}
+                >
                   {error}
                 </div>
               )}
 
-              <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem", marginBottom: "2rem" }}>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "1.5rem",
+                  marginBottom: "2rem",
+                }}
+              >
                 <div className="grid gap-2">
-                  <Label htmlFor="login-email">
-                    E-post <span className="text-destructive">*</span>
+                  <Label htmlFor="login-user-id">
+                    Brukernavn <span className="text-destructive">*</span>
                   </Label>
                   <Input
-                    id="login-email"
-                    name="email"
-                    type="email"
+                    id="login-user-id"
+                    name="user_id"
+                    type="text"
+                    autoComplete="username"
                     required
-                    placeholder="din@epost.no"
+                    placeholder="ditt TIHLDE-brukernavn"
                     className="h-12"
                   />
                 </div>
@@ -134,6 +100,7 @@ export default function RegistreringPage() {
                     id="login-password"
                     name="password"
                     type="password"
+                    autoComplete="current-password"
                     required
                     placeholder="••••••••"
                     className="h-12"
@@ -141,139 +108,27 @@ export default function RegistreringPage() {
                 </div>
               </div>
 
-              <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-                <Button type="submit" className="h-12 w-full text-base" disabled={loading}>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "1.25rem",
+                }}
+              >
+                <Button
+                  type="submit"
+                  className="h-12 w-full text-base"
+                  disabled={loading}
+                >
                   {loading ? "Logger inn..." : "Logg inn"}
                 </Button>
-                <div className="flex w-full justify-between text-sm">
-                  <button type="button" className="text-primary font-medium hover:underline">
-                    Glemt passord?
-                  </button>
-                  <button type="button" onClick={() => switchView("register")} className="text-primary font-medium hover:underline">
-                    Opprett bruker
-                  </button>
-                </div>
+                <p className="text-muted-foreground text-center text-sm">
+                  Bruk samme brukernavn og passord som på tihlde.org.
+                </p>
               </div>
             </form>
-          ) : (
-            <form onSubmit={handleRegister} style={{ padding: "3rem" }}>
-              <div style={{ marginBottom: "1.5rem", display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-                <CardTitle className="text-3xl font-bold">Opprett bruker</CardTitle>
-                <CardDescription>
-                  Fyll inn informasjonen din for å opprette en konto
-                </CardDescription>
-              </div>
-
-              {error && (
-                <div className="bg-destructive/10 text-destructive rounded-md px-4 py-3 text-sm" style={{ marginBottom: "1.5rem" }}>
-                  {error}
-                </div>
-              )}
-
-              <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem", marginBottom: "2rem" }}>
-                <div className="grid gap-2">
-                  <Label htmlFor="register-name">
-                    Fullt navn <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="register-name"
-                    name="name"
-                    type="text"
-                    required
-                    placeholder="Ola Nordmann"
-                    className="h-12"
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="register-email">
-                    E-post <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="register-email"
-                    name="email"
-                    type="email"
-                    required
-                    placeholder="din@epost.no"
-                    className="h-12"
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="register-password">
-                    Passord <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="register-password"
-                    name="password"
-                    type="password"
-                    required
-                    placeholder="••••••••"
-                    className="h-12"
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="register-confirm-password">
-                    Bekreft passord <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="register-confirm-password"
-                    name="confirmPassword"
-                    type="password"
-                    required
-                    placeholder="••••••••"
-                    className="h-12"
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="register-klasse">
-                    Klassetrinn <span className="text-destructive">*</span>
-                  </Label>
-                  <select
-                    id="register-klasse"
-                    name="klasse"
-                    defaultValue=""
-                    className="h-12 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="" disabled>Velg klassetrinn</option>
-                    <option value="1 klasse">1. klasse</option>
-                    <option value="2 klasse">2. klasse</option>
-                    <option value="3 klasse">3. klasse</option>
-                    <option value="4 klasse">4. klasse</option>
-                    <option value="5 klasse">5. klasse</option>
-                  </select>
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="register-studieretning">
-                    Studieretning <span className="text-destructive">*</span>
-                  </Label>
-                  <select
-                    id="register-studieretning"
-                    name="studieretning"
-                    defaultValue=""
-                    className="h-12 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  >
-                    <option value="" disabled>Velg studieretning</option>
-                    <option value="DigSec">DigSec</option>
-                    <option value="DigFor">DigFor</option>
-                    <option value="Data">Data</option>
-                    <option value="DigTrans">DigTrans</option>
-                  </select>
-                </div>
-              </div>
-
-              <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-                <Button type="submit" className="h-12 w-full text-base" disabled={loading}>
-                  {loading ? "Registrerer..." : "Opprett konto"}
-                </Button>
-                <div className="flex w-full justify-center text-sm">
-                  <button type="button" onClick={() => switchView("login")} className="text-primary font-medium hover:underline">
-                    Har du allerede en konto? Logg inn
-                  </button>
-                </div>
-              </div>
-            </form>
-          )}
-        </Card>
-      </div>
+          </Card>
+        </div>
       </main>
       <Footer />
     </div>

--- a/src/components/layout/user-area.tsx
+++ b/src/components/layout/user-area.tsx
@@ -35,12 +35,13 @@ export const UserArea = ({
   const signOutButton = async () => {
     setOpen(false);
     await authClient.signOut();
+    router.push("/registrering");
     router.refresh();
   };
 
   const signInButton = () => {
     setOpen(false);
-    // TODO: implement non-Vipps sign in
+    router.push("/registrering");
   };
 
   const goToAdmin = () => {

--- a/src/env.js
+++ b/src/env.js
@@ -3,11 +3,7 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
-    BETTER_AUTH_URL: z.string().url(),
-    BETTER_AUTH_SECRET:
-      process.env.NODE_ENV === "production"
-        ? z.string()
-        : z.string().optional(),
+    TIHLDE_API_URL: z.string().url().default("https://api.tihlde.org"),
     DATABASE_URL: z.string().url(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
@@ -23,8 +19,7 @@ export const env = createEnv({
   client: {},
 
   runtimeEnv: {
-    BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
-    BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+    TIHLDE_API_URL: process.env.TIHLDE_API_URL,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
     VIPPS_CLIENT_ID: process.env.VIPPS_CLIENT_ID,

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,8 +1,42 @@
-import { createAuthClient } from "better-auth/react";
-import { inferAdditionalFields } from "better-auth/client/plugins";
-import type { auth } from "~/server/auth/config";
+/**
+ * Thin client-side auth helpers that talk to our own /api/auth routes, which
+ * in turn proxy to TIHLDE. Replaces the previous better-auth React client.
+ */
 
-export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL ?? "http://localhost:3000",
-  plugins: [inferAdditionalFields<typeof auth>()],
-});
+interface Result {
+  error: string | null;
+}
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    return body?.error ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export const authClient = {
+  /** Log in with a TIHLDE username + password. */
+  async signIn(userId: string, password: string): Promise<Result> {
+    const res = await fetch("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId, password }),
+    });
+
+    if (!res.ok) {
+      return { error: await readError(res, "Noe gikk galt ved innlogging.") };
+    }
+    return { error: null };
+  },
+
+  /** Destroy the current session. */
+  async signOut(): Promise<Result> {
+    const res = await fetch("/api/auth/logout", { method: "POST" });
+    if (!res.ok) {
+      return { error: await readError(res, "Noe gikk galt ved utlogging.") };
+    }
+    return { error: null };
+  },
+};

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -1,51 +1,86 @@
-import { betterAuth } from "better-auth";
-import { prismaAdapter } from "better-auth/adapters/prisma";
-import { db } from "~/server/db";
-import { env } from "../../env";
+import "server-only";
 
-export const auth = betterAuth({
-  baseURL: env.BETTER_AUTH_URL,
-  database: prismaAdapter(db, {
-    provider: "postgresql",
-  }),
-  session: {
-    expiresIn: 60 * 60 * 24 * 7, // 7 days
-  },
-  emailAndPassword: {
-    enabled: true,
-  },
-  user: {
-    additionalFields: {
-      isVerified: {
-        type: "boolean",
-        defaultValue: false,
-        input: false,
-      },
-      hasPaid: {
-        type: "boolean",
-        defaultValue: false,
-        input: false,
-      },
-      isAdmin: {
-        type: "boolean",
-        defaultValue: false,
-        input: false,
-      },
-      phone: {
-        type: "string",
-        required: false,
-        input: false,
-      },
-      klasse: {
-        type: "string",
-        required: false,
-        input: true,
-      },
-      studieretning: {
-        type: "string",
-        required: false,
-        input: true,
-      },
+import { randomBytes } from "crypto";
+import { db } from "~/server/db";
+
+/**
+ * Custom session layer backing TIHLDE-based auth.
+ *
+ * We deliberately keep the `auth.api.getSession({ headers })` shape that the
+ * rest of the app already calls, so server components and the tRPC context did
+ * not need to change when we replaced better-auth.
+ *
+ * Sessions are opaque random tokens stored in Postgres and referenced by an
+ * httpOnly cookie — no signing secret needed since the token carries no data.
+ */
+
+export const SESSION_COOKIE = "fadderuke.session_token";
+export const SESSION_MAX_AGE = 60 * 60 * 24 * 7; // 7 days, in seconds
+
+function parseCookie(header: string | null, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return null;
+}
+
+async function getSession({ headers }: { headers: Headers }) {
+  const token = parseCookie(headers.get("cookie"), SESSION_COOKIE);
+  if (!token) return null;
+
+  const session = await db.session.findUnique({
+    where: { token },
+    include: { user: true },
+  });
+  if (!session) return null;
+
+  if (session.expiresAt.getTime() < Date.now()) {
+    await db.session.delete({ where: { token } }).catch(() => undefined);
+    return null;
+  }
+
+  const { user, ...rest } = session;
+  return { user, session: rest };
+}
+
+/** Create a persisted session for a user and return its cookie token. */
+export async function createSession(opts: {
+  userId: string;
+  tihldeToken: string;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}) {
+  const token = randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000);
+
+  await db.session.create({
+    data: {
+      token,
+      userId: opts.userId,
+      tihldeToken: opts.tihldeToken,
+      expiresAt,
+      ipAddress: opts.ipAddress ?? null,
+      userAgent: opts.userAgent ?? null,
     },
-  },
-});
+  });
+
+  return { token, expiresAt };
+}
+
+/** Invalidate a session by its cookie token. */
+export async function deleteSession(token: string) {
+  await db.session.deleteMany({ where: { token } });
+}
+
+/**
+ * Mirrors the better-auth `auth.api.getSession` interface the app relies on.
+ * Returns `{ user, session } | null`.
+ */
+export const auth = {
+  api: { getSession },
+};

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -1,0 +1,111 @@
+import "server-only";
+
+import { env } from "~/env";
+
+/**
+ * Thin client for TIHLDE's Lepton API.
+ *
+ * Auth flow (verified against the Lepton/Kvark source):
+ *   POST {API}/auth/login/  body { user_id, password }  -> { token }
+ *   GET  {API}/users/me/     header "X-CSRF-Token: <token>" -> profile
+ *
+ * Login only succeeds for activated TIHLDE members; otherwise Lepton returns
+ * 401 with a Norwegian `detail` message which we surface to the user as-is.
+ */
+
+const TOKEN_HEADER = "X-CSRF-Token";
+
+const apiUrl = (path: string) =>
+  `${env.TIHLDE_API_URL.replace(/\/$/, "")}${path}`;
+
+/** Raised for any non-success TIHLDE response; `message` is safe to show the user. */
+export class TihldeAuthError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "TihldeAuthError";
+  }
+}
+
+/** The subset of `GET /users/me/` we map onto our local user. */
+export interface TihldeProfile {
+  user_id: string;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  image: string | null;
+  study: { group?: { name?: string } | null } | null;
+  studyyear: { group?: { name?: string } | null } | null;
+}
+
+async function readDetail(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { detail?: string };
+    return body?.detail ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Authenticate against TIHLDE. Returns the API token on success. */
+export async function tihldeLogin(
+  userId: string,
+  password: string,
+): Promise<string> {
+  const res = await fetch(apiUrl("/auth/login/"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId, password }),
+    // Never cache auth requests.
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new TihldeAuthError(
+      await readDetail(res, "Brukernavnet eller passordet ditt var feil."),
+      res.status,
+    );
+  }
+
+  const data = (await res.json()) as { token?: string };
+  if (!data.token) {
+    throw new TihldeAuthError("Fikk ikke token fra TIHLDE.", 502);
+  }
+  return data.token;
+}
+
+/** Fetch the authenticated user's TIHLDE profile. */
+export async function tihldeGetMe(token: string): Promise<TihldeProfile> {
+  const res = await fetch(apiUrl("/users/me/"), {
+    headers: { [TOKEN_HEADER]: token },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new TihldeAuthError(
+      await readDetail(res, "Kunne ikke hente brukerinformasjonen din."),
+      res.status,
+    );
+  }
+
+  return (await res.json()) as TihldeProfile;
+}
+
+/** Map a TIHLDE profile onto the fields we persist locally. */
+export function mapProfile(profile: TihldeProfile) {
+  const name = [profile.first_name, profile.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return {
+    tihldeUserId: profile.user_id,
+    name: name || profile.user_id,
+    email: profile.email ?? null,
+    image: profile.image ?? null,
+    studieretning: profile.study?.group?.name ?? null,
+    klasse: profile.studyyear?.group?.name ?? null,
+  };
+}


### PR DESCRIPTION
Replaces local email/password (better-auth) with **TIHLDE login**, per request. Users now sign in with their TIHLDE accounts.

## How it works
1. Login form posts `{ user_id, password }` → `/api/auth/login`
2. Server proxies to `POST https://api.tihlde.org/auth/login/` → gets a token
3. Fetches profile from `GET /users/me/` (`X-CSRF-Token` header)
4. **Upserts a local `User`** keyed by `tihldeUserId` (name/email/study/class pulled from TIHLDE)
5. Mints an opaque, httpOnly, DB-backed session (7-day)

The `auth.api.getSession({ headers })` interface is preserved, so the 5 server call sites (tRPC context, layouts, header, admin/faddergruppe pages) are unchanged.

App-specific flags (`isAdmin`, `hasPaid`, `isVerified`, faddergruppe membership) stay in our Postgres, keyed by `tihldeUserId` — TIHLDE doesn't store them.

## Changes
- **New:** `src/server/auth/tihlde.ts`, `/api/auth/login`, `/api/auth/logout`
- **Rewrite:** `auth/config.ts` (custom session layer), `registrering` → login-only form, `auth-client.ts` (thin fetch helpers), `user-area.tsx` (logout/login)
- **Schema:** `User.tihldeUserId @unique`, `email` optional, `Session.tihldeToken`; drop better-auth `Account`/`Verification` tables (new migration `20260617213000_tihlde_auth`)
- **Removed:** `better-auth` dependency, `BETTER_AUTH_*` env (→ `TIHLDE_API_URL`), better-auth catch-all route

## Verification
Deployed to the test env (https://fadderuke-test.vercel.app) and confirmed the full round-trip:
- Bad credentials → `401` surfacing TIHLDE's own message (`"Brukernavnet du har oppgitt tilhører ingen konto..."`) — proves live connectivity + parsing
- Unauthenticated routes redirect; login page renders; validation works
- `prisma migrate diff` → **zero drift** across the full migration chain
- Successful-login path (upsert + session) is source-verified but not yet exercised with a real TIHLDE account

## Notes
- Includes the migration-history catch-up from #50 so this branch is self-contained; if #50 merges first the added file is identical (no conflict).
- **Admin bootstrapping:** since signup is gone, grant admin via DB — `UPDATE \"User\" SET \"isAdmin\"=true WHERE \"tihldeUserId\"='<user>';` (user must have logged in once first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)