### PR TITLE
fix(auth): fjern lokal allergi-kolonne som brakk all innlogging (500)

### DIFF
--- a/prisma/migrations/20260718172743_add_user_allergies/migration.sql
+++ b/prisma/migrations/20260718172743_add_user_allergies/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "User" ADD COLUMN     "allergies" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,7 +53,6 @@ model User {
     phone         String?
     klasse        String?
     studieretning String?
-    allergies     String?
     isVerified    Boolean   @default(false)
     hasPaid       Boolean   @default(false)
     isAdmin       Boolean   @default(false)

--- a/src/app/(authenticated)/layout.tsx
+++ b/src/app/(authenticated)/layout.tsx
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import React from "react";
 import { auth } from "~/server/auth/config";
+import AllergySync from "~/components/allergy-sync";
 import VippsPaymentOverlay from "~/components/vipps-payment-overlay";
 
 export default async function AuthenticatedLayout({
@@ -21,10 +22,16 @@ export default async function AuthenticatedLayout({
     return (
       <>
         {children}
+        <AllergySync />
         <VippsPaymentOverlay />
       </>
     );
   }
 
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <AllergySync />
+    </>
+  );
 }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -39,7 +39,6 @@ const bodySchema = z.object({
   study: z.enum(REGISTRATION_STUDY_SLUGS, {
     errorMap: () => ({ message: "Velg hvilken linje du går på." }),
   }),
-  allergies: z.string().trim().max(500).optional(),
 });
 
 /** Split a full name into first + last for TIHLDE (which stores them apart). */
@@ -61,11 +60,10 @@ export async function POST(request: Request) {
     );
   }
 
-  const { full_name, email, user_id, password, study, allergies } = parsed.data;
+  const { full_name, email, user_id, password, study } = parsed.data;
   const userId = user_id.toLowerCase();
   const { first, last } = splitName(full_name);
   const studieretning = studyLabelForSlug(study);
-  const allergiesValue = allergies && allergies.length > 0 ? allergies : null;
 
   try {
     // 1. Create the real TIHLDE account (pending admin approval). class:null —
@@ -89,7 +87,6 @@ export async function POST(request: Request) {
         name: full_name,
         email,
         studieretning,
-        allergies: allergiesValue,
         isVerified: false,
         hasPaid: false,
         isAdmin: false,
@@ -98,7 +95,6 @@ export async function POST(request: Request) {
         name: full_name,
         email,
         studieretning,
-        allergies: allergiesValue,
       },
     });
 

--- a/src/app/api/profile/allergy/route.ts
+++ b/src/app/api/profile/allergy/route.ts
@@ -1,0 +1,52 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "~/server/auth/config";
+import { TihldeAuthError, tihldeUpdateAllergy } from "~/server/auth/tihlde";
+
+/**
+ * Persist a user's food allergies onto their TIHLDE profile (Lepton owns the
+ * data — we don't store it locally). Self-registration collects the allergy but
+ * the fresh account is pending and has no TIHLDE token, so the client buffers it
+ * and POSTs here on later authenticated loads. We only succeed once the session
+ * carries a real TIHLDE token (i.e. after activation + a TIHLDE login); until
+ * then we report `synced: false` so the client keeps the buffer and retries.
+ */
+
+const bodySchema = z.object({
+  allergy: z.string().trim().min(1).max(500),
+});
+
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return NextResponse.json({ error: "Ikke innlogget." }, { status: 401 });
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Ugyldig allergi." }, { status: 400 });
+  }
+
+  // Pending accounts have no TIHLDE token yet — nothing we can do until the user
+  // is activated and logs in via TIHLDE. Tell the client to keep buffering.
+  const token = session.session.tihldeToken;
+  if (!token) {
+    return NextResponse.json({ synced: false });
+  }
+
+  try {
+    await tihldeUpdateAllergy(token, session.user.tihldeUserId, parsed.data.allergy);
+    return NextResponse.json({ synced: true });
+  } catch (err) {
+    if (err instanceof TihldeAuthError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    console.error("[profile/allergy] unexpected error", err);
+    return NextResponse.json(
+      { error: "Kunne ikke lagre allergiene dine." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { REGISTRATION_STUDIES } from "~/lib/majors";
 import { authClient } from "~/lib/auth-client";
+import { PENDING_ALLERGY_KEY } from "~/lib/pending-allergy";
 import { api } from "~/trpc/react";
 
 export default function RegistreringPage() {
@@ -47,7 +48,6 @@ export default function RegistreringPage() {
       user_id,
       password,
       study,
-      allergies: allergies || undefined,
     });
 
     if (registerError) {
@@ -55,6 +55,17 @@ export default function RegistreringPage() {
       setErrorField(field ?? null);
       setLoading(false);
       return;
+    }
+
+    // Allergies live in TIHLDE, not our DB. The account is still pending here
+    // (no TIHLDE token yet), so buffer the value and let `AllergySync` push it
+    // to the TIHLDE profile on a later authenticated load after activation.
+    if (allergies) {
+      try {
+        localStorage.setItem(PENDING_ALLERGY_KEY, allergies);
+      } catch {
+        // Non-critical: the user can always set allergies on tihlde.org.
+      }
     }
 
     // Account created + logged in — hand off to Vipps to pay.

--- a/src/components/allergy-sync.tsx
+++ b/src/components/allergy-sync.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { PENDING_ALLERGY_KEY } from "~/lib/pending-allergy";
+
+/**
+ * Flushes a buffered allergy (collected during self-registration) onto the
+ * user's TIHLDE profile once the session carries a real TIHLDE token. Rendered
+ * inside the authenticated layout so it runs on authenticated loads. It keeps
+ * the buffer and retries until the server confirms it synced, so a pending
+ * account (no token yet) simply tries again after activation + TIHLDE login.
+ */
+export default function AllergySync() {
+  useEffect(() => {
+    let allergy: string | null = null;
+    try {
+      allergy = localStorage.getItem(PENDING_ALLERGY_KEY);
+    } catch {
+      return;
+    }
+    if (!allergy) return;
+
+    void (async () => {
+      try {
+        const res = await fetch("/api/profile/allergy", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ allergy }),
+        });
+        if (!res.ok) return; // keep the buffer, retry on a later load
+        const body = (await res.json().catch(() => null)) as {
+          synced?: boolean;
+        } | null;
+        if (body?.synced) localStorage.removeItem(PENDING_ALLERGY_KEY);
+      } catch {
+        // Network error — keep the buffer and retry on the next load.
+      }
+    })();
+  }, []);
+
+  return null;
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -19,7 +19,6 @@ export interface RegisterInput {
   user_id: string;
   password: string;
   study: string;
-  allergies?: string;
 }
 
 interface RegisterResult extends Result {

--- a/src/lib/pending-allergy.ts
+++ b/src/lib/pending-allergy.ts
@@ -1,0 +1,7 @@
+/**
+ * Allergies are owned by TIHLDE (Lepton), not our DB. Self-registration collects
+ * the allergy while the account is still pending (no TIHLDE token), so we buffer
+ * it in the browser under this key and flush it to Lepton on a later
+ * authenticated load — see `AllergySync` and `POST /api/profile/allergy`.
+ */
+export const PENDING_ALLERGY_KEY = "fadderuke.pending_allergy";

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -251,6 +251,38 @@ export function isMemberOfGroup(
   return memberships.some((m) => m.group?.slug === slug);
 }
 
+/**
+ * Write the user's food allergies onto their TIHLDE profile (Lepton's `allergy`
+ * field), so allergies live in TIHLDE — as Kvark does — instead of our own DB.
+ *
+ * Requires the user's own API token; a pending (not-yet-activated) account has
+ * none, so the caller must only invoke this once the user has a real token.
+ * Uses PATCH on `/users/{user_id}/` (Lepton's user update, where `allergy` is
+ * writable) so we touch nothing but the allergy field.
+ */
+export async function tihldeUpdateAllergy(
+  token: string,
+  userId: string,
+  allergy: string,
+): Promise<void> {
+  const res = await fetch(apiUrl(`/users/${encodeURIComponent(userId)}/`), {
+    method: "PATCH",
+    headers: {
+      [TOKEN_HEADER]: token,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ allergy }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new TihldeAuthError(
+      await readDetail(res, "Kunne ikke lagre allergiene dine i TIHLDE."),
+      res.status,
+    );
+  }
+}
+
 /** Map a TIHLDE profile onto the fields we persist locally. */
 export function mapProfile(profile: TihldeProfile) {
   const name = [profile.first_name, profile.last_name]


### PR DESCRIPTION
## Problem
All innlogging ga **500** i prod. Vercel runtime-loggen viste én feilgruppe på `/api/auth/login`:

```
PrismaClientKnownRequestError: The column `User.allergies` does not exist in the current database.
code: 'P2022'
```

Prod-DB-en lå bak den deployede koden: den manglet `User.allergies`-kolonnen som Prisma-klienten forventer. Siden Prisma leser tilbake **alle** skalarfelt på `User`, refererte hver `db.user.upsert` (også ved ren innlogging) den manglende kolonnen → 500. Ikke admin-spesifikt; oppdaget via en admin-bruker.

## Løsning: allergier eies av TIHLDE (Lepton), ikke vår DB
- Fjerner `allergies` fra `User`-modellen, register-ruten og `RegisterInput`.
- Sletter `add_user_allergies`-migrasjonen (ble aldri kjørt i prod).
- Registreringsfeltet beholdes. `UserCreateSerializer` i Lepton tar ikke imot `allergy` ved signup, og kontoen er pending (ingen token), så verdien bufres i `localStorage` og synkes til TIHLDE-profilen når sesjonen har en ekte token:
  - `tihldeUpdateAllergy` → `PATCH /users/{id}/`
  - ny rute `POST /api/profile/allergy` (returnerer `synced:false` for pending kontoer)
  - `AllergySync`-klient i authenticated-layouten som rydder bufferen når synk lykkes.

## Prod-DB (allerede utført)
`add_payment` + `payment_phone_optional` er kjørt mot prod (`prisma migrate deploy`) — `Payment`-tabellen manglet også. `allergies` ble **ikke** lagt til i prod.

## Verifisert
- `npm run check` (eslint + tsc): 0 feil
- `npm run build`: OK
- Lokal smoke-test av `/api/auth/login`: 401 (ikke 500), ingen Prisma-feil
- Prod-DB matcher ny schema (`Payment` finnes, ingen `allergies`-kolonne)

## Merk
- Fiksen blir live først når dette deployes til `dev`.
- `tihldeUpdateAllergy` (PATCH mot Lepton) er ikke testet mot en ekte aktivert innlogging (krever token) — bør bekreftes etter deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)