### PR TITLE
fix(theme): make admin, faddergruppe & misc pages theme-aware

### DIFF
--- a/src/app/(authenticated)/admin/admin-panel.tsx
+++ b/src/app/(authenticated)/admin/admin-panel.tsx
@@ -8,22 +8,22 @@ import { AktiviteterTab } from "./aktiviteter-tab";
 export function AdminPanel() {
   return (
     <Tabs defaultValue="users" className="w-full">
-      <TabsList className="grid w-full max-w-lg grid-cols-3 bg-[#1a2540] border border-[#73aac4]/30">
+      <TabsList className="grid w-full max-w-lg grid-cols-3 bg-secondary border border-[#73aac4]/30">
         <TabsTrigger
           value="users"
-          className="data-[state=active]:bg-[#2c3a5d] data-[state=active]:text-white text-[#8694b4]"
+          className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground text-muted-foreground"
         >
           Brukere
         </TabsTrigger>
         <TabsTrigger
           value="grupper"
-          className="data-[state=active]:bg-[#2c3a5d] data-[state=active]:text-white text-[#8694b4]"
+          className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground text-muted-foreground"
         >
           Faddergrupper
         </TabsTrigger>
         <TabsTrigger
           value="aktiviteter"
-          className="data-[state=active]:bg-[#2c3a5d] data-[state=active]:text-white text-[#8694b4]"
+          className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground text-muted-foreground"
         >
           Aktiviteter
         </TabsTrigger>

--- a/src/app/(authenticated)/admin/aktiviteter-tab.tsx
+++ b/src/app/(authenticated)/admin/aktiviteter-tab.tsx
@@ -99,14 +99,14 @@ export function AktiviteterTab() {
   return (
     <div className="!space-y-6">
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-white">
+        <h3 className="text-lg font-semibold text-foreground">
           Aktiviteter ({activities?.length ?? 0})
         </h3>
         {!showForm && (
           <button
             type="button"
             onClick={() => setShowForm(true)}
-            className="inline-flex items-center !gap-2 rounded-xl border border-[#73aac4]/40 bg-[#1a2540] !px-4 !py-2 text-sm font-semibold text-white transition hover:bg-[#29385a]"
+            className="inline-flex items-center !gap-2 rounded-xl border border-[#73aac4]/40 bg-secondary !px-4 !py-2 text-sm font-semibold text-foreground transition hover:bg-secondary/80"
           >
             <Plus className="h-4 w-4" />
             Ny aktivitet
@@ -117,16 +117,16 @@ export function AktiviteterTab() {
       {showForm && (
         <form
           onSubmit={handleSubmit}
-          className="!space-y-4 rounded-xl border border-[#73aac4]/30 bg-[#1a2540] !p-5"
+          className="!space-y-4 rounded-xl border border-[#73aac4]/30 bg-secondary !p-5"
         >
           <div className="flex items-center justify-between">
-            <h4 className="font-semibold text-white">
+            <h4 className="font-semibold text-foreground">
               {editingId ? "Rediger aktivitet" : "Ny aktivitet"}
             </h4>
             <button
               type="button"
               onClick={cancelForm}
-              className="text-[#8694b4] transition hover:text-white"
+              className="text-muted-foreground transition hover:text-foreground"
             >
               <X className="h-4 w-4" />
             </button>
@@ -134,57 +134,57 @@ export function AktiviteterTab() {
 
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="flex flex-col !gap-1.5">
-              <label className="text-xs font-medium text-[#8694b4]">Tittel *</label>
+              <label className="text-xs font-medium text-muted-foreground">Tittel *</label>
               <input
                 required
                 value={form.title}
                 onChange={(e) => setForm({ ...form, title: e.target.value })}
                 placeholder="Navn på aktiviteten"
-                className="rounded-lg border border-[#73aac4]/30 bg-[#111a2f] !px-3 !py-2 text-sm text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+                className="rounded-lg border border-[#73aac4]/30 bg-background !px-3 !py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
               />
             </div>
             <div className="flex flex-col !gap-1.5">
-              <label className="text-xs font-medium text-[#8694b4]">Dato og tid *</label>
+              <label className="text-xs font-medium text-muted-foreground">Dato og tid *</label>
               <input
                 required
                 type="datetime-local"
                 value={form.date}
                 onChange={(e) => setForm({ ...form, date: e.target.value })}
-                className="rounded-lg border border-[#73aac4]/30 bg-[#111a2f] !px-3 !py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-[#73aac4] [color-scheme:dark]"
+                className="rounded-lg border border-[#73aac4]/30 bg-background !px-3 !py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
               />
             </div>
           </div>
 
           <div className="flex flex-col !gap-1.5">
-            <label className="text-xs font-medium text-[#8694b4]">Sted / kart-lenke *</label>
+            <label className="text-xs font-medium text-muted-foreground">Sted / kart-lenke *</label>
             <input
               required
               value={form.location}
               onChange={(e) => setForm({ ...form, location: e.target.value })}
               placeholder="F.eks. Gløshaugen eller https://maps.google.com/..."
-              className="rounded-lg border border-[#73aac4]/30 bg-[#111a2f] !px-3 !py-2 text-sm text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+              className="rounded-lg border border-[#73aac4]/30 bg-background !px-3 !py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
             />
           </div>
 
           <div className="flex flex-col !gap-1.5">
-            <label className="text-xs font-medium text-[#8694b4]">Bilde-URL (valgfritt)</label>
+            <label className="text-xs font-medium text-muted-foreground">Bilde-URL (valgfritt)</label>
             <input
               value={form.imageUrl}
               onChange={(e) => setForm({ ...form, imageUrl: e.target.value })}
               placeholder="https://..."
-              className="rounded-lg border border-[#73aac4]/30 bg-[#111a2f] !px-3 !py-2 text-sm text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+              className="rounded-lg border border-[#73aac4]/30 bg-background !px-3 !py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
             />
           </div>
 
           <div className="flex flex-col !gap-1.5">
-            <label className="text-xs font-medium text-[#8694b4]">Beskrivelse *</label>
+            <label className="text-xs font-medium text-muted-foreground">Beskrivelse *</label>
             <textarea
               required
               rows={3}
               value={form.description}
               onChange={(e) => setForm({ ...form, description: e.target.value })}
               placeholder="Beskriv aktiviteten..."
-              className="rounded-lg border border-[#73aac4]/30 bg-[#111a2f] !px-3 !py-2 text-sm text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+              className="rounded-lg border border-[#73aac4]/30 bg-background !px-3 !py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
             />
           </div>
 
@@ -192,14 +192,14 @@ export function AktiviteterTab() {
             <button
               type="button"
               onClick={cancelForm}
-              className="rounded-lg !px-4 !py-2 text-sm text-[#8694b4] transition hover:text-white"
+              className="rounded-lg !px-4 !py-2 text-sm text-muted-foreground transition hover:text-foreground"
             >
               Avbryt
             </button>
             <button
               type="submit"
               disabled={createMutation.isPending || updateMutation.isPending}
-              className="rounded-xl border border-[#73aac4]/40 bg-[#73aac4]/20 !px-4 !py-2 text-sm font-semibold text-white transition hover:bg-[#73aac4]/30 disabled:opacity-60"
+              className="rounded-xl border border-[#73aac4]/40 bg-primary !px-4 !py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60"
             >
               {editingId ? "Lagre endringer" : "Opprett aktivitet"}
             </button>
@@ -229,8 +229,8 @@ export function AktiviteterTab() {
                   </div>
                 )}
                 <div className="!space-y-1">
-                  <p className="font-semibold text-white">{activity.title}</p>
-                  <p className="text-xs text-[#8694b4]">
+                  <p className="font-semibold text-foreground">{activity.title}</p>
+                  <p className="text-xs text-muted-foreground">
                     {new Date(activity.date).toLocaleDateString("no-NO", {
                       weekday: "short",
                       day: "numeric",
@@ -240,11 +240,11 @@ export function AktiviteterTab() {
                       minute: "2-digit",
                     })}
                   </p>
-                  <div className="flex items-center !gap-1 text-xs text-[#5b6a8f]">
+                  <div className="flex items-center !gap-1 text-xs text-muted-foreground">
                     <MapPin className="h-3 w-3" />
                     <span className="max-w-xs truncate">{activity.location}</span>
                   </div>
-                  <p className="max-w-sm text-xs text-[#8694b4] line-clamp-2">{activity.description}</p>
+                  <p className="max-w-sm text-xs text-muted-foreground line-clamp-2">{activity.description}</p>
                 </div>
               </div>
 
@@ -252,7 +252,7 @@ export function AktiviteterTab() {
                 <button
                   type="button"
                   onClick={() => openEdit(activity)}
-                  className="inline-flex items-center !gap-1.5 rounded-lg border border-[#73aac4]/30 bg-[#1a2540] !px-3 !py-1.5 text-xs font-medium text-white transition hover:bg-[#29385a]"
+                  className="inline-flex items-center !gap-1.5 rounded-lg border border-[#73aac4]/30 bg-secondary !px-3 !py-1.5 text-xs font-medium text-foreground transition hover:bg-secondary/80"
                 >
                   <Pencil className="h-3 w-3" />
                   Rediger
@@ -271,7 +271,7 @@ export function AktiviteterTab() {
           ))}
         </div>
       ) : (
-        <p className="rounded-xl border border-[#73aac4]/20 bg-[color:var(--surface-soft)] !px-4 !py-6 text-center text-sm text-[#5b6a8f]">
+        <p className="rounded-xl border border-[#73aac4]/20 bg-[color:var(--surface-soft)] !px-4 !py-6 text-center text-sm text-muted-foreground">
           Ingen aktiviteter lagt til ennå
         </p>
       )}

--- a/src/app/(authenticated)/admin/grupper-tab.tsx
+++ b/src/app/(authenticated)/admin/grupper-tab.tsx
@@ -100,12 +100,12 @@ export function GrupperTab() {
           placeholder="Ny faddergruppe navn..."
           value={newGruppeName}
           onChange={(e) => setNewGruppeName(e.target.value)}
-          className="flex-1 max-w-sm rounded-xl border border-[#73aac4]/40 bg-[#111a2f] !px-4 !py-2.5 text-sm text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+          className="flex-1 max-w-sm rounded-xl border border-[#73aac4]/40 bg-background !px-4 !py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
         />
         <button
           type="submit"
           disabled={createMutation.isPending || !newGruppeName.trim()}
-          className="inline-flex items-center !gap-2 rounded-xl border border-[#73aac4] bg-[#212d49] !px-4 !py-2.5 text-sm font-semibold text-white transition hover:bg-[#29385a] disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center !gap-2 rounded-xl border border-[#73aac4] bg-secondary !px-4 !py-2.5 text-sm font-semibold text-foreground transition hover:bg-secondary/80 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Plus className="h-4 w-4" />
           Opprett
@@ -129,23 +129,23 @@ export function GrupperTab() {
               {/* Gruppe header */}
               <button
                 type="button"
-                className="flex w-full items-center justify-between !px-5 !py-4 text-left transition hover:bg-[#1a2540]/50"
+                className="flex w-full items-center justify-between !px-5 !py-4 text-left transition hover:bg-muted/50"
                 onClick={() =>
                   setExpandedGruppe(isExpanded ? null : gruppe.id)
                 }
               >
                 <div className="flex items-center !gap-3">
-                  <h3 className="text-lg font-semibold text-white">
+                  <h3 className="text-lg font-semibold text-foreground">
                     {gruppe.name}
                   </h3>
-                  <span className="text-sm text-[#8694b4]">
+                  <span className="text-sm text-muted-foreground">
                     {gruppe.members.length} medlemmer
                   </span>
                 </div>
                 {isExpanded ? (
-                  <ChevronUp className="h-5 w-5 text-[#8694b4]" />
+                  <ChevronUp className="h-5 w-5 text-muted-foreground" />
                 ) : (
-                  <ChevronDown className="h-5 w-5 text-[#8694b4]" />
+                  <ChevronDown className="h-5 w-5 text-muted-foreground" />
                 )}
               </button>
 
@@ -161,13 +161,13 @@ export function GrupperTab() {
                         {faddere.map((member) => (
                           <li
                             key={member.id}
-                            className="flex items-center justify-between rounded-lg !px-3 !py-2 hover:bg-[#1a2540]/50"
+                            className="flex items-center justify-between rounded-lg !px-3 !py-2 hover:bg-muted/50"
                           >
                             <div>
-                              <span className="text-sm text-white">
+                              <span className="text-sm text-foreground">
                                 {member.user.name}
                               </span>
-                              <span className="!ml-2 text-xs text-[#5b6a8f]">
+                              <span className="!ml-2 text-xs text-muted-foreground">
                                 {member.user.email}
                               </span>
                             </div>
@@ -180,7 +180,7 @@ export function GrupperTab() {
                                     role: "FADDERBARN",
                                   })
                                 }
-                                className="text-xs text-[#8694b4] hover:text-white transition"
+                                className="text-xs text-muted-foreground hover:text-foreground transition"
                                 title="Endre til fadderbarn"
                               >
                                 Til fadderbarn
@@ -202,7 +202,7 @@ export function GrupperTab() {
                         ))}
                       </ul>
                     ) : (
-                      <p className="text-sm text-[#5b6a8f]">
+                      <p className="text-sm text-muted-foreground">
                         Ingen faddere enda
                       </p>
                     )}
@@ -218,13 +218,13 @@ export function GrupperTab() {
                         {fadderbarn.map((member) => (
                           <li
                             key={member.id}
-                            className="flex items-center justify-between rounded-lg !px-3 !py-2 hover:bg-[#1a2540]/50"
+                            className="flex items-center justify-between rounded-lg !px-3 !py-2 hover:bg-muted/50"
                           >
                             <div>
-                              <span className="text-sm text-white">
+                              <span className="text-sm text-foreground">
                                 {member.user.name}
                               </span>
-                              <span className="!ml-2 text-xs text-[#5b6a8f]">
+                              <span className="!ml-2 text-xs text-muted-foreground">
                                 {member.user.email}
                               </span>
                             </div>
@@ -237,7 +237,7 @@ export function GrupperTab() {
                                     role: "FADDER",
                                   })
                                 }
-                                className="text-xs text-[#8694b4] hover:text-white transition"
+                                className="text-xs text-muted-foreground hover:text-foreground transition"
                                 title="Endre til fadder"
                               >
                                 Til fadder
@@ -259,7 +259,7 @@ export function GrupperTab() {
                         ))}
                       </ul>
                     ) : (
-                      <p className="text-sm text-[#5b6a8f]">
+                      <p className="text-sm text-muted-foreground">
                         Ingen fadderbarn enda
                       </p>
                     )}
@@ -291,7 +291,7 @@ export function GrupperTab() {
                             role: "FADDER",
                           })
                         }
-                        className="inline-flex items-center !gap-1.5 rounded-lg border border-[#73aac4]/30 !px-3 !py-1.5 text-xs font-medium text-[#90dfed] transition hover:bg-[#1a2540]"
+                        className="inline-flex items-center !gap-1.5 rounded-lg border border-[#73aac4]/30 !px-3 !py-1.5 text-xs font-medium text-[#90dfed] transition hover:bg-muted"
                       >
                         <UserPlus className="h-3.5 w-3.5" />
                         Legg til fadder
@@ -304,7 +304,7 @@ export function GrupperTab() {
                             role: "FADDERBARN",
                           })
                         }
-                        className="inline-flex items-center !gap-1.5 rounded-lg border border-[#73aac4]/30 !px-3 !py-1.5 text-xs font-medium text-[#6495e6] transition hover:bg-[#1a2540]"
+                        className="inline-flex items-center !gap-1.5 rounded-lg border border-[#73aac4]/30 !px-3 !py-1.5 text-xs font-medium text-[#6495e6] transition hover:bg-muted"
                       >
                         <UserPlus className="h-3.5 w-3.5" />
                         Legg til fadderbarn
@@ -339,7 +339,7 @@ export function GrupperTab() {
         })}
 
         {grupper?.length === 0 && (
-          <p className="text-center text-[#8694b4] !py-8">
+          <p className="text-center text-muted-foreground !py-8">
             Ingen faddergrupper opprettet enda. Bruk skjemaet over for a
             opprette en ny gruppe.
           </p>
@@ -373,8 +373,8 @@ function AddMemberForm({
   );
 
   return (
-    <div className="rounded-lg border border-[#73aac4]/30 bg-[#111a2f] !p-4 !space-y-3">
-      <p className="text-sm font-medium text-white">
+    <div className="rounded-lg border border-[#73aac4]/30 bg-background !p-4 !space-y-3">
+      <p className="text-sm font-medium text-foreground">
         Legg til {role === "FADDER" ? "fadder" : "fadderbarn"}
       </p>
       <input
@@ -382,7 +382,7 @@ function AddMemberForm({
         placeholder="Sok etter bruker..."
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        className="w-full rounded-lg border border-[#73aac4]/30 bg-[#0d1525] !px-3 !py-2 text-sm text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-1 focus:ring-[#73aac4]"
+        className="w-full rounded-lg border border-[#73aac4]/30 bg-background !px-3 !py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[#73aac4]"
       />
       <div className="max-h-40 overflow-y-auto !space-y-1">
         {filtered.map((user) => (
@@ -392,16 +392,16 @@ function AddMemberForm({
             onClick={() => setSelectedUserId(user.id)}
             className={`flex w-full items-center justify-between rounded-lg !px-3 !py-2 text-left text-sm transition ${
               selectedUserId === user.id
-                ? "bg-[#2c3a5d] text-white"
-                : "text-[#8694b4] hover:bg-[#1a2540]"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted"
             }`}
           >
             <span>{user.name}</span>
-            <span className="text-xs text-[#5b6a8f]">{user.email}</span>
+            <span className="text-xs text-muted-foreground">{user.email}</span>
           </button>
         ))}
         {filtered.length === 0 && (
-          <p className="text-center text-xs text-[#5b6a8f] !py-2">
+          <p className="text-center text-xs text-muted-foreground !py-2">
             Ingen tilgjengelige brukere
           </p>
         )}
@@ -410,7 +410,7 @@ function AddMemberForm({
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-lg !px-3 !py-1.5 text-xs text-[#8694b4] hover:text-white transition"
+          className="rounded-lg !px-3 !py-1.5 text-xs text-muted-foreground hover:text-foreground transition"
         >
           Avbryt
         </button>
@@ -420,7 +420,7 @@ function AddMemberForm({
             if (selectedUserId) onAdd(selectedUserId);
           }}
           disabled={!selectedUserId || isPending}
-          className="rounded-lg bg-[#2c3a5d] !px-3 !py-1.5 text-xs font-medium text-white transition hover:bg-[#33466f] disabled:opacity-60 disabled:cursor-not-allowed"
+          className="rounded-lg bg-primary !px-3 !py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60 disabled:cursor-not-allowed"
         >
           Legg til
         </button>

--- a/src/app/(authenticated)/admin/page.tsx
+++ b/src/app/(authenticated)/admin/page.tsx
@@ -15,7 +15,7 @@ export default async function AdminPage() {
 
   return (
     <main
-      className="relative flex min-h-screen w-full flex-1 flex-col overflow-hidden text-white"
+      className="relative flex min-h-screen w-full flex-1 flex-col overflow-hidden text-foreground"
       style={{
         backgroundColor: "var(--page-bg)",
         backgroundImage: "var(--page-bg-image), var(--page-gradient)",
@@ -29,7 +29,7 @@ export default async function AdminPage() {
             <h1 className="bg-gradient-to-r from-[#90dfed] to-[#6495e6] bg-clip-text text-4xl leading-[1.15] font-bold text-transparent md:text-5xl">
               Adminpanel
             </h1>
-            <p className="max-w-3xl text-base text-[#8694b4] sm:text-lg">
+            <p className="max-w-3xl text-base text-muted-foreground sm:text-lg">
               Administrer brukere, faddergrupper og medlemskap.
             </p>
           </section>

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -110,7 +110,7 @@ export function UsersTab() {
       {/* Unverified users section */}
       <section className="!space-y-4">
         <div className="flex items-center !gap-3">
-          <h3 className="text-lg font-semibold text-white">
+          <h3 className="text-lg font-semibold text-foreground">
             Nye uverifiserte brukere
           </h3>
           {unverifiedUsers.length > 0 && (
@@ -128,8 +128,8 @@ export function UsersTab() {
                 className="flex flex-col !gap-3 rounded-xl border border-amber-500/30 bg-amber-500/5 !p-4 backdrop-blur sm:flex-row sm:items-center sm:justify-between"
               >
                 <div>
-                  <p className="font-medium text-white">{user.name}</p>
-                  <p className="text-sm text-[#8694b4]">{user.email}</p>
+                  <p className="font-medium text-foreground">{user.name}</p>
+                  <p className="text-sm text-muted-foreground">{user.email}</p>
                   <div className="mt-1 flex flex-wrap !gap-1.5">
                     {user.klasse && (
                       <span className="rounded-full bg-[#73aac4]/15 !px-2 !py-0.5 text-xs font-medium text-[#73aac4]">
@@ -142,10 +142,10 @@ export function UsersTab() {
                       </span>
                     )}
                     {!user.klasse && !user.studieretning && (
-                      <span className="text-xs text-[#5b6a8f]">Ingen klasse/retning oppgitt</span>
+                      <span className="text-xs text-muted-foreground">Ingen klasse/retning oppgitt</span>
                     )}
                   </div>
-                  <p className="text-xs text-[#5b6a8f]">
+                  <p className="text-xs text-muted-foreground">
                     Registrert{" "}
                     {new Date(user.createdAt).toLocaleDateString("no-NO", {
                       day: "numeric",
@@ -157,7 +157,7 @@ export function UsersTab() {
 
                 {verifyingUserId === user.id ? (
                   <div className="flex flex-col !gap-2 sm:items-end">
-                    <p className="text-xs font-medium text-[#8694b4]">
+                    <p className="text-xs font-medium text-muted-foreground">
                       Velg faddergruppe:
                     </p>
                     <div className="flex flex-wrap !gap-2">
@@ -172,7 +172,7 @@ export function UsersTab() {
                             })
                           }
                           disabled={verifyAndAssignMutation.isPending}
-                          className="rounded-lg border border-[#73aac4]/40 bg-[#212d49] !px-3 !py-1.5 text-xs font-medium text-white transition hover:bg-[#29385a] disabled:opacity-60"
+                          className="rounded-lg border border-[#73aac4]/40 bg-secondary !px-3 !py-1.5 text-xs font-medium text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
                         >
                           {gruppe.name}
                         </button>
@@ -180,7 +180,7 @@ export function UsersTab() {
                       <button
                         type="button"
                         onClick={() => setVerifyingUserId(null)}
-                        className="rounded-lg !px-3 !py-1.5 text-xs text-[#8694b4] hover:text-white transition"
+                        className="rounded-lg !px-3 !py-1.5 text-xs text-muted-foreground hover:text-foreground transition"
                       >
                         Avbryt
                       </button>
@@ -208,7 +208,7 @@ export function UsersTab() {
                       <button
                         type="button"
                         onClick={() => setDeletingUserId(null)}
-                        className="rounded-lg !px-3 !py-1.5 text-xs text-[#8694b4] transition hover:text-white"
+                        className="rounded-lg !px-3 !py-1.5 text-xs text-muted-foreground transition hover:text-foreground"
                       >
                         Avbryt
                       </button>
@@ -238,7 +238,7 @@ export function UsersTab() {
             ))}
           </div>
         ) : (
-          <p className="rounded-xl border border-[#73aac4]/20 bg-[color:var(--surface-soft)] !px-4 !py-6 text-center text-sm text-[#5b6a8f]">
+          <p className="rounded-xl border border-[#73aac4]/20 bg-[color:var(--surface-soft)] !px-4 !py-6 text-center text-sm text-muted-foreground">
             Ingen uverifiserte brukere
           </p>
         )}
@@ -246,7 +246,7 @@ export function UsersTab() {
 
       {/* Verified users grouped by studieretning */}
       <section className="!space-y-4">
-        <h3 className="text-lg font-semibold text-white">
+        <h3 className="text-lg font-semibold text-foreground">
           Verifiserte brukere ({verifiedUsers.length})
         </h3>
 
@@ -255,7 +255,7 @@ export function UsersTab() {
           placeholder="Sok etter bruker..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full max-w-sm rounded-xl border border-[#73aac4]/40 bg-[#111a2f] !px-4 !py-2.5 text-sm text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+          className="w-full max-w-sm rounded-xl border border-[#73aac4]/40 bg-background !px-4 !py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
         />
 
         <div className="grid grid-cols-1 !gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -279,8 +279,8 @@ export function UsersTab() {
                   className="flex w-full items-center justify-between !gap-3 !p-4 text-left"
                 >
                   <div>
-                    <p className="font-semibold text-white">{studieretning}</p>
-                    <p className="text-xs text-[#8694b4]">
+                    <p className="font-semibold text-foreground">{studieretning}</p>
+                    <p className="text-xs text-muted-foreground">
                       {usersInGroup.length}{" "}
                       {usersInGroup.length === 1 ? "bruker" : "brukere"}
                     </p>
@@ -294,7 +294,7 @@ export function UsersTab() {
                   <div className="overflow-x-auto border-t border-[#73aac4]/20">
                     <table className="w-full text-left text-sm">
                       <thead>
-                        <tr className="border-b border-[#73aac4]/20 text-[#8694b4]">
+                        <tr className="border-b border-[#73aac4]/20 text-muted-foreground">
                           <th className="!px-4 !py-3 font-medium">Navn</th>
                           <th className="!px-4 !py-3 font-medium">E-post</th>
                           <th className="!px-4 !py-3 font-medium">Klasse</th>
@@ -309,12 +309,12 @@ export function UsersTab() {
                           return (
                             <tr
                               key={user.id}
-                              className="border-b border-[#73aac4]/10 last:border-0 hover:bg-[#1a2540]/50"
+                              className="border-b border-[#73aac4]/10 last:border-0 hover:bg-muted/50"
                             >
-                              <td className="!px-4 !py-3 font-medium text-white">
+                              <td className="!px-4 !py-3 font-medium text-foreground">
                                 {user.name}
                               </td>
-                              <td className="!px-4 !py-3 text-[#8694b4]">
+                              <td className="!px-4 !py-3 text-muted-foreground">
                                 {user.email}
                               </td>
                               <td className="!px-4 !py-3">
@@ -323,10 +323,10 @@ export function UsersTab() {
                                     {user.klasse}
                                   </span>
                                 ) : (
-                                  <span className="text-[#5b6a8f]">—</span>
+                                  <span className="text-muted-foreground">—</span>
                                 )}
                               </td>
-                              <td className="!px-4 !py-3 text-[#8694b4]">
+                              <td className="!px-4 !py-3 text-muted-foreground">
                                 {membership ? membership.gruppe.name : "—"}
                               </td>
                               <td className="!px-4 !py-3">
@@ -359,7 +359,7 @@ export function UsersTab() {
                                       : "Fadderbarn"}
                                   </button>
                                 ) : (
-                                  <span className="text-[#5b6a8f]">—</span>
+                                  <span className="text-muted-foreground">—</span>
                                 )}
                               </td>
                               <td className="!px-4 !py-3 text-center">
@@ -372,7 +372,7 @@ export function UsersTab() {
                                     })
                                   }
                                   disabled={adminMutation.isPending}
-                                  className="inline-flex items-center justify-center rounded-lg !p-1.5 transition hover:bg-white/10"
+                                  className="inline-flex items-center justify-center rounded-lg !p-1.5 transition hover:bg-foreground/10"
                                   title={
                                     user.isAdmin
                                       ? "Fjern admintilgang"
@@ -382,7 +382,7 @@ export function UsersTab() {
                                   {user.isAdmin ? (
                                     <Shield className="h-4 w-4 text-amber-400" />
                                   ) : (
-                                    <ShieldOff className="h-4 w-4 text-[#5b6a8f]" />
+                                    <ShieldOff className="h-4 w-4 text-muted-foreground" />
                                   )}
                                 </button>
                               </td>
@@ -393,7 +393,7 @@ export function UsersTab() {
                           <tr>
                             <td
                               colSpan={6}
-                              className="!px-4 !py-6 text-center text-[#8694b4]"
+                              className="!px-4 !py-6 text-center text-muted-foreground"
                             >
                               Ingen brukere funnet
                             </td>

--- a/src/app/(authenticated)/drikkeleker/page.tsx
+++ b/src/app/(authenticated)/drikkeleker/page.tsx
@@ -15,7 +15,7 @@ const games = [
 export default function DrikkelekerPage() {
   return (
     <main
-      className="relative flex min-h-screen w-full flex-col overflow-hidden text-white"
+      className="relative flex min-h-screen w-full flex-col overflow-hidden text-foreground"
       style={{
         backgroundColor: "var(--page-bg)",
         backgroundImage: "var(--page-bg-image), var(--page-gradient)",
@@ -27,10 +27,10 @@ export default function DrikkelekerPage() {
 
       <div className="max-w-page mx-auto w-full flex-1 !px-4 !pt-24 !pb-24 md:!px-6">
         <div className="text-center">
-          <h1 className="text-4xl font-extrabold tracking-tight text-slate-50 sm:text-6xl md:text-7xl">
+          <h1 className="text-4xl font-extrabold tracking-tight text-foreground sm:text-6xl md:text-7xl">
             Drikkeleker
           </h1>
-          <p className="mx-auto mt-4 max-w-2xl text-base text-slate-400 sm:text-lg">
+          <p className="mx-auto mt-4 max-w-2xl text-base text-muted-foreground sm:text-lg">
             Her finner du morsomme leker til aktiviteter. Kayr no pau!
           </p>
         </div>

--- a/src/app/(authenticated)/faddergruppe/group-view.tsx
+++ b/src/app/(authenticated)/faddergruppe/group-view.tsx
@@ -87,12 +87,12 @@ export function GroupView({
   return (
     <section className="!space-y-6">
       <div className="flex flex-wrap items-end justify-between !gap-4">
-        <h2 className="text-3xl font-extrabold tracking-[-0.02em] text-white sm:text-[36px]">
+        <h2 className="text-3xl font-extrabold tracking-[-0.02em] text-foreground sm:text-[36px]">
           {title}
         </h2>
         {canPost && (
           <button
-            className="inline-flex items-center !gap-2 rounded-xl border border-[#73aac4] bg-[#212d49] !px-4 !py-2 text-sm font-semibold text-white transition hover:bg-[#29385a] sm:text-base"
+            className="inline-flex items-center !gap-2 rounded-xl border border-[#73aac4] bg-secondary !px-4 !py-2 text-sm font-semibold text-foreground transition hover:bg-secondary/80 sm:text-base"
             type="button"
             onClick={() => setIsComposerOpen(true)}
           >
@@ -114,11 +114,11 @@ export function GroupView({
               className="rounded-xl border border-[#73aac4]/70 bg-[color:var(--surface-soft)] !p-6 shadow-[0_24px_60px_rgba(4,10,23,0.35)] backdrop-blur"
             >
               <div className="flex flex-wrap items-start justify-between !gap-3">
-                <h3 className="text-lg font-extrabold text-white sm:text-xl">
+                <h3 className="text-lg font-extrabold text-foreground sm:text-xl">
                   {message.author.name}
                 </h3>
                 <div className="flex items-center !gap-2">
-                  <span className="text-sm font-medium text-[#8694b4] sm:text-base">
+                  <span className="text-sm font-medium text-muted-foreground sm:text-base">
                     {formatTime(message.createdAt)}
                   </span>
                   {(message.author.name === currentUserName) && (
@@ -135,14 +135,14 @@ export function GroupView({
                   )}
                 </div>
               </div>
-              <p className="!mt-3 text-base font-medium text-[#8694b4] sm:text-lg">
+              <p className="!mt-3 text-base font-medium text-muted-foreground sm:text-lg">
                 {message.content}
               </p>
             </article>
           ))}
         </div>
       ) : (
-        <p className="text-center text-[#8694b4] !py-8">{emptyMessage}</p>
+        <p className="text-center text-muted-foreground !py-8">{emptyMessage}</p>
       )}
 
       {/* Composer modal */}
@@ -157,16 +157,16 @@ export function GroupView({
               setComposerMessage("");
             }}
           />
-          <div className="relative w-full max-w-lg rounded-2xl border border-[#73aac4]/70 bg-[color:var(--surface-strong)] !p-6 text-white shadow-[0_40px_90px_rgba(2,6,23,0.6)] backdrop-blur sm:!p-8">
+          <div className="relative w-full max-w-lg rounded-2xl border border-[#73aac4]/70 bg-[color:var(--surface-strong)] !p-6 text-foreground shadow-[0_40px_90px_rgba(2,6,23,0.6)] backdrop-blur sm:!p-8">
             <div className="flex items-start justify-between !gap-4">
               <div>
                 <h3 className="text-xl font-semibold">{composerTitle}</h3>
-                <p className="!mt-1 text-sm text-[#8694b4]">
+                <p className="!mt-1 text-sm text-muted-foreground">
                   {composerSubtitle}
                 </p>
               </div>
               <button
-                className="rounded-full border border-[#73aac4]/50 !px-3 !py-1 text-sm text-[#d8e6ff] transition hover:bg-white/10"
+                className="rounded-full border border-[#73aac4]/50 !px-3 !py-1 text-sm text-foreground transition hover:bg-foreground/10"
                 type="button"
                 onClick={() => {
                   setIsComposerOpen(false);
@@ -178,10 +178,10 @@ export function GroupView({
             </div>
 
             <form className="!mt-6 !space-y-4" onSubmit={handleSubmit}>
-              <label className="block !space-y-2 text-sm font-medium text-[#d8e6ff]">
+              <label className="block !space-y-2 text-sm font-medium text-foreground">
                 Melding
                 <textarea
-                  className="min-h-[140px] w-full rounded-xl border border-[#73aac4]/40 bg-[#111a2f] !px-4 !py-3 text-base text-white placeholder:text-[#5b6a8f] focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+                  className="min-h-[140px] w-full rounded-xl border border-[#73aac4]/40 bg-background !px-4 !py-3 text-base text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
                   placeholder={composerPlaceholder}
                   value={composerMessage}
                   onChange={(e) => setComposerMessage(e.target.value)}
@@ -190,7 +190,7 @@ export function GroupView({
 
               <div className="flex flex-wrap items-center justify-end !gap-3">
                 <button
-                  className="rounded-xl border border-[#73aac4]/50 !px-4 !py-2 text-sm text-[#d8e6ff] transition hover:bg-white/10"
+                  className="rounded-xl border border-[#73aac4]/50 !px-4 !py-2 text-sm text-foreground transition hover:bg-foreground/10"
                   type="button"
                   onClick={() => {
                     setIsComposerOpen(false);
@@ -200,7 +200,7 @@ export function GroupView({
                   Avbryt
                 </button>
                 <button
-                  className="rounded-xl bg-[#2c3a5d] !px-4 !py-2 text-sm font-semibold text-white transition hover:bg-[#33466f] disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded-xl bg-primary !px-4 !py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
                   type="submit"
                   disabled={
                     composerMessage.trim().length === 0 || postMutation.isPending

--- a/src/app/(authenticated)/faddergruppe/page.tsx
+++ b/src/app/(authenticated)/faddergruppe/page.tsx
@@ -39,7 +39,7 @@ export default async function FaddergroupPage() {
   if (!membership) {
     return (
       <main
-        className="relative flex min-h-screen w-full flex-1 flex-col overflow-hidden text-white"
+        className="relative flex min-h-screen w-full flex-1 flex-col overflow-hidden text-foreground"
         style={{
           backgroundColor: "var(--page-bg)",
           backgroundImage: "var(--page-bg-image), var(--page-gradient)",
@@ -48,10 +48,10 @@ export default async function FaddergroupPage() {
         <div className="pointer-events-none absolute top-[-280px] left-1/2 h-[520px] w-[820px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(100,149,230,0.35),transparent_70%)] blur-3xl" />
         <div className="max-w-page relative mx-auto flex w-full flex-1 flex-col items-center justify-center !px-4 !pt-24 !pb-16 md:!px-6">
           <div className="mx-auto max-w-md !space-y-4 text-center">
-            <h1 className="text-3xl font-bold text-white">
+            <h1 className="text-3xl font-bold text-foreground">
               Ingen faddergruppe
             </h1>
-            <p className="text-[#8694b4]">
+            <p className="text-muted-foreground">
               Du er ikke tildelt en faddergruppe enda. Kontakt en administrator
               for a bli lagt til i en gruppe.
             </p>
@@ -71,7 +71,7 @@ export default async function FaddergroupPage() {
 
   return (
     <main
-      className="relative flex min-h-screen w-full flex-1 flex-col overflow-hidden text-white"
+      className="relative flex min-h-screen w-full flex-1 flex-col overflow-hidden text-foreground"
       style={{
         backgroundColor: "var(--page-bg)",
         backgroundImage: "var(--page-bg-image), var(--page-gradient)",
@@ -87,7 +87,7 @@ export default async function FaddergroupPage() {
             <h1 className="bg-gradient-to-r from-[#90dfed] to-[#6495e6] bg-clip-text text-4xl leading-[1.15] font-bold text-transparent md:text-5xl">
               {gruppe.name}
             </h1>
-            <p className="max-w-3xl text-base text-[#8694b4] sm:text-lg">
+            <p className="max-w-3xl text-base text-muted-foreground sm:text-lg">
               Velkommen til {gruppe.name}! Her finner du en oversikt over alle
               faddere og fadderbarn i tillegg til informasjon fra fadderne til
               faddergruppa.
@@ -95,31 +95,31 @@ export default async function FaddergroupPage() {
           </section>
 
           <section className="!space-y-6">
-            <h2 className="text-3xl font-extrabold tracking-[-0.02em] text-white sm:text-[36px]">
+            <h2 className="text-3xl font-extrabold tracking-[-0.02em] text-foreground sm:text-[36px]">
               Medlemmer
             </h2>
             <div className="grid !gap-10 rounded-xl border border-[#73aac4]/70 bg-[color:var(--surface-soft)] !p-6 shadow-[0_24px_60px_rgba(4,10,23,0.35)] backdrop-blur md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] md:!gap-16">
               <div className="!space-y-4">
-                <h3 className="text-lg font-semibold text-white">Fadderbarn</h3>
-                <ul className="!space-y-2 text-sm text-[#7f8fb2] sm:text-base">
+                <h3 className="text-lg font-semibold text-foreground">Fadderbarn</h3>
+                <ul className="!space-y-2 text-sm text-muted-foreground sm:text-base">
                   {fadderbarn.map((member) => (
                     <li key={member.id}>{member.user.name}</li>
                   ))}
                   {fadderbarn.length === 0 && (
-                    <li className="text-[#5b6a8f]">Ingen fadderbarn enda</li>
+                    <li className="text-muted-foreground">Ingen fadderbarn enda</li>
                   )}
                 </ul>
               </div>
               <div className="!space-y-4">
-                <h3 className="text-lg font-semibold text-white">Faddere</h3>
-                <div className="grid !gap-2 text-sm text-[#7f8fb2] sm:text-base">
+                <h3 className="text-lg font-semibold text-foreground">Faddere</h3>
+                <div className="grid !gap-2 text-sm text-muted-foreground sm:text-base">
                   {faddere.map((member) => (
                     <div key={member.id}>
                       <span>{member.user.name}</span>
                     </div>
                   ))}
                   {faddere.length === 0 && (
-                    <span className="text-[#5b6a8f]">Ingen faddere enda</span>
+                    <span className="text-muted-foreground">Ingen faddere enda</span>
                   )}
                 </div>
               </div>

--- a/src/app/(authenticated)/payment/callback/page.tsx
+++ b/src/app/(authenticated)/payment/callback/page.tsx
@@ -25,7 +25,7 @@ function PaymentCallback() {
 
   if (!orderId) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-center">
           <p className="text-red-400">Ugyldig tilbakekobling fra Vipps.</p>
           <Link href="/" className="mt-4 block text-orange-500 underline">
@@ -38,7 +38,7 @@ function PaymentCallback() {
 
   if (confirm.isError) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-center space-y-3">
           <p className="text-red-400">
             Betalingen kunne ikke bekreftes: {confirm.error.message}
@@ -52,10 +52,10 @@ function PaymentCallback() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+    <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="text-center space-y-4">
         <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-orange-500 border-t-transparent" />
-        <p className="text-zinc-300">Bekrefter betaling med Vipps...</p>
+        <p className="text-muted-foreground">Bekrefter betaling med Vipps...</p>
       </div>
     </div>
   );
@@ -65,7 +65,7 @@ export default function PaymentCallbackPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center bg-zinc-950">
+        <div className="flex min-h-screen items-center justify-center bg-background">
           <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-orange-500 border-t-transparent" />
         </div>
       }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 
 @layer base {
   :root {
+    color-scheme: light;
     --background: 0 0% 93%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
@@ -67,6 +68,7 @@
   }
 
   .dark {
+    color-scheme: dark;
     --background: 212 100% 8%;
     --foreground: 210 40% 98%;
     --card: 211 96% 10%;


### PR DESCRIPTION
## Hva
Flere innloggede sider hadde **hardkodede mørke farger** som ignorerte temaet og brøt i **lyst tema** (usynlig hvit tekst, mørke input-bokser på lys bakgrunn osv.). Temasystemet i seg selv var i orden — problemet var komponenter som ikke brukte tokens.

Alle hardkodede verdier er mappet til appens eksisterende semantiske tokens (samme som `Button`/`Input` allerede bruker), så de rendrer riktig i **både lyst og mørkt**:

| Hardkodet | → Token |
|---|---|
| `text-white` (overskrifter/tekst) | `text-foreground` |
| grå muted (`#8694b4`/`#7f8fb2`/`#5b6a8f`) | `text-muted-foreground` |
| mørke input-fyll (`#111a2f`/`#0d1525`) | `bg-background` |
| marineblå knapper (`#212d49`/`#1a2540`) | `bg-secondary` |
| accent/CTA-knapper + aktiv fane (`#2c3a5d`/`#73aac4-20`) | `bg-primary` |
| `hover:bg-white/10` | `hover:bg-foreground/10` |
| full-side `bg-zinc-950` (betalings-callback) | `bg-background` |

I tillegg lagt til `color-scheme: light/dark` på `:root`/`.dark` i `globals.css` slik at native kontroller (f.eks. datetime-velgeren, som hadde hardkodet `[color-scheme:dark]`) følger aktivt tema.

## Berørte filer
- `admin/`: admin-panel, page, aktiviteter-tab, grupper-tab, users-tab
- `faddergruppe/`: group-view, page
- `drikkeleker/page.tsx`, `payment/callback/page.tsx`
- `globals.css`

## Bevisst uendret
Selvstendige mørke flater som er korrekte i begge temaer: mørke «poster»-placeholdere for aktiviteter uten bilde, modal-scrims (`bg-black/*`), Vipps-betalingsoverlayen (egen backdrop + mørkt kort), rødt varselmerke, chip oppå bilder, og dekorative blur-blobs. `footer`/`header-link` hadde allerede `dark:`-varianter.

## Verifisering
- ✅ `tsc --noEmit` — 0 feil
- ✅ `eslint` — 0 feil (kun preeksisterende `<img>`/unused-var-advarsler)
- ✅ `next build` — grønt
- ✅ Nettleser: sjekket lyst/mørkt tema; primærknapp, inputs og tekst flipper korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)