### PR TITLE
fix(payment): hold Vipps Idempotency-Key innenfor 50-tegnsgrensen

### DIFF
--- a/src/server/payment/vipps.ts
+++ b/src/server/payment/vipps.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { createHash } from "crypto";
+
 import type { PaymentStatus } from "@prisma/client";
 
 import { env } from "~/env";
@@ -43,6 +45,21 @@ export function buildOrderId(userId: string): string {
 export function parseUserIdFromOrderId(orderId: string): string | null {
   const match = /^fadderuka-(.+)-\d+$/.exec(orderId);
   return match?.[1] ?? null;
+}
+
+/**
+ * Vipps caps the `Idempotency-Key` header at 50 chars. Our `orderId` is already
+ * ~49 (`fadderuka-<cuid>-<timestamp>`), so appending anything (e.g. `-capture`)
+ * overflows and Vipps rejects the request with 400. Derive a short, stable key
+ * from the orderId + operation instead — deterministic, so retries stay
+ * idempotent, and always ≤ 50 chars.
+ */
+function idempotencyKey(orderId: string, operation: string): string {
+  const digest = createHash("sha256")
+    .update(`${orderId}:${operation}`)
+    .digest("hex")
+    .slice(0, 40);
+  return `${operation}-${digest}`;
 }
 
 /** Narrowed view of the Vipps credentials once we've asserted they exist. */
@@ -132,7 +149,7 @@ export async function createPayment(
       "Content-Type": "application/json",
       "Ocp-Apim-Subscription-Key": cfg.subscriptionKey,
       "Merchant-Serial-Number": cfg.merchantSerialNumber,
-      "Idempotency-Key": orderId,
+      "Idempotency-Key": idempotencyKey(orderId, "create"),
     },
     body: JSON.stringify({
       amount: { currency: "NOK", value: PAYMENT_AMOUNT_ORE },
@@ -215,8 +232,9 @@ async function capture(
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": cfg.subscriptionKey,
         "Merchant-Serial-Number": cfg.merchantSerialNumber,
-        // A fixed key per order makes retries idempotent on Vipps' side.
-        "Idempotency-Key": `${orderId}-capture`,
+        // A fixed key per order makes retries idempotent on Vipps' side. Derived
+        // (not `${orderId}-capture`) so it stays within Vipps' 50-char cap.
+        "Idempotency-Key": idempotencyKey(orderId, "capture"),
       },
       body: JSON.stringify({
         modificationAmount: { currency: "NOK", value: PAYMENT_AMOUNT_ORE },


### PR DESCRIPTION
## Problem
Bruker betalte, ble trukket i Vipps-appen, men fikk «Betalingen kunne ikke bekreftes: Kunne ikke trekke betalingen i Vipps», og betalingsvinduet ble stående («Ingen betaling funnet»).

Vercel runtime-loggen viste at Vipps avviste hver **capture** med 400:
```
"Idempotency-Key must have a maximum length of '50'"
POST /v1/payments/fadderuka-<cuid>-<timestamp>/capture
```

Capture brukte `Idempotency-Key: ${orderId}-capture`. `orderId` (`fadderuka-<cuid>-<timestamp>`) er allerede ~49 tegn, så `-capture` ga 57 → over Vipps' grense på 50. `createPayment` slapp unna fordi den brukte bare `orderId` (49). Resultat: betalingen ble **reservert (AUTHORIZED)** men aldri **captured**, så `hasPaid` ble aldri satt.

## Fiks
Utleder en kort, deterministisk `Idempotency-Key` (`<operasjon>-<sha256(orderId+operasjon) first 40 hex>`, ≤ 48 tegn) for både `create` og `capture`. Deterministisk → retries forblir idempotente hos Vipps.

## Effekt på eksisterende betalinger
Ingen penger tapt: reserverte (AUTHORIZED) betalinger fanges opp neste gang `settlePayment` kjører — via Vipps-webhooken eller «Jeg har allerede betalt» (`checkMyPayment`) — som nå captures riktig.

## Verifisert
- `npm run check` (eslint + tsc): 0 feil
- `npm run build`: OK
- Nøkkellengde-assert: create=47, capture=48 (begge ≤ 50)

## Merk
Selve capture-kallet mot Vipps' API kunne ikke kjøres herfra (krever prod-credentials + en reell AUTHORIZED betaling). Bør bekreftes mot Vercel-loggen etter deploy at capture returnerer 200 og at brukeren blir markert betalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)