### PR TITLE
chore(lint): fix broken lint script (Next 16) + resolve surfaced errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build",
-    "check": "next lint && tsc --noEmit",
+    "check": "eslint . && tsc --noEmit",
     "db:generate": "prisma migrate dev",
     "db:migrate": "prisma migrate deploy",
     "db:push": "prisma db push",
@@ -14,8 +14,8 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "postinstall": "prisma generate",
-    "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "preview": "next build && next start",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/src/app/(authenticated)/aktiviteter/page.tsx
+++ b/src/app/(authenticated)/aktiviteter/page.tsx
@@ -9,8 +9,8 @@ export default async function AktiviteterPage() {
   const grouped = activities.reduce<Record<string, typeof activities>>(
     (acc, activity) => {
       const key = new Date(activity.date).toDateString();
-      if (!acc[key]) acc[key] = [];
-      acc[key]!.push(activity);
+      acc[key] ??= [];
+      acc[key].push(activity);
       return acc;
     },
     {},
@@ -58,7 +58,7 @@ export default async function AktiviteterPage() {
                     </span>
                   </div>
                   <div className="grid gap-6 md:grid-cols-2">
-                    {dayActivities!.map((activity) => (
+                    {dayActivities.map((activity) => (
                       <div
                         key={activity.id}
                         className="rounded-2xl border border-[color:var(--surface-border)] bg-[color:var(--surface-strong)] p-6 shadow-[0_0_0_1px_var(--surface-border)] backdrop-blur"

--- a/src/app/(authenticated)/payment/callback/page.tsx
+++ b/src/app/(authenticated)/payment/callback/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense, useEffect } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { api } from "~/trpc/react";
 
@@ -27,9 +28,9 @@ function PaymentCallback() {
       <div className="flex min-h-screen items-center justify-center bg-zinc-950">
         <div className="text-center">
           <p className="text-red-400">Ugyldig tilbakekobling fra Vipps.</p>
-          <a href="/" className="mt-4 block text-orange-500 underline">
+          <Link href="/" className="mt-4 block text-orange-500 underline">
             Gå til forsiden
-          </a>
+          </Link>
         </div>
       </div>
     );
@@ -42,9 +43,9 @@ function PaymentCallback() {
           <p className="text-red-400">
             Betalingen kunne ikke bekreftes: {confirm.error.message}
           </p>
-          <a href="/" className="block text-orange-500 underline">
+          <Link href="/" className="block text-orange-500 underline">
             Gå til forsiden
-          </a>
+          </Link>
         </div>
       </div>
     );

--- a/src/components/vipps-payment-overlay.tsx
+++ b/src/components/vipps-payment-overlay.tsx
@@ -32,7 +32,7 @@ export default function VippsPaymentOverlay() {
     onSuccess: (data) => {
       if (data.found) {
         toast({ title: "Betaling funnet!", description: "Du er nå registrert." });
-        paymentStatus.refetch();
+        void paymentStatus.refetch();
       } else {
         toast({
           title: "Ingen betaling funnet",

--- a/src/server/api/routers/activity.ts
+++ b/src/server/api/routers/activity.ts
@@ -24,6 +24,8 @@ export const activityRouter = createTRPCRouter({
           title: input.title,
           description: input.description,
           location: input.location,
+          // `||` is intentional: coerce empty string (allowed by the schema) to null, not "".
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           imageUrl: input.imageUrl || null,
           date: new Date(input.date),
         },
@@ -48,6 +50,8 @@ export const activityRouter = createTRPCRouter({
           title: input.title,
           description: input.description,
           location: input.location,
+          // `||` is intentional: coerce empty string (allowed by the schema) to null, not "".
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           imageUrl: input.imageUrl || null,
           date: new Date(input.date),
         },


### PR DESCRIPTION
## Hvorfor
`npm run lint` var ødelagt på `dev`: repoet er på Next.js 16, som **fjernet `next lint`-kommandoen**. Scriptet feilet med `Invalid project directory provided, no such directory: .../lint`, så verken lokal lint eller CI fanget noe.

## Hva
- Peker lint-scriptene på ESLint direkte (`eslint .`) — flat config (`eslint.config.js`) fantes allerede.
- Fikser de **8 pre-eksisterende feilene** som da ble synlige, med semantikken bevart:
  - `activity.ts`: beholder bevisst `|| null` (gjør tom streng → `null`, ikke `""`), dokumentert med `eslint-disable` i stedet for å bytte til `??` (som ville lagret `""` i DB).
  - `payment/callback/page.tsx`: `<a href="/">` → `next/link` `<Link>`.
  - `vipps-payment-overlay.tsx`: `void` på floating `refetch()`.
  - `aktiviteter/page.tsx`: `??=` og fjernet unødvendige non-null-assertions.

## Verifisert
- `npm run lint` → exit 0 (8 gjenværende warnings er ikke-blokkerende: `<img>`, anonyme default-exports, ubrukte variabler).
- `npm run typecheck` → rent.

Rene atferds-nøytrale refaktoreringer. Bør inn før flere feature-PR-er merges, så lint faktisk gir signal igjen.

> Merk: `eslint-config-next` er fortsatt `^15` mens `next` er `^16` — bør bumpes, men holdt utenfor denne PR-en for å begrense scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)