### PR TITLE
fix(admin): vis kun fadderbarn i betalingsoversikten

### DIFF
--- a/src/app/(authenticated)/admin/betalinger-tab.tsx
+++ b/src/app/(authenticated)/admin/betalinger-tab.tsx
@@ -346,7 +346,7 @@ export function BetalingerTab() {
 
     const today = toDateAndTime(new Date()).date;
     downloadCsv(
-      `fadderuka-pameldte-${suffix}-${today}.csv`,
+      `fadderuka-fadderbarn-${suffix}-${today}.csv`,
       toCsv(data, columns),
     );
   };
@@ -387,7 +387,11 @@ export function BetalingerTab() {
     <div className="!space-y-8">
       {/* Key figures — enough to follow sign-ups and the budget at a glance */}
       <section className="grid grid-cols-2 !gap-3 sm:grid-cols-3 lg:grid-cols-6">
-        <StatCard label="Påmeldte" value={String(stats.total)} />
+        <StatCard
+          label="Påmeldte"
+          value={String(stats.total)}
+          hint="Fadderbarn"
+        />
         <StatCard label="Betalt" value={String(stats.paid)} />
         <StatCard
           label="Ikke betalt"
@@ -439,11 +443,16 @@ export function BetalingerTab() {
         )}
       </section>
 
-      {/* Combined, flat overview — one row per registered user */}
+      {/* Combined, flat overview — one row per paying registration */}
       <section className="!space-y-4">
-        <h3 className="text-lg font-semibold text-foreground">
-          Samlet oversikt ({filtered.length})
-        </h3>
+        <div>
+          <h3 className="text-lg font-semibold text-foreground">
+            Samlet oversikt ({filtered.length})
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            Kun fadderbarn. Admin og faddere er utelatt siden de ikke betaler.
+          </p>
+        </div>
 
         <div className="flex flex-wrap items-center !gap-3">
           <input

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -240,6 +240,14 @@ export const adminRouter = createTRPCRouter({
    */
   getRegistrations: adminProcedure.query(async ({ ctx }) => {
     const users = await ctx.db.user.findMany({
+      // Only fadderbarn pay. Admins and faddere would otherwise inflate both the
+      // sign-up count and the outstanding sum with people who never owed money.
+      // Users without a group are kept: an unassigned registration is a
+      // fadderbarn until proven otherwise, and they are exactly who to chase.
+      where: {
+        isAdmin: false,
+        memberships: { none: { role: "FADDER" } },
+      },
       select: {
         id: true,
         name: true,


### PR DESCRIPTION
## Hvorfor

Betalingsoversikten fra #73 tok med alle brukere. Men bare fadderbarn betaler — admin og faddere gjør ikke det, og de blåste derfor opp både antall påmeldte og «betalt»-tallet.

I prod var effekten stor: **17 av 23 brukere er admin, og alle 17 var markert betalt.** Det er forklaringen på at oversikten viste 22 betalte mens det bare finnes 4 faktiske Vipps-betalinger.

## Endring

`admin.getRegistrations` filtrerer nå bort brukere som er admin eller har rollen `FADDER`.

Brukere **uten** faddergruppe beholdes bevisst — en utildelt påmelding er et fadderbarn inntil noe annet er bestemt, og det er nettopp dem man må purre på. Hadde de blitt filtrert på rolle alene, ville nye påmeldte forsvunnet fra purrelisten.

I tillegg: overskriften sier eksplisitt at admin og faddere er utelatt, «Påmeldte»-kortet er merket «Fadderbarn», og CSV-filnavnet er `fadderuka-fadderbarn-*` så en eksport ikke leses som hele brukerbasen.

## Effekt på prod-tallene

| | Før | Etter |
|---|---|---|
| Rader i oversikten | 23 | 6 |
| Betalt | 22 | 5 |
| Ikke betalt | 1 | 1 |

Kjørt som SQL mot prod-databasen med samme betingelse som Prisma-filteret.

## Verifisering

- `typecheck`, `lint` (0 errors) og `build` grønne.
- Filteret kjørt mot prod-data, tallene over.
- **Ikke verifisert i nettleser** — krever admin-innlogging, som jeg ikke kan gjøre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)