### PR TITLE
feat: tydeliggjør at allergier-feltet er fritekst, ikke ja/nei

### DIFF
--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -220,15 +220,18 @@ export default function RegistreringPage() {
                 </div>
 
                 <div className="grid gap-2">
-                  <Label htmlFor="reg-allergies">Har du noen matallergier?</Label>
+                  <Label htmlFor="reg-allergies">Matallergier</Label>
                   <Input
                     id="reg-allergies"
                     name="allergies"
                     type="text"
                     maxLength={500}
-                    placeholder="Valgfritt"
+                    placeholder="F.eks. nøtter, laktose, gluten"
                     className="h-12"
                   />
+                  <p className="text-muted-foreground text-xs">
+                    Fyll ut kun hvis du har allergier – la stå tomt ellers.
+                  </p>
                 </div>
               </div>
 


### PR DESCRIPTION
«Har du noen matallergier?» leste som et ja/nei-spørsmål. Vi vil ikke at folk skal skrive noe hvis de ikke har allergier.

## Endring på `/registrering`
- Label: «Har du noen matallergier?» → **«Matallergier»**
- Ny hjelpetekst: **«Fyll ut kun hvis du har allergier – la stå tomt ellers»**
- Placeholder: «Valgfritt» → «F.eks. nøtter, laktose, gluten»

## Verifisert
- ✅ eslint
- ✅ Feltet rendrer korrekt i nettleser

🤖 Generated with [Claude Code](https://claude.com/claude-code)