### PR TITLE
feat(auth): grant admin to FadderKom committee members

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -11,11 +11,16 @@ import { db } from "~/server/db";
 import {
   TihldeAuthError,
   isAdminFromPermissions,
+  isMemberOfGroup,
   mapProfile,
   tihldeGetMe,
+  tihldeGetMemberships,
   tihldeGetPermissions,
   tihldeLogin,
 } from "~/server/auth/tihlde";
+
+/** TIHLDE group whose members are always app admins. */
+const ADMIN_GROUP_SLUG = "fadderkom";
 
 const bodySchema = z.object({
   user_id: z.string().min(1, "Brukernavn er påkrevd."),
@@ -37,9 +42,10 @@ export async function POST(request: Request) {
     const profile = await tihldeGetMe(token);
     const mapped = mapProfile(profile);
 
-    // 2. Derive admin status live from TIHLDE permissions (as Kvark does).
-    //    Backend admins are automatically app admins and skip payment, so we
-    //    also mark them verified/paid. A permissions fetch failure must not
+    // 2. Derive admin status live from TIHLDE (as Kvark does). A user is an
+    //    app admin if they hold write permissions OR are a member of the
+    //    FadderKom committee. Admins are automatically app admins and skip
+    //    payment, so we also mark them verified/paid. A fetch failure must not
     //    block login — and must not silently revoke an existing admin — so on
     //    error we leave admin-related flags untouched.
     let adminGrant: {
@@ -48,12 +54,18 @@ export async function POST(request: Request) {
       hasPaid?: boolean;
     } = {};
     try {
-      const isAdmin = isAdminFromPermissions(await tihldeGetPermissions(token));
+      const [perms, memberships] = await Promise.all([
+        tihldeGetPermissions(token),
+        tihldeGetMemberships(token, profile.user_id),
+      ]);
+      const isAdmin =
+        isAdminFromPermissions(perms) ||
+        isMemberOfGroup(memberships, ADMIN_GROUP_SLUG);
       adminGrant = isAdmin
         ? { isAdmin: true, isVerified: true, hasPaid: true }
         : { isAdmin: false };
     } catch (err) {
-      console.error("[auth/login] permissions fetch failed", err);
+      console.error("[auth/login] admin derivation failed", err);
     }
 
     // 3. Upsert the local user, keyed by TIHLDE user_id. Payment flags for

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -136,6 +136,44 @@ export function isAdminFromPermissions(perms: TihldePermissions): boolean {
   );
 }
 
+interface TihldeMembership {
+  group: { slug?: string; name?: string } | null;
+}
+
+/**
+ * Fetch the user's group memberships. The endpoint is paginated (25 per page);
+ * we read the first page, which is enough to detect committee membership.
+ */
+export async function tihldeGetMemberships(
+  token: string,
+  userId: string,
+): Promise<TihldeMembership[]> {
+  const res = await fetch(
+    apiUrl(`/users/${encodeURIComponent(userId)}/memberships/`),
+    { headers: { [TOKEN_HEADER]: token }, cache: "no-store" },
+  );
+
+  if (!res.ok) {
+    throw new TihldeAuthError(
+      await readDetail(res, "Kunne ikke hente gruppemedlemskap."),
+      res.status,
+    );
+  }
+
+  const body = (await res.json()) as
+    | { results?: TihldeMembership[] }
+    | TihldeMembership[];
+  return Array.isArray(body) ? body : (body.results ?? []);
+}
+
+/** Whether the user is a member of the group with the given slug. */
+export function isMemberOfGroup(
+  memberships: TihldeMembership[],
+  slug: string,
+): boolean {
+  return memberships.some((m) => m.group?.slug === slug);
+}
+
 /** Map a TIHLDE profile onto the fields we persist locally. */
 export function mapProfile(profile: TihldeProfile) {
   const name = [profile.first_name, profile.last_name]


### PR DESCRIPTION
Follow-up to #52 (this commit was made just after #52 was merged, so it didn't land in `dev`).

## What
In addition to write-permission holders, any member of the TIHLDE **FadderKom** committee (slug `fadderkom`, verified against the live groups API) is now treated as an app admin on login — and like other admins, skips payment (`isVerified` + `hasPaid`).

- On login, fetches the user's memberships from `GET /users/{user_id}/memberships/` (in parallel with the permissions check) and grants admin if any membership's `group.slug === "fadderkom"`.
- Re-derived every login, so it stays in sync with TIHLDE.
- A memberships/permissions fetch failure never blocks login and never silently revokes an existing admin.

## Files
- `src/server/auth/tihlde.ts` — add `tihldeGetMemberships` + `isMemberOfGroup`
- `src/app/api/auth/login/route.ts` — include FadderKom membership in the admin grant

## Notes
- **Applies on next login** — existing FadderKom members keep their current role until they log in again.
- Built clean; deployed and smoke-tested on the test env from the previous branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)