### PR TITLE
feat(admin): ShadCN date picker + better activity-form UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "next": "^16.1.1",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
+        "react-day-picker": "^10.0.1",
         "react-dom": "^19.0.0",
         "server-only": "^0.0.1",
         "superjson": "^2.2.1",
@@ -50,6 +51,8 @@
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -483,6 +486,8 @@
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
+    "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
@@ -858,6 +863,8 @@
     "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+
+    "react-day-picker": ["react-day-picker@10.0.1", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "date-fns": "^4.1.0" }, "peerDependencies": { "@types/react": ">=16.8.0", "react": ">=16.8.0" }, "optionalPeers": ["@types/react"] }, "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "next": "^16.1.1",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.0.0",
     "server-only": "^0.0.1",
     "superjson": "^2.2.1",

--- a/src/app/(authenticated)/admin/aktiviteter-tab.tsx
+++ b/src/app/(authenticated)/admin/aktiviteter-tab.tsx
@@ -4,27 +4,27 @@ import { useState } from "react";
 import { MapPin, Pencil, Plus, Trash2, X } from "lucide-react";
 import { api } from "~/trpc/react";
 import { toast } from "~/components/ui/use-toast";
+import { DateTimePicker } from "~/components/ui/date-time-picker";
 
 type FormState = {
   title: string;
   description: string;
   location: string;
   imageUrl: string;
-  date: string;
+  date: Date | undefined;
 };
 
-const emptyForm: FormState = {
-  title: "",
-  description: "",
-  location: "",
-  imageUrl: "",
-  date: "",
-};
+/** Fresh form with the date pre-filled to today at 18:00 — the common case. */
+function makeEmptyForm(): FormState {
+  const date = new Date();
+  date.setHours(18, 0, 0, 0);
+  return { title: "", description: "", location: "", imageUrl: "", date };
+}
 
 export function AktiviteterTab() {
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [form, setForm] = useState<FormState>(emptyForm);
+  const [form, setForm] = useState<FormState>(makeEmptyForm);
   const utils = api.useUtils();
 
   const { data: activities, isLoading } = api.activity.getAll.useQuery();
@@ -33,7 +33,7 @@ export function AktiviteterTab() {
     onSuccess: () => {
       void utils.activity.getAll.invalidate();
       setShowForm(false);
-      setForm(emptyForm);
+      setForm(makeEmptyForm());
       toast({ title: "Aktivitet opprettet" });
     },
   });
@@ -42,7 +42,7 @@ export function AktiviteterTab() {
     onSuccess: () => {
       void utils.activity.getAll.invalidate();
       setEditingId(null);
-      setForm(emptyForm);
+      setForm(makeEmptyForm());
       toast({ title: "Aktivitet oppdatert" });
     },
   });
@@ -54,14 +54,22 @@ export function AktiviteterTab() {
     },
   });
 
+  const isValid =
+    form.title.trim().length > 0 &&
+    form.location.trim().length > 0 &&
+    form.description.trim().length > 0 &&
+    form.date instanceof Date &&
+    !Number.isNaN(form.date.getTime());
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isValid || !form.date) return;
     const payload = {
-      title: form.title,
-      description: form.description,
-      location: form.location,
-      imageUrl: form.imageUrl || undefined,
-      date: new Date(form.date).toISOString(),
+      title: form.title.trim(),
+      description: form.description.trim(),
+      location: form.location.trim(),
+      imageUrl: form.imageUrl.trim() || undefined,
+      date: form.date.toISOString(),
     };
     if (editingId) {
       updateMutation.mutate({ id: editingId, ...payload });
@@ -77,7 +85,7 @@ export function AktiviteterTab() {
       description: activity.description,
       location: activity.location,
       imageUrl: activity.imageUrl ?? "",
-      date: new Date(activity.date).toISOString().slice(0, 16),
+      date: new Date(activity.date),
     });
     setShowForm(true);
   };
@@ -85,7 +93,7 @@ export function AktiviteterTab() {
   const cancelForm = () => {
     setShowForm(false);
     setEditingId(null);
-    setForm(emptyForm);
+    setForm(makeEmptyForm());
   };
 
   if (isLoading) {
@@ -144,13 +152,16 @@ export function AktiviteterTab() {
               />
             </div>
             <div className="flex flex-col !gap-1.5">
-              <label className="text-xs font-medium text-muted-foreground">Dato og tid *</label>
-              <input
-                required
-                type="datetime-local"
+              <label
+                htmlFor="activity-date"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Dato og tid *
+              </label>
+              <DateTimePicker
+                id="activity-date"
                 value={form.date}
-                onChange={(e) => setForm({ ...form, date: e.target.value })}
-                className="rounded-lg border border-[#73aac4]/30 bg-background !px-3 !py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[#73aac4]"
+                onChange={(date) => setForm({ ...form, date })}
               />
             </div>
           </div>
@@ -198,8 +209,10 @@ export function AktiviteterTab() {
             </button>
             <button
               type="submit"
-              disabled={createMutation.isPending || updateMutation.isPending}
-              className="rounded-xl border border-[#73aac4]/40 bg-primary !px-4 !py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-60"
+              disabled={
+                !isValid || createMutation.isPending || updateMutation.isPending
+              }
+              className="rounded-xl border border-[#73aac4]/40 bg-primary !px-4 !py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {editingId ? "Lagre endringer" : "Opprett aktivitet"}
             </button>

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DayPicker } from "react-day-picker";
+
+import { cn } from "~/lib/utils";
+import { buttonVariants } from "~/components/ui/button";
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+/**
+ * ShadCN-style calendar built on react-day-picker v10. Layout comes entirely
+ * from these Tailwind classNames (no `react-day-picker/style.css` import), and
+ * colours use the app's semantic theme tokens so it works in light and dark.
+ */
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col gap-4 sm:flex-row",
+        month: "flex flex-col gap-4",
+        month_caption: "relative flex h-9 items-center justify-center",
+        caption_label: "text-sm font-medium capitalize",
+        nav: "absolute inset-x-0 top-0 flex items-center justify-between px-1",
+        button_previous: cn(
+          buttonVariants({ variant: "outline" }),
+          "size-7 p-0 opacity-70 hover:opacity-100",
+        ),
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "size-7 p-0 opacity-70 hover:opacity-100",
+        ),
+        month_grid: "w-full border-collapse",
+        weekdays: "flex",
+        weekday:
+          "text-muted-foreground w-9 rounded-md text-[0.8rem] font-normal capitalize",
+        week: "mt-2 flex w-full",
+        day: cn(
+          "relative size-9 p-0 text-center text-sm",
+          "[&:has([aria-selected])]:bg-accent [&:has([aria-selected])]:rounded-md",
+        ),
+        day_button: cn(
+          buttonVariants({ variant: "ghost" }),
+          "size-9 p-0 font-normal aria-selected:opacity-100",
+        ),
+        selected:
+          "[&>button]:bg-primary [&>button]:text-primary-foreground [&>button:hover]:bg-primary [&>button:hover]:text-primary-foreground",
+        today: "[&>button]:bg-accent [&>button]:text-accent-foreground",
+        outside: "text-muted-foreground opacity-50",
+        disabled: "text-muted-foreground opacity-50",
+        hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation, className: chevronClassName }) => {
+          const Icon = orientation === "left" ? ChevronLeft : ChevronRight;
+          return <Icon className={cn("size-4", chevronClassName)} />;
+        },
+      }}
+      {...props}
+    />
+  );
+}
+Calendar.displayName = "Calendar";
+
+export { Calendar };

--- a/src/components/ui/date-time-picker.tsx
+++ b/src/components/ui/date-time-picker.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import { CalendarIcon, Clock } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Button } from "~/components/ui/button";
+import { Calendar } from "~/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+
+const DEFAULT_HOUR = 18;
+
+const labelFormatter = new Intl.DateTimeFormat("no-NO", {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+const captionFormatter = new Intl.DateTimeFormat("no-NO", {
+  month: "long",
+  year: "numeric",
+});
+
+const weekdayFormatter = new Intl.DateTimeFormat("no-NO", { weekday: "short" });
+
+function toTimeString(date: Date) {
+  const h = String(date.getHours()).padStart(2, "0");
+  const m = String(date.getMinutes()).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+export function DateTimePicker({
+  value,
+  onChange,
+  id,
+  placeholder = "Velg dato og tid",
+}: {
+  value: Date | undefined;
+  onChange: (date: Date | undefined) => void;
+  id?: string;
+  placeholder?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleSelectDay = (day: Date | undefined) => {
+    if (!day) {
+      onChange(undefined);
+      return;
+    }
+    // Preserve the currently selected time (or fall back to a sensible default).
+    const next = new Date(day);
+    if (value) {
+      next.setHours(value.getHours(), value.getMinutes(), 0, 0);
+    } else {
+      next.setHours(DEFAULT_HOUR, 0, 0, 0);
+    }
+    onChange(next);
+  };
+
+  const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const [h, m] = e.target.value.split(":").map(Number);
+    const base = value ? new Date(value) : new Date();
+    base.setHours(h ?? 0, m ?? 0, 0, 0);
+    onChange(base);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          className={cn(
+            "w-full justify-start gap-2 font-normal",
+            !value && "text-muted-foreground",
+          )}
+        >
+          <CalendarIcon className="size-4 shrink-0" />
+          <span className="truncate">
+            {value ? labelFormatter.format(value) : placeholder}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={value}
+          onSelect={handleSelectDay}
+          defaultMonth={value}
+          autoFocus
+          weekStartsOn={1}
+          formatters={{
+            formatCaption: (month) => captionFormatter.format(month),
+            formatWeekdayName: (day) => weekdayFormatter.format(day),
+          }}
+        />
+        <div className="flex items-center gap-2 border-t p-3">
+          <Clock className="text-muted-foreground size-4 shrink-0" />
+          <label htmlFor={`${id ?? "datetime"}-time`} className="sr-only">
+            Klokkeslett
+          </label>
+          <input
+            id={`${id ?? "datetime"}-time`}
+            type="time"
+            value={value ? toTimeString(value) : ""}
+            onChange={handleTimeChange}
+            className="border-input bg-background text-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 text-sm focus-visible:ring-2 focus-visible:outline-none"
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Hva
Bytter ut det native `datetime-local`-feltet på «Ny aktivitet»-skjemaet (admin → Aktiviteter) med en **ShadCN-basert date picker** (Calendar i Popover) + klokkeslett-felt, og rydder opp i skjema-UX-en rundt.

### Endringer
- **ShadCN date picker** i stedet for native input
  - Ny `src/components/ui/calendar.tsx` (bygget på `react-day-picker` v10, kun Tailwind-klasser — ingen `style.css`-import)
  - Ny `src/components/ui/date-time-picker.tsx` (dato + tid i én popover, én `Date`-verdi ut)
- **Datoen defaulter til i dag kl. 18:00** for nye aktiviteter (vanligste tilfelle)
- **Norsk kalender**: mandag-start, `no-NO` måned/ukedag-labels, trigger viser «torsdag 16. juli 2026 kl. 18:00»
- **Validering**: «Opprett aktivitet» er deaktivert til alle påkrevde felt er gyldige; verdier trimmes før submit
- **Tema-bevisst** via semantiske tokens (`bg-popover`, `bg-primary`, `bg-accent`, `text-muted-foreground` …)

### Hvorfor
Native `datetime-local` var inkonsekvent på tvers av nettlesere og ga dårlig UX. Nå får admin en konsistent, forutsigbar kalender med fornuftig default-dato.

## Avhengighet
Legger til `react-day-picker` (^10). Ingen ekstra runtime-config; `Popover`/`Button` fantes fra før.

## Reviewer-notat
- Aktiviteter har både dato **og** tid, derfor date picker + eget klokkeslett-felt (ikke bare dato).
- Kalenderen henter layout fra Tailwind-klassene i `calendar.tsx` (ingen `react-day-picker/style.css`).

## Verifisering
- ✅ `tsc --noEmit` — 0 feil
- ✅ `eslint` — 0 feil
- ✅ `next build` — grønt
- ✅ Nettleser: åpnet skjemaet i admin, bekreftet at datoen defaulter til i dag (16. markert/valgt), at kalenderen åpner og navigerer, og at alt ser riktig ut i **både lyst og mørkt tema**

🤖 Generated with [Claude Code](https://claude.com/claude-code)