### PR TITLE
feat(events): hent Fadderuka-events fra TIHLDE-API-et

### DIFF
--- a/src/app/(authenticated)/aktiviteter/page.tsx
+++ b/src/app/(authenticated)/aktiviteter/page.tsx
@@ -3,7 +3,7 @@ import { api } from "~/trpc/server";
 import AktiviteterList from "./aktiviteter-list";
 
 export default async function AktiviteterPage() {
-  const activities = await api.activity.getAll();
+  const activities = await api.activity.getUpcoming();
 
   // Group activities by calendar day
   const grouped = activities.reduce<Record<string, typeof activities>>(

--- a/src/app/(authenticated)/page.tsx
+++ b/src/app/(authenticated)/page.tsx
@@ -8,7 +8,7 @@ import Footer from "~/components/layout/footer/footer";
 import { api } from "~/trpc/server";
 
 export default async function Home() {
-  const activities = await api.activity.getAll();
+  const activities = await api.activity.getUpcoming();
   const upcoming = activities
     .filter((activity) => new Date(activity.date) >= new Date())
     .slice(0, 8);

--- a/src/server/api/routers/activity.ts
+++ b/src/server/api/routers/activity.ts
@@ -1,11 +1,41 @@
 import { z } from "zod";
 import { adminProcedure, createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import {
+  getTihldeFadderukaEvents,
+  type EventItem,
+} from "~/server/tihlde/events";
 
 export const activityRouter = createTRPCRouter({
   getAll: publicProcedure.query(({ ctx }) => {
     return ctx.db.activity.findMany({
       orderBy: { date: "asc" },
     });
+  }),
+
+  /**
+   * Merged, date-sorted event feed for the public pages: Fadderuka events from
+   * TIHLDE plus any locally-managed activities. Admins still create local
+   * activities via the mutations below; TIHLDE events are read-only.
+   */
+  getUpcoming: publicProcedure.query(async ({ ctx }): Promise<EventItem[]> => {
+    const [local, tihlde] = await Promise.all([
+      ctx.db.activity.findMany({ orderBy: { date: "asc" } }),
+      getTihldeFadderukaEvents(),
+    ]);
+
+    const localEvents: EventItem[] = local.map((a) => ({
+      id: a.id,
+      title: a.title,
+      description: a.description,
+      location: a.location,
+      date: a.date,
+      imageUrl: a.imageUrl,
+      source: "local",
+    }));
+
+    return [...tihlde, ...localEvents].sort(
+      (a, b) => a.date.getTime() - b.date.getTime(),
+    );
   }),
 
   create: adminProcedure

--- a/src/server/tihlde/events.ts
+++ b/src/server/tihlde/events.ts
@@ -1,0 +1,105 @@
+import "server-only";
+
+import { env } from "~/env";
+
+/**
+ * Read-only client for TIHLDE's Lepton events API.
+ *
+ * The events endpoints are public (no auth), so we fetch them server-side and
+ * cache the responses. We surface only the events in the "Fadderuka" category,
+ * mapped onto the same shape the app uses for its local activities.
+ *
+ *   GET {API}/events/           -> paginated list (upcoming/non-expired only)
+ *   GET {API}/events/{id}/      -> single event incl. `description`
+ */
+
+/** Category text (not id — ids can drift) used to select Fadderuka events. */
+const FADDERUKA_CATEGORY = "Fadderuka";
+
+/** How long (seconds) to cache TIHLDE responses. Events change rarely. */
+const REVALIDATE_SECONDS = 300;
+
+const apiUrl = (path: string) =>
+  `${env.TIHLDE_API_URL.replace(/\/$/, "")}${path}`;
+
+/** The normalized event shape shared by TIHLDE and local activities. */
+export interface EventItem {
+  id: string;
+  title: string;
+  description: string;
+  location: string;
+  date: Date;
+  imageUrl: string | null;
+  source: "tihlde" | "local";
+}
+
+interface TihldeEventListItem {
+  id: number;
+  title: string;
+  start_date: string;
+  location: string;
+  image: string | null;
+  category: { id: number; text: string } | null;
+}
+
+interface TihldeEventDetail extends TihldeEventListItem {
+  description: string;
+}
+
+/**
+ * Fetch upcoming Fadderuka events from TIHLDE, normalized to `EventItem`.
+ *
+ * On any network/API failure this returns an empty array rather than throwing,
+ * so a TIHLDE outage never breaks the pages (local activities still render).
+ */
+export async function getTihldeFadderukaEvents(): Promise<EventItem[]> {
+  try {
+    const res = await fetch(apiUrl("/events/?page_size=100"), {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) return [];
+
+    const body = (await res.json()) as { results?: TihldeEventListItem[] };
+    const fadderuka = (body.results ?? []).filter(
+      (e) => e.category?.text === FADDERUKA_CATEGORY,
+    );
+
+    // The list endpoint omits `description`; fetch each event's detail for it.
+    const detailed = await Promise.all(
+      fadderuka.map((e) => getEventDetail(e.id)),
+    );
+
+    return detailed
+      .filter((e): e is TihldeEventDetail => e !== null)
+      .map(mapEvent);
+  } catch {
+    return [];
+  }
+}
+
+async function getEventDetail(id: number): Promise<TihldeEventDetail | null> {
+  try {
+    const res = await fetch(apiUrl(`/events/${id}/`), {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as TihldeEventDetail;
+  } catch {
+    return null;
+  }
+}
+
+function mapEvent(e: TihldeEventDetail): EventItem {
+  return {
+    id: `tihlde-${e.id}`,
+    title: e.title,
+    description: e.description,
+    location: e.location,
+    date: new Date(e.start_date),
+    // `||` is intentional: `image` is often an empty string on Fadderuka
+    // events, and we want to coerce "" (not just null) to null.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    imageUrl: e.image || null,
+    source: "tihlde",
+  };
+}


### PR DESCRIPTION
## Hva

Events hentes nå fra det tilkoblede TIHLDE-API-et (Lepton) i stedet for kun å lages lokalt.

- **Ny klient** `src/server/tihlde/events.ts` — read-only mot `api.tihlde.org/events/` (offentlig, ingen auth). Henter kommende events, filtrerer på kategori **"Fadderuka"** (matcher på tekst, ikke id, som kan drifte år til år), henter beskrivelse per event, og mapper til appens felles `EventItem`-form. Cacher 5 min. Ved API-feil returneres `[]` i stedet for å krasje siden.
- **Ny `getUpcoming` tRPC-prosedyre** i `activity`-routeren slår sammen TIHLDE Fadderuka-events (`source: "tihlde"`) med lokale aktiviteter (`source: "local"`), sortert på dato.
- **Forsiden** og **aktivitetssiden** bruker nå den sammenslåtte listen.

Lokale aktiviteter, admin-fanen og `create/update/delete`-mutasjonene er **uendret**, slik at grupper kan lage egne events senere.

## Verifisert

- `npm run check` (eslint + tsc): 0 feil
- `npm run build`: OK
- Mapping-logikken kjørt mot ekte TIHLDE-API: 5 Fadderuka-events hentet med beskrivelser, korrekt datosortering og bildefallback

## Merk

Fadder-relevante bedpresser ligger under kategori "Bedpres", ikke "Fadderuka", så de kommer ikke med i denne filtreringen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)