### PR TITLE
Vis betalers navn i Vipps-portalen

### DIFF
--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -6,6 +6,7 @@ import {
   VippsError,
   VippsNotConfiguredError,
   buildOrderId,
+  buildPaymentDescription,
   createPayment,
   parseUserIdFromOrderId,
   settlePayment,
@@ -45,7 +46,7 @@ export const paymentRouter = createTRPCRouter({
   initiatePayment: protectedProcedure.mutation(async ({ ctx }) => {
     const user = await ctx.db.user.findUnique({
       where: { id: ctx.session.user.id },
-      select: { hasPaid: true },
+      select: { hasPaid: true, name: true },
     });
 
     if (!user) {
@@ -62,7 +63,10 @@ export const paymentRouter = createTRPCRouter({
     const orderId = buildOrderId(ctx.session.user.id);
 
     try {
-      const payment = await createPayment(orderId);
+      // Payer's name in the description so the Vipps portal shows who paid.
+      const payment = await createPayment(orderId, {
+        paymentDescription: buildPaymentDescription({ name: user.name }),
+      });
 
       // Persist the order so the callback and webhook can settle it, and so
       // "Jeg har allerede betalt" can re-check this user's own payments.

--- a/src/server/payment/vipps.ts
+++ b/src/server/payment/vipps.ts
@@ -123,17 +123,44 @@ async function getAccessToken(cfg: VippsConfig): Promise<string> {
   return data.access_token;
 }
 
+/** Vipps caps `paymentDescription` at 100 characters. */
+const PAYMENT_DESCRIPTION_MAX = 100;
+
+/** Event label appended after the payer's name in the portal description. */
+const EVENT_LABEL = "Fadderuka";
+
+/** Default text shown in the Vipps portal when we have no payer name. */
+const DEFAULT_PAYMENT_DESCRIPTION = `${EVENT_LABEL} - TIHLDE`;
+
+/**
+ * Build the `paymentDescription` shown against a transaction in the Vipps
+ * merchant portal. Leading with the payer's name is what lets an admin see
+ * *who* paid — the portal otherwise only shows a generic label. Mirrors the
+ * "Navn - Arrangement" format TIHLDE uses for other events.
+ */
+export function buildPaymentDescription(payer?: {
+  name?: string | null;
+}): string {
+  const name = payer?.name?.trim();
+  if (!name) return DEFAULT_PAYMENT_DESCRIPTION;
+  return `${name} - ${EVENT_LABEL}`.slice(0, PAYMENT_DESCRIPTION_MAX);
+}
+
 /**
  * Create a WALLET payment and return the URL to redirect the user to.
  *
  * `phoneNumber` is optional: with the `WEB_REDIRECT` flow Vipps collects the
  * number on its own checkout page, so registration doesn't need to ask for it.
  * When we do have one (e.g. a prefilled retry) we pass it to skip that step.
+ *
+ * `paymentDescription` is what appears against the transaction in the Vipps
+ * portal — pass the payer's details so admins can tell who paid.
  */
 export async function createPayment(
   orderId: string,
-  phoneNumber?: string,
+  opts: { phoneNumber?: string; paymentDescription?: string } = {},
 ): Promise<{ redirectUrl: string }> {
+  const { phoneNumber, paymentDescription } = opts;
   const cfg = requireConfig();
 
   if (!env.VIPPS_CALLBACK_URL) {
@@ -162,7 +189,7 @@ export async function createPayment(
       reference: orderId,
       returnUrl: `${env.VIPPS_CALLBACK_URL}/payment/callback?orderId=${orderId}`,
       userFlow: "WEB_REDIRECT",
-      paymentDescription: "Fadderuka - TIHLDE",
+      paymentDescription: paymentDescription ?? DEFAULT_PAYMENT_DESCRIPTION,
     }),
   });
 


### PR DESCRIPTION
## Hva

I Vipps-portalen (portal.vippsmobilepay.com) sto det ikke hvem som hadde betalt — alle transaksjoner hadde den faste teksten `Fadderuka - TIHLDE`.

Nå bygges `paymentDescription` med betalers navn i formatet **`<navn> - Fadderuka`**, samme `Navn - Arrangement`-format TIHLDE bruker for andre arrangement (f.eks. «Josefine Arntsen - Utmatrikuleringsball 2026»).

## Detaljer

- `buildPaymentDescription({ name })` i `src/server/payment/vipps.ts` — navn først, så `Fadderuka`. Faller tilbake til `Fadderuka - TIHLDE` når navn mangler. Kappes til Vipps' 100-tegnsgrense.
- `initiatePayment` henter `name` og sender beskrivelsen inn.

Gjelder kun **nye** betalinger — eksisterende transaksjoner beholder gammel tekst.

## Verifisert

`tsc --noEmit` og `next build` grønt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)