### PR TITLE
feat: nyregistrering til fadderuka lager ekte TIHLDE-bruker + Vipps

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,8 @@ const compat = new FlatCompat({
 
 export default tseslint.config(
   {
-    ignores: [".next"],
+    // `.claude/` is agent tooling scratch (e.g. isolated worktrees) — never source to lint.
+    ignores: [".next", ".claude/**"],
   },
   ...compat.extends("next/core-web-vitals"),
   {

--- a/prisma/migrations/20260718164417_payment_phone_optional/migration.sql
+++ b/prisma/migrations/20260718164417_payment_phone_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Payment" ALTER COLUMN "phone" DROP NOT NULL;

--- a/prisma/migrations/20260718172743_add_user_allergies/migration.sql
+++ b/prisma/migrations/20260718172743_add_user_allergies/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "allergies" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,7 @@ model User {
     phone         String?
     klasse        String?
     studieretning String?
+    allergies     String?
     isVerified    Boolean   @default(false)
     hasPaid       Boolean   @default(false)
     isAdmin       Boolean   @default(false)
@@ -131,7 +132,7 @@ model Payment {
     // Vipps payment.
     id        String        @id @default(cuid())
     orderId   String        @unique
-    phone     String
+    phone     String? // set only if we prefilled a number; Vipps collects it otherwise
     amount    Int // amount in øre
     status    PaymentStatus @default(CREATED)
     createdAt DateTime      @default(now())

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -103,7 +103,9 @@ export async function POST(request: Request) {
       expires: expiresAt,
     });
 
-    return NextResponse.json({ ok: true });
+    // `verified` lets the registration page skip straight to the app for users
+    // who don't owe a payment (admins/FadderKom are auto-verified above).
+    return NextResponse.json({ ok: true, verified: user.isVerified });
   } catch (err) {
     if (err instanceof TihldeAuthError) {
       // 401/403 from TIHLDE → surface the (Norwegian) detail to the user.

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,142 @@
+import { cookies, headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  REGISTRATION_STUDY_SLUGS,
+  studyLabelForSlug,
+} from "~/lib/majors";
+import {
+  SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  createSession,
+} from "~/server/auth/config";
+import { TihldeAuthError, tihldeCreateUser } from "~/server/auth/tihlde";
+import { db } from "~/server/db";
+
+/**
+ * Self-registration for brand-new students during fadderuka.
+ *
+ * Creates a REAL (but pending-approval) TIHLDE account via Lepton's public
+ * `POST /users/`, mirrors it into our local user table, and mints our own
+ * session so the user gets straight into the app. Payment (Vipps) is handled
+ * separately by the client after this succeeds. The password is forwarded to
+ * TIHLDE and never stored or logged here.
+ */
+
+const bodySchema = z.object({
+  full_name: z.string().trim().min(1, "Fyll inn fullt navn."),
+  email: z.string().trim().email("Ugyldig e-postadresse."),
+  user_id: z
+    .string()
+    .trim()
+    .min(1, "Fyll inn et brukernavn.")
+    .max(15, "Brukernavn kan være maks 15 tegn.")
+    .refine((v) => !v.includes("@"), "Brukernavn skal være uten @stud.ntnu.no."),
+  password: z.string().min(8, "Passordet må være minst 8 tegn."),
+  study: z.enum(REGISTRATION_STUDY_SLUGS, {
+    errorMap: () => ({ message: "Velg hvilken linje du går på." }),
+  }),
+  allergies: z.string().trim().max(500).optional(),
+});
+
+/** Split a full name into first + last for TIHLDE (which stores them apart). */
+function splitName(fullName: string): { first: string; last: string } {
+  const parts = fullName.trim().split(/\s+/);
+  const first = parts.shift() ?? fullName;
+  // TIHLDE requires a last name; fall back to the first name when only one word.
+  const last = parts.length > 0 ? parts.join(" ") : first;
+  return { first, last };
+}
+
+export async function POST(request: Request) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    const first = parsed.error?.issues[0];
+    return NextResponse.json(
+      { error: first?.message ?? "Ugyldig skjema.", field: first?.path[0] },
+      { status: 400 },
+    );
+  }
+
+  const { full_name, email, user_id, password, study, allergies } = parsed.data;
+  const userId = user_id.toLowerCase();
+  const { first, last } = splitName(full_name);
+  const studieretning = studyLabelForSlug(study);
+  const allergiesValue = allergies && allergies.length > 0 ? allergies : null;
+
+  try {
+    // 1. Create the real TIHLDE account (pending admin approval). class:null —
+    //    the study membership is enough; the year group may not exist yet.
+    await tihldeCreateUser({
+      user_id: userId,
+      password,
+      first_name: first,
+      last_name: last,
+      email,
+      study,
+      class: null,
+    });
+
+    // 2. Mirror into our local user table, keyed by the TIHLDE user_id. Payment
+    //    flags are ours (earned via Vipps) and start false.
+    const user = await db.user.upsert({
+      where: { tihldeUserId: userId },
+      create: {
+        tihldeUserId: userId,
+        name: full_name,
+        email,
+        studieretning,
+        allergies: allergiesValue,
+        isVerified: false,
+        hasPaid: false,
+        isAdmin: false,
+      },
+      update: {
+        name: full_name,
+        email,
+        studieretning,
+        allergies: allergiesValue,
+      },
+    });
+
+    // 3. Mint our own session (no TIHLDE token — the account isn't activated
+    //    yet) and set the httpOnly cookie so they're logged into the app.
+    const hdrs = await headers();
+    const { token: sessionToken, expiresAt } = await createSession({
+      userId: user.id,
+      tihldeToken: null,
+      ipAddress: hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+      userAgent: hdrs.get("user-agent"),
+    });
+
+    const cookieStore = await cookies();
+    cookieStore.set(SESSION_COOKIE, sessionToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: SESSION_MAX_AGE,
+      expires: expiresAt,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    if (err instanceof TihldeAuthError) {
+      // 400 from Lepton (duplicate username, bad email, …) → show the message
+      // and hint the client which field it belongs to when we can tell.
+      const status = err.status >= 400 && err.status < 500 ? 400 : 502;
+      const field = /brukernavn/i.test(err.message)
+        ? "user_id"
+        : /e-?post/i.test(err.message)
+          ? "email"
+          : undefined;
+      return NextResponse.json({ error: err.message, field }, { status });
+    }
+    console.error("[auth/register] unexpected error", err);
+    return NextResponse.json(
+      { error: "Noe gikk galt ved registreringen." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/logg-inn/page.tsx
+++ b/src/app/logg-inn/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import Footer from "~/components/layout/footer/footer";
+import { Button } from "~/components/ui/button";
+import { Card, CardDescription, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { authClient } from "~/lib/auth-client";
+
+export default function LoggInnPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleLogin = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+    const userId = (formData.get("user_id") as string)?.trim();
+    const password = formData.get("password") as string;
+
+    const { error } = await authClient.signIn(userId, password);
+
+    if (error) {
+      setError(error);
+      setLoading(false);
+      return;
+    }
+
+    router.push("/");
+    router.refresh();
+  };
+
+  return (
+    <div
+      className="flex min-h-screen flex-col"
+      style={{
+        backgroundColor: "var(--page-bg)",
+        backgroundImage: "var(--page-bg-image)",
+      }}
+    >
+      <main className="flex flex-1 items-center justify-center px-4 py-8">
+        <div className="w-full max-w-xl">
+          <Card>
+            <form onSubmit={handleLogin} style={{ padding: "3rem" }}>
+              <div
+                style={{
+                  marginBottom: "1.5rem",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.5rem",
+                }}
+              >
+                <CardTitle className="text-3xl font-bold">Logg inn</CardTitle>
+                <CardDescription>
+                  Logg inn med ditt TIHLDE-brukernavn og passord
+                </CardDescription>
+              </div>
+
+              {error && (
+                <div
+                  className="bg-destructive/10 text-destructive rounded-md px-4 py-3 text-sm"
+                  style={{ marginBottom: "1.5rem" }}
+                >
+                  {error}
+                </div>
+              )}
+
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "1.5rem",
+                  marginBottom: "2rem",
+                }}
+              >
+                <div className="grid gap-2">
+                  <Label htmlFor="login-user-id">
+                    Brukernavn <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="login-user-id"
+                    name="user_id"
+                    type="text"
+                    autoComplete="username"
+                    required
+                    placeholder="ditt TIHLDE-brukernavn"
+                    className="h-12"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="login-password">
+                    Passord <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="login-password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    required
+                    placeholder="••••••••"
+                    className="h-12"
+                  />
+                </div>
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "1.25rem",
+                }}
+              >
+                <Button
+                  type="submit"
+                  className="h-12 w-full text-base"
+                  disabled={loading}
+                >
+                  {loading ? "Logger inn..." : "Logg inn"}
+                </Button>
+                <p className="text-muted-foreground text-center text-sm">
+                  Ny student uten TIHLDE-bruker?{" "}
+                  <Link href="/registrering" className="underline">
+                    Registrer deg her
+                  </Link>
+                </p>
+              </div>
+            </form>
+          </Card>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/payment/callback/page.tsx
+++ b/src/app/payment/callback/page.tsx
@@ -2,19 +2,14 @@
 
 import { Suspense, useEffect } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { api } from "~/trpc/react";
 
 function PaymentCallback() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const orderId = searchParams.get("orderId");
 
-  const confirm = api.payment.confirmPayment.useMutation({
-    onSuccess: () => {
-      router.replace("/");
-    },
-  });
+  const confirm = api.payment.confirmPayment.useMutation();
 
   useEffect(() => {
     if (orderId) {
@@ -45,6 +40,43 @@ function PaymentCallback() {
           </p>
           <Link href="/" className="block text-orange-500 underline">
             Gå til forsiden
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (confirm.isSuccess) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <div className="max-w-md space-y-6 text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-500/10">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              className="h-8 w-8 text-green-500"
+              stroke="currentColor"
+              strokeWidth={2.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M20 6 9 17l-5-5" />
+            </svg>
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold text-foreground">
+              Takk! Du er registrert 🎉
+            </h1>
+            <p className="text-muted-foreground">
+              Betalingen din er bekreftet, og du er nå registrert for Fadderuka.
+              Velkommen!
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-orange-500 px-6 text-base font-bold text-white shadow-lg shadow-orange-500/25 transition-all hover:bg-orange-600"
+          >
+            Gå til appen
           </Link>
         </div>
       </div>

--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -1,38 +1,74 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useState } from "react";
 import Footer from "~/components/layout/footer/footer";
 import { Button } from "~/components/ui/button";
 import { Card, CardDescription, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { REGISTRATION_STUDIES } from "~/lib/majors";
 import { authClient } from "~/lib/auth-client";
+import { api } from "~/trpc/react";
 
 export default function RegistreringPage() {
   const [error, setError] = useState<string | null>(null);
+  const [errorField, setErrorField] = useState<string | null>(null);
+  const [study, setStudy] = useState<string>("");
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
 
-  const handleLogin = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+  const initiatePayment = api.payment.initiatePayment.useMutation();
+
+  // One submit that (1) creates a real TIHLDE account, (2) logs the user into
+  // the app, and (3) sends them to Vipps to pay for fadderuka.
+  const handleRegister = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
-    setLoading(true);
+    setErrorField(null);
 
     const formData = new FormData(e.currentTarget);
-    const userId = (formData.get("user_id") as string)?.trim();
+    const full_name = (formData.get("full_name") as string)?.trim();
+    const email = (formData.get("email") as string)?.trim();
+    const user_id = (formData.get("user_id") as string)?.trim();
     const password = formData.get("password") as string;
+    const allergies = (formData.get("allergies") as string)?.trim();
 
-    const { error } = await authClient.signIn(userId, password);
+    if (!study) {
+      setError("Velg hvilken linje du går på.");
+      setErrorField("study");
+      return;
+    }
 
-    if (error) {
-      setError(error);
+    setLoading(true);
+
+    const { error: registerError, field } = await authClient.register({
+      full_name,
+      email,
+      user_id,
+      password,
+      study,
+      allergies: allergies || undefined,
+    });
+
+    if (registerError) {
+      setError(registerError);
+      setErrorField(field ?? null);
       setLoading(false);
       return;
     }
 
-    router.push("/");
-    router.refresh();
+    // Account created + logged in — hand off to Vipps to pay.
+    try {
+      const { redirectUrl } = await initiatePayment.mutateAsync();
+      window.location.href = redirectUrl;
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Kunne ikke starte betalingen. Prøv igjen.",
+      );
+      setLoading(false);
+    }
   };
 
   return (
@@ -46,7 +82,7 @@ export default function RegistreringPage() {
       <main className="flex flex-1 items-center justify-center px-4 py-8">
         <div className="w-full max-w-xl">
           <Card>
-            <form onSubmit={handleLogin} style={{ padding: "3rem" }}>
+            <form onSubmit={handleRegister} style={{ padding: "3rem" }}>
               <div
                 style={{
                   marginBottom: "1.5rem",
@@ -55,9 +91,12 @@ export default function RegistreringPage() {
                   gap: "0.5rem",
                 }}
               >
-                <CardTitle className="text-3xl font-bold">Logg inn</CardTitle>
+                <CardTitle className="text-3xl font-bold">
+                  Registrer deg for Fadderuka
+                </CardTitle>
                 <CardDescription>
-                  Logg inn med ditt TIHLDE-brukernavn og passord
+                  Opprett en TIHLDE-bruker og betal med Vipps. Brukeren kan du
+                  senere bruke på tihlde.org.
                 </CardDescription>
               </div>
 
@@ -79,30 +118,116 @@ export default function RegistreringPage() {
                 }}
               >
                 <div className="grid gap-2">
-                  <Label htmlFor="login-user-id">
+                  <Label htmlFor="reg-full-name">
+                    Fullt navn <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="reg-full-name"
+                    name="full_name"
+                    type="text"
+                    autoComplete="name"
+                    required
+                    placeholder="Ola Nordmann"
+                    className="h-12"
+                  />
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="reg-email">
+                    E-post <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="reg-email"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    placeholder="din@epost.no"
+                    aria-invalid={errorField === "email"}
+                    className="h-12"
+                  />
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="reg-user-id">
                     Brukernavn <span className="text-destructive">*</span>
                   </Label>
                   <Input
-                    id="login-user-id"
+                    id="reg-user-id"
                     name="user_id"
                     type="text"
                     autoComplete="username"
                     required
-                    placeholder="ditt TIHLDE-brukernavn"
+                    maxLength={15}
+                    placeholder="ønsket brukernavn"
+                    aria-invalid={errorField === "user_id"}
                     className="h-12"
                   />
+                  <p className="text-muted-foreground text-xs">
+                    Har du NTNU-brukernavn, bruk gjerne det (uten
+                    @stud.ntnu.no).
+                  </p>
                 </div>
+
                 <div className="grid gap-2">
-                  <Label htmlFor="login-password">
+                  <Label htmlFor="reg-password">
                     Passord <span className="text-destructive">*</span>
                   </Label>
                   <Input
-                    id="login-password"
+                    id="reg-password"
                     name="password"
                     type="password"
-                    autoComplete="current-password"
+                    autoComplete="new-password"
                     required
-                    placeholder="••••••••"
+                    minLength={8}
+                    placeholder="minst 8 tegn"
+                    className="h-12"
+                  />
+                </div>
+
+                <div className="grid gap-2">
+                  <span className="text-sm font-medium">
+                    Hvilken linje har du kommet inn på?{" "}
+                    <span className="text-destructive">*</span>
+                  </span>
+                  <div
+                    className="grid gap-2"
+                    role="radiogroup"
+                    aria-label="Linje"
+                  >
+                    {REGISTRATION_STUDIES.map((option) => (
+                      <label
+                        key={option.slug}
+                        className="flex cursor-pointer items-center gap-3 rounded-md border border-input px-4 py-3 text-sm has-[:checked]:border-primary has-[:checked]:bg-primary/5"
+                      >
+                        <input
+                          type="radio"
+                          name="study"
+                          value={option.slug}
+                          checked={study === option.slug}
+                          onChange={(e) => {
+                            setStudy(e.target.value);
+                            if (errorField === "study") {
+                              setError(null);
+                              setErrorField(null);
+                            }
+                          }}
+                          className="h-4 w-4"
+                        />
+                        {option.label}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="reg-allergies">Har du noen matallergier?</Label>
+                  <Input
+                    id="reg-allergies"
+                    name="allergies"
+                    type="text"
+                    maxLength={500}
+                    placeholder="Valgfritt"
                     className="h-12"
                   />
                 </div>
@@ -120,10 +245,13 @@ export default function RegistreringPage() {
                   className="h-12 w-full text-base"
                   disabled={loading}
                 >
-                  {loading ? "Logger inn..." : "Logg inn"}
+                  {loading ? "Registrerer..." : "Registrer og betal med Vipps"}
                 </Button>
                 <p className="text-muted-foreground text-center text-sm">
-                  Bruk samme brukernavn og passord som på tihlde.org.
+                  Har du allerede TIHLDE-bruker?{" "}
+                  <Link href="/logg-inn" className="underline">
+                    Logg inn
+                  </Link>
                 </p>
               </div>
             </form>

--- a/src/components/vipps-payment-overlay.tsx
+++ b/src/components/vipps-payment-overlay.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import { useState } from "react";
 import { Button } from "~/components/ui/button";
 import { useToast } from "~/components/ui/use-toast";
 import { api } from "~/trpc/react";
 
 export default function VippsPaymentOverlay() {
-  const [showPhoneCheck, setShowPhoneCheck] = useState(false);
-  const [phoneNumber, setPhoneNumber] = useState("");
-  const [paymentPhone, setPaymentPhone] = useState("");
-  const [phoneError, setPhoneError] = useState("");
   const { toast } = useToast();
 
   const paymentStatus = api.payment.getStatus.useQuery();
 
   const initiatePayment = api.payment.initiatePayment.useMutation({
     onSuccess: (data) => {
-      // TODO: When Vipps is configured, this will redirect to Vipps checkout
       window.location.href = data.redirectUrl;
     },
     onError: (error) => {
@@ -28,7 +22,7 @@ export default function VippsPaymentOverlay() {
     },
   });
 
-  const checkPayment = api.payment.checkPaymentByPhone.useMutation({
+  const checkPayment = api.payment.checkMyPayment.useMutation({
     onSuccess: (data) => {
       if (data.found) {
         toast({ title: "Betaling funnet!", description: "Du er nå registrert." });
@@ -37,7 +31,7 @@ export default function VippsPaymentOverlay() {
         toast({
           title: "Ingen betaling funnet",
           description:
-            "Vi fant ingen registrert betaling for dette nummeret. Prøv å betal med Vipps.",
+            "Vi fant ingen fullført betaling ennå. Prøv å betale med Vipps.",
           variant: "destructive",
         });
       }
@@ -61,25 +55,6 @@ export default function VippsPaymentOverlay() {
     return null;
   }
 
-  function validatePhone(value: string): boolean {
-    if (!/^\d{8}$/.test(value)) {
-      setPhoneError("Telefonnummeret må være 8 siffer");
-      return false;
-    }
-    setPhoneError("");
-    return true;
-  }
-
-  function handlePayWithVipps() {
-    if (!validatePhone(paymentPhone)) return;
-    initiatePayment.mutate({ phoneNumber: paymentPhone });
-  }
-
-  function handleCheckPayment() {
-    if (!validatePhone(phoneNumber)) return;
-    checkPayment.mutate({ phoneNumber });
-  }
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
       <div className="mx-4 w-full max-w-md rounded-2xl border border-white/10 bg-zinc-900 p-8 shadow-2xl sm:p-10">
@@ -100,160 +75,59 @@ export default function VippsPaymentOverlay() {
               <path d="M18 12a2 2 0 0 0 0 4h4v-4Z" />
             </svg>
           </div>
-          <h2 className="text-2xl font-bold text-white mt-8">Betal for Fadderuka</h2>
+          <h2 className="text-2xl font-bold text-white mt-8">
+            Fullfør registreringen
+          </h2>
           <p className="mt-4 text-sm text-zinc-400">
             Du må betale for fadderuka før du kan se innholdet. Betal enkelt med
             Vipps for å bli registrert som fadderbarn.
           </p>
         </div>
 
-        {/* Pay with Vipps section */}
-        {!showPhoneCheck ? (
-          <div className="space-y-4 m-10 mb-12">
-            <div>
-              <label
-                htmlFor="payment-phone"
-                className="mb-2 block text-sm font-medium text-zinc-300"
-              >
-                Telefonnummer
-              </label>
-              <input
-                id="payment-phone"
-                type="tel"
-                inputMode="numeric"
-                placeholder="12345678"
-                maxLength={8}
-                value={paymentPhone}
-                onChange={(e) => {
-                  const val = e.target.value.replace(/\D/g, "");
-                  setPaymentPhone(val);
-                  if (phoneError) setPhoneError("");
-                }}
-                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3! py-2.5! text-white placeholder:text-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-              />
-              {phoneError && (
-                <p className="mt-1 text-sm text-red-400">{phoneError}</p>
-              )}
-            </div>
+        <div className="space-y-4 m-10 mb-12">
+          <Button
+            onClick={() => initiatePayment.mutate()}
+            disabled={initiatePayment.isPending}
+            className="h-14 w-full rounded-xl bg-orange-500 text-lg font-bold text-white shadow-lg shadow-orange-500/25 transition-all hover:bg-orange-600 hover:shadow-orange-500/40 disabled:opacity-50"
+          >
+            {initiatePayment.isPending ? (
+              <span className="flex items-center gap-2">
+                <svg
+                  className="h-5 w-5 animate-spin"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Laster...
+              </span>
+            ) : (
+              "Betal med Vipps"
+            )}
+          </Button>
 
-            <Button
-              onClick={handlePayWithVipps}
-              disabled={initiatePayment.isPending || paymentPhone.length !== 8}
-              className="h-14 w-full rounded-xl bg-orange-500 text-lg font-bold text-white shadow-lg shadow-orange-500/25 transition-all hover:bg-orange-600 hover:shadow-orange-500/40 disabled:opacity-50"
-            >
-              {initiatePayment.isPending ? (
-                <span className="flex items-center gap-2">
-                  <svg
-                    className="h-5 w-5 animate-spin"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                    />
-                  </svg>
-                  Laster...
-                </span>
-              ) : (
-                "Betal med Vipps"
-              )}
-            </Button>
-
-            <button
-              onClick={() => setShowPhoneCheck(true)}
-              className="w-full py-2 text-sm text-zinc-400 underline-offset-2 transition-colors hover:text-zinc-200 hover:underline"
-            >
-              Jeg har allerede betalt
-            </button>
-          </div>
-        ) : (
-          /* Already paid - phone check section */
-          <div className="space-y-4 m-10 mb-12">
-            <p className="text-sm text-zinc-400">
-              Skriv inn telefonnummeret du betalte med, så sjekker vi om
-              betalingen er registrert.
-            </p>
-
-            <div>
-              <label
-                htmlFor="check-phone"
-                className="mb-2 block text-sm font-medium text-zinc-300"
-              >
-                Telefonnummer
-              </label>
-              <input
-                id="check-phone"
-                type="tel"
-                inputMode="numeric"
-                placeholder="12345678"
-                maxLength={8}
-                value={phoneNumber}
-                onChange={(e) => {
-                  const val = e.target.value.replace(/\D/g, "");
-                  setPhoneNumber(val);
-                  if (phoneError) setPhoneError("");
-                }}
-                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3! py-2.5! text-white placeholder:text-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-              />
-              {phoneError && (
-                <p className="mt-1 text-sm text-red-400">{phoneError}</p>
-              )}
-            </div>
-
-            <Button
-              onClick={handleCheckPayment}
-              disabled={checkPayment.isPending || phoneNumber.length !== 8}
-              className="h-12 w-full rounded-xl bg-zinc-700 font-semibold text-white transition-colors hover:bg-zinc-600 disabled:opacity-50"
-            >
-              {checkPayment.isPending ? (
-                <span className="flex items-center gap-2">
-                  <svg
-                    className="h-5 w-5 animate-spin"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                    />
-                  </svg>
-                  Sjekker...
-                </span>
-              ) : (
-                "Sjekk betaling"
-              )}
-            </Button>
-
-            <button
-              onClick={() => {
-                setShowPhoneCheck(false);
-                setPhoneError("");
-              }}
-              className="w-full py-2 text-sm text-zinc-400 underline-offset-2 transition-colors hover:text-zinc-200 hover:underline"
-            >
-              Tilbake til betaling
-            </button>
-          </div>
-        )}
+          <button
+            onClick={() => checkPayment.mutate()}
+            disabled={checkPayment.isPending}
+            className="w-full py-2 text-sm text-zinc-400 underline-offset-2 transition-colors hover:text-zinc-200 hover:underline disabled:opacity-50"
+          >
+            {checkPayment.isPending
+              ? "Sjekker betaling..."
+              : "Jeg har allerede betalt"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -7,6 +7,26 @@ interface Result {
   error: string | null;
 }
 
+interface SignInResult extends Result {
+  /** True when the user is already verified (e.g. an admin) and owes no payment. */
+  verified: boolean;
+}
+
+/** New-user self-registration payload (mirrors /api/auth/register). */
+export interface RegisterInput {
+  full_name: string;
+  email: string;
+  user_id: string;
+  password: string;
+  study: string;
+  allergies?: string;
+}
+
+interface RegisterResult extends Result {
+  /** Which form field the error belongs to, when the server could tell. */
+  field?: string;
+}
+
 async function readError(res: Response, fallback: string): Promise<string> {
   try {
     const body = (await res.json()) as { error?: string };
@@ -18,7 +38,7 @@ async function readError(res: Response, fallback: string): Promise<string> {
 
 export const authClient = {
   /** Log in with a TIHLDE username + password. */
-  async signIn(userId: string, password: string): Promise<Result> {
+  async signIn(userId: string, password: string): Promise<SignInResult> {
     const res = await fetch("/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -26,7 +46,37 @@ export const authClient = {
     });
 
     if (!res.ok) {
-      return { error: await readError(res, "Noe gikk galt ved innlogging.") };
+      return {
+        error: await readError(res, "Noe gikk galt ved innlogging."),
+        verified: false,
+      };
+    }
+
+    const body = (await res.json().catch(() => null)) as {
+      verified?: boolean;
+    } | null;
+    return { error: null, verified: body?.verified ?? false };
+  },
+
+  /** Register a brand-new TIHLDE account and log into the app. */
+  async register(input: RegisterInput): Promise<RegisterResult> {
+    const res = await fetch("/api/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+
+    if (!res.ok) {
+      let field: string | undefined;
+      let error = "Noe gikk galt ved registreringen.";
+      try {
+        const body = (await res.json()) as { error?: string; field?: string };
+        error = body?.error ?? error;
+        field = body?.field;
+      } catch {
+        // keep defaults
+      }
+      return { error, field };
     }
     return { error: null };
   },

--- a/src/lib/majors.ts
+++ b/src/lib/majors.ts
@@ -8,6 +8,34 @@ export const MAJORS = [
 
 export type Major = (typeof MAJORS)[number];
 
+/**
+ * Study programmes ("linje") selectable during fadderuka self-registration,
+ * each mapped to its TIHLDE STUDY group slug (verified against the live
+ * `GET /groups/?type=STUDY` API). The label is stored as `studieretning` and is
+ * kept in sync with MAJORS so `findMajor` resolves it.
+ */
+export const REGISTRATION_STUDIES = [
+  { label: "Dataingeniør", slug: "dataingenir" },
+  { label: "Digital Forretningsutvikling", slug: "digital-forretningsutvikling" },
+  {
+    label: "Digital Infrastruktur og Cybersikkerhet",
+    slug: "digital-infrastruktur-og-cybersikkerhet",
+  },
+  { label: "Digital transformasjon", slug: "digital-samhandling" },
+] as const;
+
+export type RegistrationStudySlug =
+  (typeof REGISTRATION_STUDIES)[number]["slug"];
+
+export const REGISTRATION_STUDY_SLUGS = REGISTRATION_STUDIES.map(
+  (s) => s.slug,
+) as [RegistrationStudySlug, ...RegistrationStudySlug[]];
+
+/** Resolve a study slug to its display label (for storing `studieretning`). */
+export function studyLabelForSlug(slug: string): string | null {
+  return REGISTRATION_STUDIES.find((s) => s.slug === slug)?.label ?? null;
+}
+
 export const UKJENT_STUDIERETNING = "Ukjent studieretning";
 
 /** TIHLDE's casing for studieretning names isn't guaranteed, so match case-insensitively. */

--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -11,10 +11,6 @@ import {
   settlePayment,
 } from "~/server/payment/vipps";
 
-const phoneInput = z.object({
-  phoneNumber: z.string().regex(/^\d{8}$/, "Telefonnummeret må være 8 siffer"),
-});
-
 /** Translate a Vipps-layer error into the tRPC error shown to the client. */
 function toTRPCError(err: unknown): TRPCError {
   if (err instanceof TRPCError) return err;
@@ -43,88 +39,77 @@ export const paymentRouter = createTRPCRouter({
     };
   }),
 
-  initiatePayment: protectedProcedure
-    .input(phoneInput)
-    .mutation(async ({ ctx, input }) => {
-      const user = await ctx.db.user.findUnique({
-        where: { id: ctx.session.user.id },
-        select: { hasPaid: true },
+  // Starts a Vipps payment for the signed-in user and returns the URL to
+  // redirect them to. No phone number is collected — Vipps prompts for it on
+  // its own checkout page in the WEB_REDIRECT flow.
+  initiatePayment: protectedProcedure.mutation(async ({ ctx }) => {
+    const user = await ctx.db.user.findUnique({
+      where: { id: ctx.session.user.id },
+      select: { hasPaid: true },
+    });
+
+    if (!user) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Bruker ikke funnet" });
+    }
+
+    if (user.hasPaid) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Du har allerede betalt",
+      });
+    }
+
+    const orderId = buildOrderId(ctx.session.user.id);
+
+    try {
+      const payment = await createPayment(orderId);
+
+      // Persist the order so the callback and webhook can settle it, and so
+      // "Jeg har allerede betalt" can re-check this user's own payments.
+      await ctx.db.payment.create({
+        data: {
+          orderId,
+          userId: ctx.session.user.id,
+          amount: PAYMENT_AMOUNT_ORE,
+        },
       });
 
-      if (!user) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Bruker ikke funnet" });
-      }
-
-      if (user.hasPaid) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Du har allerede betalt",
-        });
-      }
-
-      await ctx.db.user.update({
-        where: { id: ctx.session.user.id },
-        data: { phone: input.phoneNumber },
-      });
-
-      const orderId = buildOrderId(ctx.session.user.id);
-
-      try {
-        const payment = await createPayment(input.phoneNumber, orderId);
-
-        // Persist the order so the callback and webhook can settle it, and so
-        // "Jeg har allerede betalt" can re-check this user's own payments.
-        await ctx.db.payment.create({
-          data: {
-            orderId,
-            userId: ctx.session.user.id,
-            phone: input.phoneNumber,
-            amount: PAYMENT_AMOUNT_ORE,
-          },
-        });
-
-        return { redirectUrl: payment.redirectUrl };
-      } catch (err) {
-        throw toTRPCError(err);
-      }
-    }),
+      return { redirectUrl: payment.redirectUrl };
+    } catch (err) {
+      throw toTRPCError(err);
+    }
+  }),
 
   // Fallback for when the Vipps redirect never returns the user to us (they
-  // closed the app, lost connection, etc.). We only ever settle *this* user's
-  // own orders against Vipps — never trust a phone number as proof of payment.
-  checkPaymentByPhone: protectedProcedure
-    .input(phoneInput)
-    .mutation(async ({ ctx, input }) => {
-      await ctx.db.user.update({
-        where: { id: ctx.session.user.id },
-        data: { phone: input.phoneNumber },
-      });
+  // closed the app, lost connection, etc.). We settle *this* user's own
+  // pending orders against Vipps — the API, not any client input, is the proof
+  // of payment, so this needs no arguments.
+  checkMyPayment: protectedProcedure.mutation(async ({ ctx }) => {
+    const orders = await ctx.db.payment.findMany({
+      where: {
+        userId: ctx.session.user.id,
+        status: { in: ["CREATED", "AUTHORIZED"] },
+      },
+      orderBy: { createdAt: "desc" },
+      select: { orderId: true },
+    });
 
-      const orders = await ctx.db.payment.findMany({
-        where: {
-          userId: ctx.session.user.id,
-          status: { in: ["CREATED", "AUTHORIZED"] },
-        },
-        orderBy: { createdAt: "desc" },
-        select: { orderId: true },
-      });
-
-      for (const order of orders) {
-        try {
-          const { paid } = await settlePayment(order.orderId);
-          if (paid) return { found: true };
-        } catch (err) {
-          // A single unsettleable order shouldn't abort the whole check.
-          console.error("[payment] settle failed for", order.orderId, err);
-        }
+    for (const order of orders) {
+      try {
+        const { paid } = await settlePayment(order.orderId);
+        if (paid) return { found: true };
+      } catch (err) {
+        // A single unsettleable order shouldn't abort the whole check.
+        console.error("[payment] settle failed for", order.orderId, err);
       }
+    }
 
-      const user = await ctx.db.user.findUnique({
-        where: { id: ctx.session.user.id },
-        select: { hasPaid: true },
-      });
-      return { found: user?.hasPaid ?? false };
-    }),
+    const user = await ctx.db.user.findUnique({
+      where: { id: ctx.session.user.id },
+      select: { hasPaid: true },
+    });
+    return { found: user?.hasPaid ?? false };
+  }),
 
   confirmPayment: protectedProcedure
     .input(z.object({ orderId: z.string() }))

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -51,7 +51,9 @@ async function getSession({ headers }: { headers: Headers }) {
 /** Create a persisted session for a user and return its cookie token. */
 export async function createSession(opts: {
   userId: string;
-  tihldeToken: string;
+  // Self-registered users have no TIHLDE token until they're activated and log
+  // in via TIHLDE, so this is optional.
+  tihldeToken?: string | null;
   ipAddress?: string | null;
   userAgent?: string | null;
 }) {
@@ -62,7 +64,7 @@ export async function createSession(opts: {
     data: {
       token,
       userId: opts.userId,
-      tihldeToken: opts.tihldeToken,
+      tihldeToken: opts.tihldeToken ?? null,
       expiresAt,
       ipAddress: opts.ipAddress ?? null,
       userAgent: opts.userAgent ?? null,

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -76,6 +76,83 @@ export async function tihldeLogin(
   return data.token;
 }
 
+/** Fields accepted by Lepton's public `POST /users/` (UserCreateSerializer). */
+export interface TihldeCreateUserInput {
+  user_id: string;
+  password: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  /** STUDY group slug (linje), or null to skip the study membership. */
+  study: string | null;
+  /** STUDYYEAR group slug (kull), or null to skip the year membership. */
+  class: string | null;
+}
+
+/**
+ * Read a create-user error from Lepton. DRF returns the message in one of a few
+ * shapes: `{detail: "..."}`, per-field arrays nested under `detail`
+ * (`{detail: {email: ["..."]}}`), or those field arrays at the top level. We
+ * surface the first human-readable message, mapping a duplicate `user_id` to a
+ * login hint.
+ */
+async function readCreateError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { detail?: unknown };
+
+    if (typeof body.detail === "string") return body.detail;
+
+    // Field errors live under `detail` when it's an object, else at top level.
+    const bag =
+      body.detail && typeof body.detail === "object"
+        ? (body.detail as Record<string, unknown>)
+        : (body as Record<string, unknown>);
+
+    // user_id is the primary key; a duplicate means the account already exists.
+    if ("user_id" in bag) {
+      return "Brukernavnet er opptatt. Har du allerede en bruker? Logg inn i stedet.";
+    }
+
+    // Otherwise return the first field error message we can find.
+    for (const value of Object.values(bag)) {
+      if (typeof value === "string") return value;
+      if (Array.isArray(value)) {
+        const first = (value as unknown[])[0];
+        if (typeof first === "string") return first;
+      }
+    }
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Create a brand-new TIHLDE account via Lepton's public `POST /users/`.
+ *
+ * The account is created "pending" — it is NOT a TIHLDE member yet, so it cannot
+ * log in on tihlde.org (or via our own TIHLDE login) until an admin approves it
+ * through the normal Kvark flow (`POST /users/activate/`). We never store the
+ * password: it is forwarded straight to TIHLDE.
+ */
+export async function tihldeCreateUser(
+  input: TihldeCreateUserInput,
+): Promise<void> {
+  const res = await fetch(apiUrl("/users/"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new TihldeAuthError(
+      await readCreateError(res, "Kunne ikke opprette TIHLDE-brukeren din."),
+      res.status,
+    );
+  }
+}
+
 /** Fetch the authenticated user's TIHLDE profile. */
 export async function tihldeGetMe(token: string): Promise<TihldeProfile> {
   const res = await fetch(apiUrl("/users/me/"), {

--- a/src/server/payment/vipps.ts
+++ b/src/server/payment/vipps.ts
@@ -106,10 +106,16 @@ async function getAccessToken(cfg: VippsConfig): Promise<string> {
   return data.access_token;
 }
 
-/** Create a WALLET payment and return the URL to redirect the user to. */
+/**
+ * Create a WALLET payment and return the URL to redirect the user to.
+ *
+ * `phoneNumber` is optional: with the `WEB_REDIRECT` flow Vipps collects the
+ * number on its own checkout page, so registration doesn't need to ask for it.
+ * When we do have one (e.g. a prefilled retry) we pass it to skip that step.
+ */
 export async function createPayment(
-  phoneNumber: string,
   orderId: string,
+  phoneNumber?: string,
 ): Promise<{ redirectUrl: string }> {
   const cfg = requireConfig();
 
@@ -131,7 +137,11 @@ export async function createPayment(
     body: JSON.stringify({
       amount: { currency: "NOK", value: PAYMENT_AMOUNT_ORE },
       paymentMethod: { type: "WALLET" },
-      customer: { phoneNumber: `47${phoneNumber}` }, // E.164 format
+      // Include the customer only when we actually have a number; otherwise
+      // Vipps prompts for it in the WEB_REDIRECT checkout.
+      ...(phoneNumber
+        ? { customer: { phoneNumber: `47${phoneNumber}` } } // E.164 format
+        : {}),
       reference: orderId,
       returnUrl: `${env.VIPPS_CALLBACK_URL}/payment/callback?orderId=${orderId}`,
       userFlow: "WEB_REDIRECT",


### PR DESCRIPTION
## Hva

Gjør `/registrering` om til **nyregistrering for helt nye studenter**. Ved «Registrer og betal med Vipps» opprettes en **ekte (ventende) TIHLDE-konto** via Leptons offentlige `POST /users/`, brukeren logges inn i appen (lokal økt), og sendes til Vipps for å betale for fadderuka. Kontoen kan brukes på tihlde.org etter godkjenning.

## Hvorfor

Kravet var «så enkelt som mulig, men samme bruker på tihlde.org». Kartlegging av Lepton/Kvark viste at eneste vei til en gjenbrukbar konto er å opprette en ekte TIHLDE-bruker. Manuell signup ble valgt (framfor Feide) fordi den tillater personlig e-post og et enkelt skjema, i tråd med Google Formen.

## Flyt

`/registrering` (Fullt navn · E-post · Brukernavn · Passord · Linje · Matallergier) → `POST /api/auth/register` → Lepton `POST /users/` + lokal User + økt → Vipps → bekreftelsesside.

## Endringer

- **Ny** `POST /api/auth/register`: zod-validering, `tihldeCreateUser` (linje→STUDY-slug, `class: null`), speiler til lokal `User`, minter økt. Passord videresendes til Lepton, **lagres/loggføres aldri** hos oss.
- **Aktivering** skjer i TIHLDEs eksisterende admin-flyt (Kvark `/admin/brukere`) — ingen aktiveringskode her. TIHLDE-medlemskap og Fadderuka `hasPaid` er uavhengige flagg.
- TIHLDE-login flyttet til **`/logg-inn`** for eksisterende medlemmer; sidene lenker til hverandre.
- `createSession`: `tihldeToken` valgfri (selvregistrerte har ingen ennå).
- Ny `User.allergies` (+ migrasjon); allergifeltet lagres lokalt.
- Gjenbruker Vipps-arbeidet fra denne branchen: input-løs `initiatePayment`, `checkMyPayment`, telefonløs `createPayment`, bekreftelsesside for callback, forenklet overlay, nullable `Payment.phone`.
- eslint ignorerer nå `.claude/**` (agent-scratch/worktrees) så lint ikke feiler på gamle byggeartefakter.

## Verifisert

- ✅ typecheck, `npm run lint` (0 errors), `next build`
- ✅ Skjemaet rendrer korrekt (alle felt + 4 linjevalg)
- ✅ Validering + felt-mapping via curl; Lepton-feil surfaces pent (testet `@ntnu.no` mot ekte Lepton)

## Ikke verifisert (bevisst)

- **Vellykket kontooppretting** kjørte jeg ikke — det ville laget en ekte ventende bruker i TIHLDE-prod. Bør testes mot test/staging eller med en testbruker som slettes.
- **Vipps-redirect** kan ikke fullføres lokalt (`VIPPS_API_URL`/`VIPPS_CALLBACK_URL` mangler i lokal `.env`).

## Merk før merge

- Migrasjoner må deployes (`prisma migrate deploy`): `payment_phone_optional`, `add_user_allergies`.
- Kull/år sendes som `null` (STUDYYEAR-gruppe for årets kull finnes ikke ennå).
- «Koble Feide senere» finnes ikke i Lepton i dag — utenfor scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)