### PR TITLE
feat(auth): derive admin from TIHLDE permissions, auto-skip payment

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -10,8 +10,10 @@ import {
 import { db } from "~/server/db";
 import {
   TihldeAuthError,
+  isAdminFromPermissions,
   mapProfile,
   tihldeGetMe,
+  tihldeGetPermissions,
   tihldeLogin,
 } from "~/server/auth/tihlde";
 
@@ -35,21 +37,41 @@ export async function POST(request: Request) {
     const profile = await tihldeGetMe(token);
     const mapped = mapProfile(profile);
 
-    // 2. Upsert the local user, keyed by TIHLDE user_id. App-specific flags
-    //    (isAdmin, hasPaid, isVerified) are owned by us and never overwritten.
+    // 2. Derive admin status live from TIHLDE permissions (as Kvark does).
+    //    Backend admins are automatically app admins and skip payment, so we
+    //    also mark them verified/paid. A permissions fetch failure must not
+    //    block login — and must not silently revoke an existing admin — so on
+    //    error we leave admin-related flags untouched.
+    let adminGrant: {
+      isAdmin?: boolean;
+      isVerified?: boolean;
+      hasPaid?: boolean;
+    } = {};
+    try {
+      const isAdmin = isAdminFromPermissions(await tihldeGetPermissions(token));
+      adminGrant = isAdmin
+        ? { isAdmin: true, isVerified: true, hasPaid: true }
+        : { isAdmin: false };
+    } catch (err) {
+      console.error("[auth/login] permissions fetch failed", err);
+    }
+
+    // 3. Upsert the local user, keyed by TIHLDE user_id. Payment flags for
+    //    non-admins are owned by us (earned via Vipps) and left untouched.
     const user = await db.user.upsert({
       where: { tihldeUserId: mapped.tihldeUserId },
-      create: mapped,
+      create: { ...mapped, ...adminGrant },
       update: {
         name: mapped.name,
         email: mapped.email,
         image: mapped.image,
         studieretning: mapped.studieretning,
         klasse: mapped.klasse,
+        ...adminGrant,
       },
     });
 
-    // 3. Mint our own session and set the httpOnly cookie.
+    // 4. Mint our own session and set the httpOnly cookie.
     const hdrs = await headers();
     const { token: sessionToken, expiresAt } = await createSession({
       userId: user.id,

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -93,6 +93,49 @@ export async function tihldeGetMe(token: string): Promise<TihldeProfile> {
   return (await res.json()) as TihldeProfile;
 }
 
+interface PermissionEntry {
+  read?: boolean;
+  write?: boolean;
+  write_all?: boolean;
+  destroy?: boolean;
+}
+
+interface TihldePermissions {
+  permissions: Record<string, PermissionEntry>;
+}
+
+/** Fetch the authenticated user's global TIHLDE permissions. */
+export async function tihldeGetPermissions(
+  token: string,
+): Promise<TihldePermissions> {
+  const res = await fetch(apiUrl("/users/me/permissions/"), {
+    headers: { [TOKEN_HEADER]: token },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new TihldeAuthError(
+      await readDetail(res, "Kunne ikke hente brukerens tillatelser."),
+      res.status,
+    );
+  }
+
+  return (await res.json()) as TihldePermissions;
+}
+
+/**
+ * Whether a TIHLDE user counts as an admin for this app.
+ *
+ * Mirrors Kvark's `hasWritePermission`: a user with `write` or `write_all` on
+ * any permission app holds an elevated/backend role (board, committee, HS,
+ * Index, …). Regular members get read-only permissions and are not admins.
+ */
+export function isAdminFromPermissions(perms: TihldePermissions): boolean {
+  return Object.values(perms.permissions ?? {}).some(
+    (p) => p?.write === true || p?.write_all === true,
+  );
+}
+
 /** Map a TIHLDE profile onto the fields we persist locally. */
 export function mapProfile(profile: TihldeProfile) {
   const name = [profile.first_name, profile.last_name]


### PR DESCRIPTION
Follow-up to #51 (this change was committed just after #51 was merged, so it didn't land in `dev`).

## What
Admin status is now derived **live from TIHLDE** on every login, mirroring how Kvark does it — instead of a manually-set local flag.

- On login we call `GET /users/me/permissions/` and apply Kvark's `hasWritePermission` rule: a user with `write` or `write_all` on **any** permission app is an admin (board / committee / HS / Index / …). Regular members get read-only permissions and are not admins.
- **Backend admins are automatically app admins and skip payment** — so they're also marked `isVerified` + `hasPaid`, and the Vipps overlay never shows for them.
- Re-evaluated each login, so admin rights stay in sync with TIHLDE.
- A permissions-fetch failure never blocks login and never silently revokes an existing admin (admin flags are simply left untouched on error).

## Files
- `src/server/auth/tihlde.ts` — add `tihldeGetPermissions` + `isAdminFromPermissions`
- `src/app/api/auth/login/route.ts` — derive admin grant and apply it in the user upsert (create + update)

## Verification
Built clean; deployed to the test env earlier on the previous branch and confirmed the login round-trip + error handling. Live admin grant is exercised by logging in with a TIHLDE account that holds write permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)