### PR TITLE
feat(admin): samlet betalings- og påmeldingsoversikt

### DIFF
--- a/prisma/migrations/20260719120000_payment_captured_at/migration.sql
+++ b/prisma/migrations/20260719120000_payment_captured_at/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "Payment" ADD COLUMN "capturedAt" TIMESTAMP(3);
+
+-- Backfill: `updatedAt` was written by settlePayment in the same moment the
+-- capture succeeded, so it is an accurate capture time for existing rows.
+-- Exact timestamps from the Vipps portal can be layered on afterwards via
+-- scripts/backfill-captured-at.ts.
+UPDATE "Payment"
+SET "capturedAt" = "updatedAt"
+WHERE "status" = 'CAPTURED' AND "capturedAt" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,6 +134,10 @@ model Payment {
     phone     String? // set only if we prefilled a number; Vipps collects it otherwise
     amount    Int // amount in øre
     status    PaymentStatus @default(CREATED)
+    // When the money was actually captured. Distinct from `updatedAt`, which any
+    // later status write would move: this is what the admin overview reports as
+    // the payment time, so it must stay pinned to the capture itself.
+    capturedAt DateTime?
     createdAt DateTime      @default(now())
     updatedAt DateTime      @updatedAt
     userId    String

--- a/scripts/backfill-captured-at.ts
+++ b/scripts/backfill-captured-at.ts
@@ -1,0 +1,172 @@
+/**
+ * One-off backfill of `Payment.capturedAt` from a Vipps portal export.
+ *
+ * The migration seeds `capturedAt` from `updatedAt`, which is accurate for every
+ * payment that went through this app. This script is for correcting those rows
+ * against the exact timestamps Vipps reports — export the transaction list from
+ * the Vipps merchant portal and feed it in.
+ *
+ * Usage:
+ *   bun run scripts/backfill-captured-at.ts <fil.csv> [--dry]
+ *
+ * The CSV needs a header row containing a reference column and a timestamp
+ * column; common Vipps/Excel header spellings are recognised (see COLUMN_ALIASES).
+ * Separator is auto-detected (";" or ","). Rows whose reference is unknown are
+ * reported and skipped — nothing is created, only existing orders are updated.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { PrismaClient } from "@prisma/client";
+
+const db = new PrismaClient();
+
+const COLUMN_ALIASES = {
+  reference: ["reference", "referanse", "orderid", "ordre-id", "ordreid"],
+  timestamp: [
+    "timestamp",
+    "tidspunkt",
+    "dato",
+    "date",
+    "capturedat",
+    "captured",
+    "betalt",
+  ],
+};
+
+/** Strip quotes/BOM and normalise a header cell for alias matching. */
+function normaliseHeader(cell: string): string {
+  return cell
+    .replace(/^﻿/, "")
+    .replace(/^"|"$/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]/g, "");
+}
+
+function splitLine(line: string, separator: string): string[] {
+  // Vipps exports quote fields containing the separator; handle that minimally.
+  const cells: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === separator && !inQuotes) {
+      cells.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  cells.push(current);
+  return cells.map((c) => c.trim());
+}
+
+function findColumn(headers: string[], aliases: string[]): number {
+  return headers.findIndex((h) => aliases.includes(h));
+}
+
+async function main() {
+  const [file, ...flags] = process.argv.slice(2);
+  const dryRun = flags.includes("--dry");
+
+  if (!file) {
+    console.error(
+      "Bruk: bun run scripts/backfill-captured-at.ts <fil.csv> [--dry]",
+    );
+    process.exit(1);
+  }
+
+  const raw = readFileSync(file, "utf8");
+  const lines = raw.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  const headerLine = lines[0];
+
+  if (!headerLine) {
+    console.error("Tom fil.");
+    process.exit(1);
+  }
+
+  const separator = headerLine.includes(";") ? ";" : ",";
+  const headers = splitLine(headerLine, separator).map(normaliseHeader);
+
+  const refIndex = findColumn(headers, COLUMN_ALIASES.reference);
+  const timeIndex = findColumn(headers, COLUMN_ALIASES.timestamp);
+
+  if (refIndex === -1 || timeIndex === -1) {
+    console.error(
+      `Fant ikke nødvendige kolonner. Header var: ${headers.join(", ")}`,
+    );
+    console.error(
+      `Trenger én av [${COLUMN_ALIASES.reference.join(", ")}] og én av [${COLUMN_ALIASES.timestamp.join(", ")}]`,
+    );
+    process.exit(1);
+  }
+
+  let updated = 0;
+  let unchanged = 0;
+  const missing: string[] = [];
+  const badDates: string[] = [];
+
+  for (const line of lines.slice(1)) {
+    const cells = splitLine(line, separator);
+    const orderId = cells[refIndex]?.replace(/^"|"$/g, "").trim();
+    const rawDate = cells[timeIndex]?.replace(/^"|"$/g, "").trim();
+
+    if (!orderId || !rawDate) continue;
+
+    const capturedAt = new Date(rawDate);
+    if (Number.isNaN(capturedAt.getTime())) {
+      badDates.push(`${orderId}: "${rawDate}"`);
+      continue;
+    }
+
+    const existing = await db.payment.findUnique({
+      where: { orderId },
+      select: { capturedAt: true },
+    });
+
+    if (!existing) {
+      missing.push(orderId);
+      continue;
+    }
+
+    if (existing.capturedAt?.getTime() === capturedAt.getTime()) {
+      unchanged += 1;
+      continue;
+    }
+
+    if (!dryRun) {
+      await db.payment.update({ where: { orderId }, data: { capturedAt } });
+    }
+    updated += 1;
+    console.log(
+      `${dryRun ? "[dry] " : ""}${orderId} -> ${capturedAt.toISOString()}`,
+    );
+  }
+
+  console.log(
+    `\nFerdig. Oppdatert: ${updated}, allerede riktig: ${unchanged}, ukjent referanse: ${missing.length}, ugyldig dato: ${badDates.length}`,
+  );
+  if (missing.length > 0) {
+    console.log("Ukjente referanser:", missing.join(", "));
+  }
+  if (badDates.length > 0) {
+    console.log("Ugyldige datoer:", badDates.join(", "));
+  }
+  if (dryRun) console.log("(Tørrkjøring – ingenting ble skrevet)");
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => void db.$disconnect());

--- a/src/app/(authenticated)/admin/admin-panel.tsx
+++ b/src/app/(authenticated)/admin/admin-panel.tsx
@@ -4,11 +4,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { UsersTab } from "./users-tab";
 import { GrupperTab } from "./grupper-tab";
 import { AktiviteterTab } from "./aktiviteter-tab";
+import { BetalingerTab } from "./betalinger-tab";
 
 export function AdminPanel() {
   return (
     <Tabs defaultValue="users" className="w-full">
-      <TabsList className="grid w-full max-w-lg grid-cols-3 bg-secondary border border-border">
+      <TabsList className="grid w-full max-w-2xl grid-cols-4 bg-secondary border border-border">
         <TabsTrigger
           value="users"
           className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground text-muted-foreground"
@@ -27,6 +28,12 @@ export function AdminPanel() {
         >
           Aktiviteter
         </TabsTrigger>
+        <TabsTrigger
+          value="betalinger"
+          className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground text-muted-foreground"
+        >
+          Betalinger
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="users" className="!mt-6">
@@ -39,6 +46,10 @@ export function AdminPanel() {
 
       <TabsContent value="aktiviteter" className="!mt-6">
         <AktiviteterTab />
+      </TabsContent>
+
+      <TabsContent value="betalinger" className="!mt-6">
+        <BetalingerTab />
       </TabsContent>
     </Tabs>
   );

--- a/src/app/(authenticated)/admin/betalinger-tab.tsx
+++ b/src/app/(authenticated)/admin/betalinger-tab.tsx
@@ -1,0 +1,604 @@
+"use client";
+
+import { ArrowDown, ArrowUp, Download, RefreshCw } from "lucide-react";
+import { Fragment, useMemo, useState } from "react";
+import { api, type RouterOutputs } from "~/trpc/react";
+import { toast } from "~/components/ui/use-toast";
+import { downloadCsv, toCsv, toDateAndTime, type CsvColumn } from "~/lib/csv";
+
+type Registration = RouterOutputs["admin"]["getRegistrations"][number];
+
+type Filter = "alle" | "betalt" | "ubetalt" | "uten-gruppe";
+type SortKey = "navn" | "registrert" | "betalt" | "status" | "gruppe";
+type SortDir = "asc" | "desc";
+
+/** Statuses that mean the user started paying but never completed it. */
+const IN_PROGRESS_STATUSES = ["CREATED", "AUTHORIZED"] as const;
+
+const STATUS_LABELS: Record<string, string> = {
+  CREATED: "Påbegynt",
+  AUTHORIZED: "Reservert",
+  CAPTURED: "Betalt",
+  ABORTED: "Avbrutt",
+  EXPIRED: "Utløpt",
+  TERMINATED: "Terminert",
+  FAILED: "Feilet",
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  CAPTURED: "bg-emerald-500/15 text-emerald-400",
+  AUTHORIZED: "bg-sky-500/15 text-sky-400",
+  CREATED: "bg-amber-500/15 text-amber-400",
+};
+
+const FILTERS: { value: Filter; label: string }[] = [
+  { value: "alle", label: "Alle" },
+  { value: "betalt", label: "Betalt" },
+  { value: "ubetalt", label: "Ikke betalt" },
+  { value: "uten-gruppe", label: "Uten faddergruppe" },
+];
+
+/** Format øre as Norwegian kroner, e.g. 38000 → "380 kr". */
+function kr(ore: number): string {
+  return `${(ore / 100).toLocaleString("no-NO")} kr`;
+}
+
+function formatDateTime(value: Date | string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("no-NO", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * A user can be marked paid without a captured Vipps order — older records and
+ * anyone settled outside the app. Saying "Ikke startet" for them would be wrong,
+ * so flag the distinction instead of hiding it.
+ */
+function statusLabel(status: string | null, hasPaid: boolean): string {
+  if (status === "CAPTURED") return STATUS_LABELS.CAPTURED!;
+  if (hasPaid) return "Betalt (utenfor Vipps)";
+  if (!status) return "Ikke startet";
+  return STATUS_LABELS[status] ?? status;
+}
+
+function StatusBadge({
+  status,
+  hasPaid,
+}: {
+  status: string | null;
+  hasPaid: boolean;
+}) {
+  if (hasPaid && status !== "CAPTURED") {
+    return (
+      <span className="rounded-full bg-emerald-500/10 !px-2.5 !py-0.5 text-xs font-semibold text-emerald-400/80">
+        {statusLabel(status, hasPaid)}
+      </span>
+    );
+  }
+
+  if (!status) {
+    return <span className="text-muted-foreground">Ikke startet</span>;
+  }
+  return (
+    <span
+      className={`rounded-full !px-2.5 !py-0.5 text-xs font-semibold ${
+        STATUS_STYLES[status] ?? "bg-red-500/15 text-red-400"
+      }`}
+    >
+      {STATUS_LABELS[status] ?? status}
+    </span>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card !p-4">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className="!mt-1 text-2xl font-semibold text-foreground">{value}</p>
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+/** Live Vipps status + event timeline for one order, fetched on expand. */
+function PaymentDetails({ orderId }: { orderId: string }) {
+  const { data, isLoading, error } = api.admin.getPaymentDetails.useQuery(
+    { orderId },
+    { retry: false },
+  );
+
+  if (isLoading) {
+    return (
+      <p className="text-sm text-muted-foreground">Henter fra Vipps...</p>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-400">{error.message}</p>;
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="!space-y-3">
+      <div className="flex flex-wrap !gap-x-6 !gap-y-1 text-sm">
+        <span className="text-muted-foreground">
+          Status i Vipps:{" "}
+          <span className="font-medium text-foreground">
+            {data.snapshot.state}
+          </span>
+        </span>
+        <span className="text-muted-foreground">
+          Reservert:{" "}
+          <span className="font-medium text-foreground">
+            {kr(data.snapshot.authorized)}
+          </span>
+        </span>
+        <span className="text-muted-foreground">
+          Trukket:{" "}
+          <span className="font-medium text-foreground">
+            {kr(data.snapshot.captured)}
+          </span>
+        </span>
+        {data.snapshot.refunded > 0 && (
+          <span className="text-muted-foreground">
+            Refundert:{" "}
+            <span className="font-medium text-foreground">
+              {kr(data.snapshot.refunded)}
+            </span>
+          </span>
+        )}
+      </div>
+
+      <div className="!space-y-1">
+        <p className="text-xs font-semibold text-muted-foreground">
+          Hendelseslogg
+        </p>
+        {data.events.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Ingen hendelser</p>
+        ) : (
+          <ul className="!space-y-1">
+            {data.events.map((event, i) => (
+              <li
+                key={`${event.action}-${event.timestamp ?? i}`}
+                className="flex flex-wrap items-center !gap-2 text-sm"
+              >
+                <span
+                  className={`font-medium ${
+                    event.success ? "text-foreground" : "text-red-400"
+                  }`}
+                >
+                  {STATUS_LABELS[event.action] ?? event.action}
+                </span>
+                {event.amount != null && (
+                  <span className="text-muted-foreground">
+                    {kr(event.amount)}
+                  </span>
+                )}
+                <span className="text-muted-foreground">
+                  {formatDateTime(event.timestamp)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function BetalingerTab() {
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<Filter>("alle");
+  const [sortKey, setSortKey] = useState<SortKey>("registrert");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const utils = api.useUtils();
+  const { data: registrations, isLoading } =
+    api.admin.getRegistrations.useQuery();
+  const { data: price } = api.admin.getPaymentAmount.useQuery();
+
+  const syncMutation = api.admin.syncPayments.useMutation({
+    onSuccess: (result) => {
+      void utils.admin.getRegistrations.invalidate();
+      void utils.admin.getUsers.invalidate();
+      toast({
+        title: "Synkronisert mot Vipps",
+        description: `${result.checked} ordre sjekket, ${result.settled} ble bekreftet betalt${
+          result.failed > 0 ? `, ${result.failed} feilet` : ""
+        }.`,
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Synk feilet",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const rows = useMemo(() => registrations ?? [], [registrations]);
+
+  const stats = useMemo(() => {
+    const paid = rows.filter((r) => r.hasPaid);
+    const unpaid = rows.filter((r) => !r.hasPaid);
+    const inProgress = unpaid.filter(
+      (r) =>
+        r.paymentStatus !== null &&
+        (IN_PROGRESS_STATUSES as readonly string[]).includes(r.paymentStatus),
+    );
+    const collected = paid.reduce((sum, r) => sum + r.amountPaid, 0);
+    const amountOre = price?.amountOre ?? 0;
+
+    return {
+      total: rows.length,
+      paid: paid.length,
+      unpaid: unpaid.length,
+      inProgress: inProgress.length,
+      withoutGroup: rows.filter((r) => !r.gruppe).length,
+      collected,
+      // Only Vipps-captured orders contribute to `collected`, so say how many
+      // that is — the paid count can be higher for users settled elsewhere.
+      collectedCount: paid.filter((r) => r.paymentStatus === "CAPTURED").length,
+      outstanding: unpaid.length * amountOre,
+    };
+  }, [rows, price]);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+
+    const matchesFilter = (r: Registration) => {
+      if (filter === "betalt") return r.hasPaid;
+      if (filter === "ubetalt") return !r.hasPaid;
+      if (filter === "uten-gruppe") return !r.gruppe;
+      return true;
+    };
+
+    const matchesSearch = (r: Registration) =>
+      !query ||
+      r.name.toLowerCase().includes(query) ||
+      (r.email?.toLowerCase().includes(query) ?? false) ||
+      (r.orderId?.toLowerCase().includes(query) ?? false);
+
+    const result = rows.filter((r) => matchesFilter(r) && matchesSearch(r));
+
+    const compare = (a: Registration, b: Registration) => {
+      switch (sortKey) {
+        case "navn":
+          return a.name.localeCompare(b.name, "no");
+        case "gruppe":
+          return (a.gruppe ?? "").localeCompare(b.gruppe ?? "", "no");
+        case "status":
+          // Paid first when ascending; unpaid users have no meaningful date.
+          return Number(a.hasPaid) - Number(b.hasPaid);
+        case "betalt":
+          return (
+            (a.paidAt ? new Date(a.paidAt).getTime() : 0) -
+            (b.paidAt ? new Date(b.paidAt).getTime() : 0)
+          );
+        case "registrert":
+        default:
+          return (
+            new Date(a.registeredAt).getTime() -
+            new Date(b.registeredAt).getTime()
+          );
+      }
+    };
+
+    return [...result].sort((a, b) =>
+      sortDir === "asc" ? compare(a, b) : compare(b, a),
+    );
+  }, [rows, search, filter, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "navn" || key === "gruppe" ? "asc" : "desc");
+    }
+  };
+
+  const exportCsv = (data: Registration[], suffix: string) => {
+    const columns: CsvColumn<Registration>[] = [
+      { header: "Navn", value: (r) => r.name },
+      { header: "E-post", value: (r) => r.email },
+      { header: "Klasse", value: (r) => r.klasse },
+      { header: "Studieretning", value: (r) => r.studieretning },
+      { header: "Faddergruppe", value: (r) => r.gruppe },
+      {
+        header: "Rolle",
+        value: (r) =>
+          r.rolle === "FADDER"
+            ? "Fadder"
+            : r.rolle === "FADDERBARN"
+              ? "Fadderbarn"
+              : "",
+      },
+      { header: "Verifisert", value: (r) => (r.isVerified ? "Ja" : "Nei") },
+      { header: "Betalt", value: (r) => (r.hasPaid ? "Ja" : "Nei") },
+      {
+        header: "Betalingsstatus",
+        value: (r) => statusLabel(r.paymentStatus, r.hasPaid),
+      },
+      { header: "Beløp (kr)", value: (r) => r.amountPaid / 100 },
+      { header: "Påmeldt dato", value: (r) => toDateAndTime(r.registeredAt).date },
+      { header: "Påmeldt tid", value: (r) => toDateAndTime(r.registeredAt).time },
+      { header: "Betalt dato", value: (r) => toDateAndTime(r.paidAt).date },
+      { header: "Betalt tid", value: (r) => toDateAndTime(r.paidAt).time },
+      { header: "Vipps-referanse", value: (r) => r.orderId },
+    ];
+
+    const today = toDateAndTime(new Date()).date;
+    downloadCsv(
+      `fadderuka-pameldte-${suffix}-${today}.csv`,
+      toCsv(data, columns),
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center !py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-transparent" />
+      </div>
+    );
+  }
+
+  const unpaidRows = rows.filter((r) => !r.hasPaid);
+
+  const sortIndicator = (key: SortKey) =>
+    sortKey === key ? (
+      sortDir === "asc" ? (
+        <ArrowUp className="inline h-3 w-3" />
+      ) : (
+        <ArrowDown className="inline h-3 w-3" />
+      )
+    ) : null;
+
+  const sortableHeader = (key: SortKey, label: string) => (
+    <th className="!px-4 !py-3 font-medium">
+      <button
+        type="button"
+        onClick={() => toggleSort(key)}
+        className="inline-flex items-center !gap-1 transition hover:text-foreground"
+      >
+        {label}
+        {sortIndicator(key)}
+      </button>
+    </th>
+  );
+
+  return (
+    <div className="!space-y-8">
+      {/* Key figures — enough to follow sign-ups and the budget at a glance */}
+      <section className="grid grid-cols-2 !gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <StatCard label="Påmeldte" value={String(stats.total)} />
+        <StatCard label="Betalt" value={String(stats.paid)} />
+        <StatCard
+          label="Ikke betalt"
+          value={String(stats.unpaid)}
+          hint={`${stats.inProgress} påbegynt`}
+        />
+        <StatCard label="Uten gruppe" value={String(stats.withoutGroup)} />
+        <StatCard
+          label="Innbetalt"
+          value={kr(stats.collected)}
+          hint={`${stats.collectedCount} via Vipps`}
+        />
+        <StatCard
+          label="Utestående"
+          value={kr(stats.outstanding)}
+          hint="Hvis alle betaler"
+        />
+      </section>
+
+      {/* Actions */}
+      <section className="flex flex-wrap !gap-2">
+        <button
+          type="button"
+          onClick={() => syncMutation.mutate()}
+          disabled={syncMutation.isPending}
+          className="inline-flex items-center !gap-2 rounded-xl border border-border bg-secondary !px-4 !py-2 text-sm font-semibold text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${syncMutation.isPending ? "animate-spin" : ""}`}
+          />
+          {syncMutation.isPending ? "Synkroniserer..." : "Synk mot Vipps"}
+        </button>
+        <button
+          type="button"
+          onClick={() => exportCsv(filtered, "utvalg")}
+          className="inline-flex items-center !gap-2 rounded-xl border border-border bg-secondary !px-4 !py-2 text-sm font-semibold text-foreground transition hover:bg-secondary/80"
+        >
+          <Download className="h-4 w-4" />
+          Last ned CSV ({filtered.length})
+        </button>
+        {filtered.length !== rows.length && (
+          <button
+            type="button"
+            onClick={() => exportCsv(rows, "alle")}
+            className="inline-flex items-center !gap-2 rounded-xl !px-3 !py-2 text-sm text-muted-foreground transition hover:text-foreground"
+          >
+            Last ned alle ({rows.length})
+          </button>
+        )}
+      </section>
+
+      {/* Combined, flat overview — one row per registered user */}
+      <section className="!space-y-4">
+        <h3 className="text-lg font-semibold text-foreground">
+          Samlet oversikt ({filtered.length})
+        </h3>
+
+        <div className="flex flex-wrap items-center !gap-3">
+          <input
+            type="text"
+            placeholder="Søk navn, e-post eller referanse..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full max-w-sm rounded-xl border border-border bg-background !px-4 !py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+          />
+          <div className="flex flex-wrap !gap-2">
+            {FILTERS.map((f) => (
+              <button
+                key={f.value}
+                type="button"
+                onClick={() => setFilter(f.value)}
+                className={`rounded-full !px-3 !py-1.5 text-xs font-semibold transition ${
+                  filter === f.value
+                    ? "bg-primary text-primary-foreground"
+                    : "border border-border bg-secondary text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="overflow-x-auto rounded-xl border border-border bg-card">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-border text-muted-foreground">
+                {sortableHeader("navn", "Navn")}
+                <th className="!px-4 !py-3 font-medium">E-post</th>
+                <th className="!px-4 !py-3 font-medium">Klasse</th>
+                <th className="!px-4 !py-3 font-medium">Studieretning</th>
+                {sortableHeader("gruppe", "Faddergruppe")}
+                <th className="!px-4 !py-3 font-medium">Rolle</th>
+                {sortableHeader("status", "Betaling")}
+                <th className="!px-4 !py-3 font-medium">Beløp</th>
+                {sortableHeader("registrert", "Påmeldt")}
+                {sortableHeader("betalt", "Betalt")}
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((r) => (
+                <Fragment key={r.id}>
+                  <tr
+                    onClick={() =>
+                      setExpandedId(expandedId === r.id ? null : r.id)
+                    }
+                    className="cursor-pointer border-b border-border last:border-0 hover:bg-muted/50"
+                  >
+                    <td className="!px-4 !py-3 font-medium text-foreground">
+                      {r.name}
+                    </td>
+                    <td className="!px-4 !py-3 text-muted-foreground">
+                      {r.email ?? "—"}
+                    </td>
+                    <td className="!px-4 !py-3 text-muted-foreground">
+                      {r.klasse ?? "—"}
+                    </td>
+                    <td className="!px-4 !py-3 text-muted-foreground">
+                      {r.studieretning ?? "—"}
+                    </td>
+                    <td className="!px-4 !py-3 text-muted-foreground">
+                      {r.gruppe ?? "—"}
+                    </td>
+                    <td className="!px-4 !py-3 text-muted-foreground">
+                      {r.rolle === "FADDER"
+                        ? "Fadder"
+                        : r.rolle === "FADDERBARN"
+                          ? "Fadderbarn"
+                          : "—"}
+                    </td>
+                    <td className="!px-4 !py-3">
+                      <StatusBadge status={r.paymentStatus} hasPaid={r.hasPaid} />
+                    </td>
+                    <td className="!px-4 !py-3 text-muted-foreground">
+                      {r.amountPaid > 0 ? kr(r.amountPaid) : "—"}
+                    </td>
+                    <td className="!px-4 !py-3 whitespace-nowrap text-muted-foreground">
+                      {formatDateTime(r.registeredAt)}
+                    </td>
+                    <td className="!px-4 !py-3 whitespace-nowrap text-muted-foreground">
+                      {formatDateTime(r.paidAt)}
+                    </td>
+                  </tr>
+                  {expandedId === r.id && (
+                    <tr className="border-b border-border">
+                      <td colSpan={10} className="bg-muted/30 !px-4 !py-4">
+                        {r.orderId ? (
+                          <div className="!space-y-2">
+                            <p className="font-mono text-xs text-muted-foreground">
+                              {r.orderId}
+                              {r.attemptCount > 1 &&
+                                ` · ${r.attemptCount} betalingsforsøk`}
+                            </p>
+                            <PaymentDetails orderId={r.orderId} />
+                          </div>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">
+                            Brukeren har aldri startet en betaling i Vipps.
+                          </p>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={10}
+                    className="!px-4 !py-8 text-center text-muted-foreground"
+                  >
+                    Ingen påmeldte funnet
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Chase list — derived from the same dataset, no extra query */}
+      <section className="!space-y-4">
+        <h3 className="text-lg font-semibold text-foreground">
+          Har ikke betalt ({unpaidRows.length})
+        </h3>
+
+        {unpaidRows.length === 0 ? (
+          <p className="rounded-xl border border-border bg-card !px-4 !py-6 text-center text-sm text-muted-foreground">
+            Alle påmeldte har betalt
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 !gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {unpaidRows.map((r) => (
+              <div
+                key={r.id}
+                className="rounded-xl border border-amber-500/30 bg-amber-500/5 !p-4"
+              >
+                <p className="font-medium text-foreground">{r.name}</p>
+                <p className="text-sm text-muted-foreground">{r.email ?? "—"}</p>
+                <p className="!mt-1 text-xs text-muted-foreground">
+                  {r.klasse ?? "Ingen klasse"} · påmeldt{" "}
+                  {formatDateTime(r.registeredAt)}
+                </p>
+                <div className="!mt-2">
+                  <StatusBadge status={r.paymentStatus} hasPaid={r.hasPaid} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,78 @@
+/**
+ * Minimal CSV helpers for admin exports.
+ *
+ * Semicolon-separated with a UTF-8 BOM: that is what Norwegian Excel expects —
+ * a comma-separated file opens as a single column, and without the BOM æøå come
+ * out mojibake.
+ */
+
+const SEPARATOR = ";";
+const BOM = "﻿";
+
+/** A column: the header text plus how to read it off a row. */
+export interface CsvColumn<T> {
+  header: string;
+  value: (row: T) => string | number | null | undefined;
+}
+
+/** Quote a field if it could otherwise break the row, and escape inner quotes. */
+function escapeField(raw: string | number | null | undefined): string {
+  const value = raw == null ? "" : String(raw);
+  if (!/["\n\r;]/.test(value)) return value;
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+export function toCsv<T>(rows: T[], columns: CsvColumn<T>[]): string {
+  const lines = [
+    columns.map((c) => escapeField(c.header)).join(SEPARATOR),
+    ...rows.map((row) =>
+      columns.map((c) => escapeField(c.value(row))).join(SEPARATOR),
+    ),
+  ];
+  return lines.join("\r\n");
+}
+
+/** Trigger a browser download of `csv` as `filename`. Client-side only. */
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([BOM + csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Split a date into `YYYY-MM-DD` and `HH:mm` in Norwegian local time. Separate
+ * columns so the export can be sorted and pivoted directly in Excel, which
+ * doesn't reliably parse a combined Norwegian datetime string.
+ */
+export function toDateAndTime(date: Date | string | null | undefined): {
+  date: string;
+  time: string;
+} {
+  if (!date) return { date: "", time: "" };
+  const d = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(d.getTime())) return { date: "", time: "" };
+
+  const parts = new Intl.DateTimeFormat("no-NO", {
+    timeZone: "Europe/Oslo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+
+  return {
+    date: `${get("year")}-${get("month")}-${get("day")}`,
+    time: `${get("hour")}:${get("minute")}`,
+  };
+}

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -1,9 +1,34 @@
 import { TRPCError } from "@trpc/server";
+import type { PaymentStatus } from "@prisma/client";
 import { z } from "zod";
 import {
   adminProcedure,
   createTRPCRouter,
 } from "~/server/api/trpc";
+import {
+  PAYMENT_AMOUNT_ORE,
+  VippsError,
+  VippsNotConfiguredError,
+  fetchPaymentEvents,
+  fetchPaymentSnapshot,
+  settlePayment,
+} from "~/server/payment/vipps";
+
+/** Translate a Vipps-layer error into the tRPC error shown to the admin. */
+function toTRPCError(err: unknown): TRPCError {
+  if (err instanceof TRPCError) return err;
+  if (err instanceof VippsNotConfiguredError) {
+    return new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: err.message });
+  }
+  if (err instanceof VippsError) {
+    return new TRPCError({ code: "BAD_GATEWAY", message: err.message });
+  }
+  console.error("[admin] unexpected Vipps error", err);
+  return new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: "Noe gikk galt mot Vipps.",
+  });
+}
 
 export const adminRouter = createTRPCRouter({
   /** List all users with their verification/admin status and group memberships */
@@ -17,6 +42,7 @@ export const adminRouter = createTRPCRouter({
         studieretning: true,
         isVerified: true,
         isAdmin: true,
+        hasPaid: true,
         createdAt: true,
         memberships: {
           select: {
@@ -205,4 +231,137 @@ export const adminRouter = createTRPCRouter({
       }
       return { success: true };
     }),
+
+  /**
+   * The combined registration/payment overview: exactly one row per registered
+   * user, flat (not grouped by studieretning like `getUsers`). This is the
+   * single source for the admin table, the key figures and the CSV export, so
+   * the per-user payment facts are derived here rather than in the client.
+   */
+  getRegistrations: adminProcedure.query(async ({ ctx }) => {
+    const users = await ctx.db.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        klasse: true,
+        studieretning: true,
+        isVerified: true,
+        hasPaid: true,
+        createdAt: true,
+        memberships: {
+          select: { id: true, role: true, gruppe: { select: { id: true, name: true } } },
+        },
+        payments: {
+          select: {
+            orderId: true,
+            status: true,
+            amount: true,
+            createdAt: true,
+            capturedAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return users.map((user) => {
+      const captured = user.payments.filter((p) => p.status === "CAPTURED");
+
+      // A user can have several orders (abandoned attempts, retries). The
+      // captured one is what counts; otherwise report their most recent attempt.
+      const paidAt = captured.reduce<Date | null>((earliest, p) => {
+        if (!p.capturedAt) return earliest;
+        return !earliest || p.capturedAt < earliest ? p.capturedAt : earliest;
+      }, null);
+
+      const amountPaid = captured.reduce((sum, p) => sum + p.amount, 0);
+      const latest = user.payments[0];
+      const membership = user.memberships[0];
+
+      const paymentStatus: PaymentStatus | null =
+        captured.length > 0 ? "CAPTURED" : (latest?.status ?? null);
+
+      return {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        klasse: user.klasse,
+        studieretning: user.studieretning,
+        isVerified: user.isVerified,
+        hasPaid: user.hasPaid,
+        registeredAt: user.createdAt,
+        gruppe: membership?.gruppe.name ?? null,
+        rolle: membership?.role ?? null,
+        paymentStatus,
+        paidAt,
+        amountPaid,
+        orderId: captured[0]?.orderId ?? latest?.orderId ?? null,
+        attemptCount: user.payments.length,
+      };
+    });
+  }),
+
+  /** Raw Vipps orders (a user may have several), newest first. */
+  getPayments: adminProcedure.query(async ({ ctx }) => {
+    return ctx.db.payment.findMany({
+      select: {
+        id: true,
+        orderId: true,
+        status: true,
+        amount: true,
+        createdAt: true,
+        capturedAt: true,
+        user: { select: { id: true, name: true, email: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }),
+
+  /** Live status and event timeline for one order, straight from Vipps. */
+  getPaymentDetails: adminProcedure
+    .input(z.object({ orderId: z.string() }))
+    .query(async ({ input }) => {
+      try {
+        const [snapshot, events] = await Promise.all([
+          fetchPaymentSnapshot(input.orderId),
+          fetchPaymentEvents(input.orderId),
+        ]);
+        return { snapshot, events };
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Reconcile every unsettled order against Vipps. The webhook normally does
+   * this, so this is the manual catch-up for orders whose webhook never landed.
+   * One failing order must not abort the run — mirrors `payment.checkMyPayment`.
+   */
+  syncPayments: adminProcedure.mutation(async ({ ctx }) => {
+    const orders = await ctx.db.payment.findMany({
+      where: { status: { in: ["CREATED", "AUTHORIZED"] } },
+      select: { orderId: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    let settled = 0;
+    let failed = 0;
+
+    for (const order of orders) {
+      try {
+        const { paid } = await settlePayment(order.orderId);
+        if (paid) settled += 1;
+      } catch (err) {
+        failed += 1;
+        console.error("[admin] settle failed for", order.orderId, err);
+      }
+    }
+
+    return { checked: orders.length, settled, failed };
+  }),
+
+  /** Fadderuka price in øre, so the client doesn't hardcode the amount. */
+  getPaymentAmount: adminProcedure.query(() => ({ amountOre: PAYMENT_AMOUNT_ORE })),
 });

--- a/src/server/payment/vipps.ts
+++ b/src/server/payment/vipps.ts
@@ -298,6 +298,99 @@ function toStatus(payment: VippsPayment): PaymentStatus {
   }
 }
 
+/** A single entry from the Vipps payment event log, normalised for the admin UI. */
+export interface VippsPaymentEvent {
+  /** What happened: CREATED, AUTHORIZED, CAPTURED, ABORTED, … */
+  action: string;
+  /** Amount in øre this event applied to, when Vipps reports one. */
+  amount: number | null;
+  /** ISO timestamp of the event. */
+  timestamp: string | null;
+  success: boolean;
+}
+
+/** Live view of a payment, straight from Vipps. */
+export interface VippsPaymentSnapshot {
+  state: VippsPayment["state"];
+  /** Amounts in øre. */
+  authorized: number;
+  captured: number;
+  refunded: number;
+  cancelled: number;
+}
+
+/**
+ * Read a payment's current state from Vipps. Vipps — not our database — is the
+ * source of truth, so this is what the admin detail view shows when an order
+ * looks wrong locally.
+ */
+export async function fetchPaymentSnapshot(
+  orderId: string,
+): Promise<VippsPaymentSnapshot> {
+  const cfg = requireConfig();
+  const accessToken = await getAccessToken(cfg);
+  const payment = await getPayment(cfg, accessToken, orderId);
+
+  return {
+    state: payment.state,
+    authorized: payment.aggregate.authorizedAmount.value,
+    captured: payment.aggregate.capturedAmount.value,
+    refunded: payment.aggregate.refundedAmount.value,
+    cancelled: payment.aggregate.cancelledAmount.value,
+  };
+}
+
+/**
+ * Fetch the payment's event log — the same timeline the Vipps portal shows
+ * (reserved → captured → …), with timestamps. This is where an admin sees
+ * exactly *when* something happened, including failed attempts.
+ *
+ * Vipps has used both `name` and `paymentAction` for the event label across API
+ * revisions, so we accept either.
+ */
+export async function fetchPaymentEvents(
+  orderId: string,
+): Promise<VippsPaymentEvent[]> {
+  const cfg = requireConfig();
+  const accessToken = await getAccessToken(cfg);
+
+  const response = await fetch(
+    `${cfg.apiUrl}/epayment/v1/payments/${orderId}/events`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Ocp-Apim-Subscription-Key": cfg.subscriptionKey,
+        "Merchant-Serial-Number": cfg.merchantSerialNumber,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    console.error(
+      "Vipps payment events error:",
+      response.status,
+      await response.text(),
+    );
+    throw new VippsError("Kunne ikke hente hendelsesloggen fra Vipps");
+  }
+
+  const data = (await response.json()) as {
+    name?: string;
+    paymentAction?: string;
+    amount?: { value?: number };
+    timestamp?: string;
+    timeStamp?: string;
+    success?: boolean;
+  }[];
+
+  return data.map((event) => ({
+    action: event.name ?? event.paymentAction ?? "UKJENT",
+    amount: event.amount?.value ?? null,
+    timestamp: event.timestamp ?? event.timeStamp ?? null,
+    success: event.success ?? true,
+  }));
+}
+
 /**
  * Reconcile a single payment against Vipps — the source of truth — capturing it
  * if it is only reserved, and marking the owning user paid/verified once money
@@ -335,6 +428,15 @@ export async function settlePayment(
 
   // No-op when the row is absent (updateMany avoids a P2025 on a missing order).
   await db.payment.updateMany({ where: { orderId }, data: { status } });
+
+  // Stamp the capture time once. Scoped to `capturedAt: null` so a re-settle
+  // (webhook retry, admin sync) never moves an already-recorded payment time.
+  if (paid) {
+    await db.payment.updateMany({
+      where: { orderId, capturedAt: null },
+      data: { capturedAt: new Date() },
+    });
+  }
 
   if (paid && userId) {
     await db.user.update({


### PR DESCRIPTION
## Hva

Ny **Betalinger**-fane i adminpanelet med en samlet, flat oversikt over alle påmeldte — én rad per bruker, ikke gruppert etter studieprogram som brukerlisten er i dag.

Svarer på en konkret forespørsel: kunne følge antall påmeldte, sette opp faddergrupper og følge økonomien mot budsjett, med dato og tidspunkt for både påmelding og betaling — i panelet eller som Excel/CSV.

## Innhold

- **Nøkkeltall**: påmeldte, betalt, ikke betalt (med antall påbegynte), uten faddergruppe, innbetalt og utestående.
- **Samlet tabell**: navn, e-post, klasse, studieretning, faddergruppe, rolle, betalingsstatus, beløp, påmeldt- og betalt-tidspunkt, Vipps-referanse. Sorterbar på navn/gruppe/status/påmeldt/betalt, med søk og filtrene Alle / Betalt / Ikke betalt / Uten faddergruppe.
- **Detaljvisning** ved klikk på rad: live status og hendelseslogg fra Vipps.
- **Synk mot Vipps**: avstemmer ordre som aldri fikk webhook.
- **Purreliste** over alle som ikke har betalt.
- **CSV-eksport** med semikolon + BOM (norsk Excel), dato og klokkeslett i separate kolonner.

## Datamodell

`Payment.capturedAt` lagrer når pengene faktisk ble trukket — `updatedAt` duger ikke, siden enhver senere statusskriving flytter den. Feltet settes i `settlePayment`, scopet til `capturedAt: null` så webhook-retry eller admin-synk aldri flytter et registrert tidspunkt.

Migrasjonen backfiller fra `updatedAt`, som ble skrevet i samme øyeblikk som capture. `scripts/backfill-captured-at.ts` kan i tillegg korrigere mot en CSV-eksport fra Vipps-portalen (kjør med `--dry` først).

⚠️ **Vercel kjører ikke `prisma migrate deploy`** — migrasjonen må kjøres manuelt mot Neon etter merge.

## Om tallene

I dev er 22 brukere markert betalt, men bare 3 har en capturet Vipps-ordre — resten er satt betalt utenfor appen. Det skjules ikke: de vises som «Betalt (utenfor Vipps)», og «Innbetalt» summerer kun reelle capturer med hint om antall. Ellers ville nøkkeltallet overdrevet hva som faktisk har kommet inn.

## Verifisering

- `typecheck`, `lint` (0 errors) og `build` grønne.
- Migrasjon kjørt mot lokal DB: alle `CAPTURED`-rader har `capturedAt`.
- CSV-utilen kjørt med kantverdier: quoting/escaping av `"` og `;` korrekt, UTC→Oslo-konvertering korrekt, null gir tomme felt.
- `/admin` redirecter fortsatt ikke-admins.
- **Ikke verifisert:** selve fanen i nettleser, CSV-nedlasting og Synk mot Vipps — krever admin-innlogging og `VIPPS_API_URL`, som ikke er satt lokalt (den er satt i prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)