### PR TITLE
Overfør Photon (kvark) sitt flate design til Fadderuka

### DIFF
--- a/src/app/(authenticated)/components/countdown.tsx
+++ b/src/app/(authenticated)/components/countdown.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import ActivityModal, {
+  type ModalActivity,
+} from "~/components/ui/activity-modal";
 import { Reveal } from "~/components/ui/reveal";
 
 function getRemaining(target: Date) {
@@ -14,16 +17,12 @@ function getRemaining(target: Date) {
   };
 }
 
-export default function Countdown({
-  title,
-  target,
-}: {
-  title: string;
-  target: Date;
-}) {
+export default function Countdown({ activity }: { activity: ModalActivity }) {
+  const target = activity.date;
   const [remaining, setRemaining] = useState<ReturnType<
     typeof getRemaining
   > | null>(null);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     setRemaining(getRemaining(target));
@@ -43,17 +42,28 @@ export default function Countdown({
   return (
     <Reveal className="max-w-page mx-auto w-full px-4 pt-10 text-center md:px-6">
       <p className="text-muted-foreground text-xs font-medium tracking-[0.18em] uppercase">
-        {remaining?.done
-          ? "Aktiviteten har startet"
-          : `Neste happening — ${title}`}
+        {remaining?.done ? (
+          "Aktiviteten har startet"
+        ) : (
+          <>
+            Neste happening —{" "}
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              className="hover:text-foreground underline underline-offset-4 transition-colors"
+            >
+              {activity.title}
+            </button>
+          </>
+        )}
       </p>
       <div className="mt-5 flex items-stretch justify-center gap-2.5 sm:gap-4">
         {units.map((unit) => (
           <div
             key={unit.label}
-            className="bg-card ring-foreground/10 flex min-w-[68px] flex-col items-center gap-1 rounded-2xl px-3 py-4 ring-1 shadow-[inset_0_1px_0_hsl(var(--foreground)/0.06)] sm:min-w-[92px] sm:px-5"
+            className="bg-card ring-foreground/10 flex min-w-[68px] flex-col items-center gap-1 rounded-2xl px-3 py-4 shadow-[inset_0_1px_0_hsl(var(--foreground)/0.06)] ring-1 sm:min-w-[92px] sm:px-5"
           >
-            <span className="font-heading text-foreground text-4xl font-semibold tabular-nums tracking-tight sm:text-5xl md:text-6xl">
+            <span className="font-heading text-foreground text-4xl font-semibold tracking-tight tabular-nums sm:text-5xl md:text-6xl">
               {String(unit.value ?? 0).padStart(2, "0")}
             </span>
             <span className="text-muted-foreground text-[10px] font-medium tracking-[0.15em] uppercase sm:text-xs">
@@ -62,6 +72,10 @@ export default function Countdown({
           </div>
         ))}
       </div>
+      <ActivityModal
+        activity={open ? activity : null}
+        onClose={() => setOpen(false)}
+      />
     </Reveal>
   );
 }

--- a/src/app/(authenticated)/components/hero.tsx
+++ b/src/app/(authenticated)/components/hero.tsx
@@ -11,7 +11,9 @@ export default function Hero() {
 
       <div className="max-w-page mx-auto w-full px-4 pt-10 pb-10 md:px-6">
         <Reveal className="mx-auto flex max-w-2xl flex-col items-center gap-5 text-center">
-          <h1 className="font-heading text-foreground text-4xl font-semibold tracking-tight text-balance sm:text-5xl md:text-6xl">
+          {/* Fluid size + `nowrap`: the title always sits on one line, shrinking
+              to fit narrow screens instead of wrapping. */}
+          <h1 className="font-heading text-foreground text-[clamp(1.25rem,6.2vw,3.5rem)] font-semibold tracking-tight whitespace-nowrap">
             Velkommen til fadderuka
           </h1>
 

--- a/src/app/(authenticated)/page.tsx
+++ b/src/app/(authenticated)/page.tsx
@@ -35,9 +35,7 @@ export default async function Home() {
       <Hero />
 
       <div className="mt-auto">
-        {upcoming[0] ? (
-          <Countdown title={upcoming[0].title} target={upcoming[0].date} />
-        ) : null}
+        {events[0] ? <Countdown activity={events[0]} /> : null}
 
         <Reveal className="max-w-page mx-auto flex w-full items-end justify-between px-4 pt-10 md:px-6">
           <h2 className="font-heading text-foreground text-2xl font-semibold tracking-tight">

--- a/src/components/ui/activity-modal.tsx
+++ b/src/components/ui/activity-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { MapPin, X } from "lucide-react";
 
 import Markdown from "~/components/ui/markdown";
@@ -21,6 +22,13 @@ export default function ActivityModal({
   activity: ModalActivity | null;
   onClose: () => void;
 }) {
+  // Rendered into `document.body` via a portal: an ancestor with a transform,
+  // filter or `will-change` (e.g. the `Reveal` wrappers the lists sit inside)
+  // becomes the containing block for `position: fixed`, which offsets the modal
+  // and shrinks its backdrop so clicks outside it stop closing.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   useEffect(() => {
     if (!activity) return;
 
@@ -36,7 +44,7 @@ export default function ActivityModal({
     };
   }, [activity, onClose]);
 
-  if (!activity) return null;
+  if (!activity || !mounted) return null;
 
   const date = new Date(activity.date);
   const dateStr = date.toLocaleDateString("no-NO", {
@@ -50,13 +58,13 @@ export default function ActivityModal({
     minute: "2-digit",
   });
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 supports-[backdrop-filter]:backdrop-blur-xs animate-in fade-in-0 duration-100 ease-out"
       onClick={onClose}
     >
       <div
-        className="relative flex h-[92vh] w-full max-w-4xl flex-col overflow-y-auto rounded-xl bg-popover text-popover-foreground ring-1 ring-foreground/10 animate-in fade-in-0 zoom-in-95 duration-100"
+        className="relative flex max-h-[92vh] w-full max-w-4xl flex-col overflow-y-auto rounded-xl bg-popover text-popover-foreground ring-1 ring-foreground/10 animate-in fade-in-0 zoom-in-95 duration-100"
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -114,6 +122,7 @@ export default function ActivityModal({
           </Markdown>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Hva

Overfører Photon (appen `kvark`) sitt flate, minimalistiske design-språk til hele Fadderuka — **med Fadderukas blå fargepalett bevart** (utenom fargene, som ønsket).

Photon bygger på Base UI, Fadderuka på Radix, så komponentfiler er ikke kopiert 1:1 — design-*idiomene* (radier, ring-elevasjon, trykk-effekt, fokusringer, kompakte høyder, footer-barer) er overført til Fadderukas eksisterende komponenter.

## Endringer

**Token/CSS-lag** (`globals.css`, `tailwind.config.ts`)
- `--radius` → 0.625rem, utvidet radius-skala (`2xl`–`4xl`), `font-heading`-alias
- Nøytraliserte alle atmosfære-tokens (`--page-gradient`, `--surface-*`, `--card-sheen`, glød) til flate, tema-baserte verdier → ~15 sider ble flate automatisk
- Slettet død `src/styles/globals.css`

**Delte primitiver** (button, card, input, dropdown, popover, drawer, tabs, activity-modal, activity-card, game-card, header-link, toast)
- Hårtynn `ring-1 ring-foreground/10`-elevasjon i stedet for skygger/glød/sheen
- `rounded-lg` kontroller / `rounded-xl` kort, 3px fokusringer, `active:translate-y-px` trykk, kompakte `h-8`, tonet destructive-variant

**Layout** — glass sticky header, flat token-basert footer, Photon nav-hover

**Bespoke sider** — fjernet gradient-hero, hardkodede hex-blåtoner (`#73aac4`, `#02376E` m.fl.), gradient-overskrifter og alle dekorative radial-glow-divs på tvers av admin/faddergruppe/aktiviteter/drikkeleker

**Header** — viser profilbilde (avatar) når innlogget, bruker-ikon som fallback for gjester

## Verifisering

- ✅ `tsc --noEmit` rent
- ✅ `eslint .` — 0 feil (kun forhåndseksisterende `<img>`-advarsler)
- ✅ `next build` — alle 18 ruter bygget
- ✅ Visuelt bekreftet i browser (dev-server), både mørk og lys modus: flat design, hårtynn ring-kort, glass-header, `rounded-lg` inputs, bevart blå primærfarge
- ⚠️ Innlogget avatar-visning er typechecket + kodegjennomgått, men ikke drevet i browser (ingen aktiv sesjon i preview) — bør bekreftes visuelt ved pålogging

🤖 Generated with [Claude Code](https://claude.com/claude-code)