### PR TITLE
feat(admin): refunder Vipps-betaling fra adminpanelet

### DIFF
--- a/prisma/migrations/20260719140000_payment_refunded_status/migration.sql
+++ b/prisma/migrations/20260719140000_payment_refunded_status/migration.sql
@@ -1,0 +1,3 @@
+-- Full refunds issued from the admin panel get their own terminal status, so a
+-- later `syncPayments` can tell them apart from a live CAPTURED order.
+ALTER TYPE "PaymentStatus" ADD VALUE 'REFUNDED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,8 @@ enum PaymentStatus {
     EXPIRED
     TERMINATED
     FAILED
+    // Money was captured and then paid back in full via the admin panel.
+    REFUNDED
 }
 
 model Post {

--- a/src/app/(authenticated)/admin/betalinger-tab.tsx
+++ b/src/app/(authenticated)/admin/betalinger-tab.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ArrowDown, ArrowUp, Download, RefreshCw } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  Download,
+  RefreshCw,
+  Undo2,
+} from "lucide-react";
 import { Fragment, useMemo, useState } from "react";
 import { api, type RouterOutputs } from "~/trpc/react";
 import { toast } from "~/components/ui/use-toast";
@@ -23,12 +30,14 @@ const STATUS_LABELS: Record<string, string> = {
   EXPIRED: "Utløpt",
   TERMINATED: "Terminert",
   FAILED: "Feilet",
+  REFUNDED: "Refundert",
 };
 
 const STATUS_STYLES: Record<string, string> = {
   CAPTURED: "bg-emerald-500/15 text-emerald-400",
   AUTHORIZED: "bg-sky-500/15 text-sky-400",
   CREATED: "bg-amber-500/15 text-amber-400",
+  REFUNDED: "bg-orange-500/15 text-orange-400",
 };
 
 const FILTERS: { value: Filter; label: string }[] = [
@@ -113,8 +122,101 @@ function StatCard({
   );
 }
 
+/**
+ * The refund control. Deliberately two-step and styled as destructive: a refund
+ * moves real money out of the TIHLDE account and cannot be undone from here, so
+ * the first click only reveals what is about to happen — nothing is sent to
+ * Vipps until the admin confirms the amount and the name.
+ */
+function RefundAction({
+  orderId,
+  name,
+  refundable,
+}: {
+  orderId: string;
+  name: string;
+  refundable: number;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const utils = api.useUtils();
+
+  const refundMutation = api.admin.refundPayment.useMutation({
+    onSuccess: (result) => {
+      setConfirming(false);
+      void utils.admin.getPaymentDetails.invalidate({ orderId });
+      void utils.admin.getRegistrations.invalidate();
+      void utils.admin.getUsers.invalidate();
+      toast({
+        title: "Betalingen er refundert",
+        description: `${kr(result.refunded)} er sendt tilbake til ${result.name}, som nå står som ikke betalt.`,
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Refusjon feilet",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  if (!confirming) {
+    return (
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="inline-flex items-center !gap-2 rounded-xl border border-red-500/40 bg-red-500/10 !px-3 !py-2 text-sm font-semibold text-red-400 transition hover:bg-red-500/20"
+      >
+        <Undo2 className="h-4 w-4" />
+        Refunder {kr(refundable)}
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-red-500/40 bg-red-500/10 !p-4 !space-y-3">
+      <div className="flex items-start !gap-2">
+        <AlertTriangle className="!mt-0.5 h-5 w-5 shrink-0 text-red-400" />
+        <div className="!space-y-1">
+          <p className="text-sm font-semibold text-red-400">
+            Dette kan ikke angres
+          </p>
+          <p className="text-sm text-foreground">
+            {kr(refundable)} betales tilbake til{" "}
+            <span className="font-semibold">{name}</span> via Vipps. Pengene
+            trekkes fra TIHLDE sin konto, og {name.split(" ")[0]} blir markert
+            som <span className="font-semibold">ikke betalt</span>. Skal
+            personen delta likevel, må hen betale på nytt.
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap !gap-2">
+        <button
+          type="button"
+          onClick={() => refundMutation.mutate({ orderId })}
+          disabled={refundMutation.isPending}
+          className="inline-flex items-center !gap-2 rounded-xl bg-red-600 !px-4 !py-2 text-sm font-semibold text-white transition hover:bg-red-700 disabled:opacity-60"
+        >
+          <Undo2 className="h-4 w-4" />
+          {refundMutation.isPending
+            ? "Refunderer..."
+            : `Ja, refunder ${kr(refundable)}`}
+        </button>
+        <button
+          type="button"
+          onClick={() => setConfirming(false)}
+          disabled={refundMutation.isPending}
+          className="rounded-xl border border-border bg-secondary !px-4 !py-2 text-sm font-semibold text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
+        >
+          Avbryt
+        </button>
+      </div>
+    </div>
+  );
+}
+
 /** Live Vipps status + event timeline for one order, fetched on expand. */
-function PaymentDetails({ orderId }: { orderId: string }) {
+function PaymentDetails({ orderId, name }: { orderId: string; name: string }) {
   const { data, isLoading, error } = api.admin.getPaymentDetails.useQuery(
     { orderId },
     { retry: false },
@@ -196,6 +298,15 @@ function PaymentDetails({ orderId }: { orderId: string }) {
           </ul>
         )}
       </div>
+
+      {/* Only offer a refund when Vipps actually holds money we can pay back. */}
+      {data.snapshot.captured > data.snapshot.refunded && (
+        <RefundAction
+          orderId={orderId}
+          name={name}
+          refundable={data.snapshot.captured - data.snapshot.refunded}
+        />
+      )}
     </div>
   );
 }
@@ -550,7 +661,7 @@ export function BetalingerTab() {
                               {r.attemptCount > 1 &&
                                 ` · ${r.attemptCount} betalingsforsøk`}
                             </p>
-                            <PaymentDetails orderId={r.orderId} />
+                            <PaymentDetails orderId={r.orderId} name={r.name} />
                           </div>
                         ) : (
                           <p className="text-sm text-muted-foreground">

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -11,6 +11,7 @@ import {
   VippsNotConfiguredError,
   fetchPaymentEvents,
   fetchPaymentSnapshot,
+  refundPayment,
   settlePayment,
 } from "~/server/payment/vipps";
 
@@ -337,6 +338,38 @@ export const adminRouter = createTRPCRouter({
           fetchPaymentEvents(input.orderId),
         ]);
         return { snapshot, events };
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Refund one order in full and unmark the user as paid. Irreversible — the
+   * money leaves the merchant account — so the client must confirm first.
+   * All the guards (nothing captured, already refunded) live in the Vipps
+   * layer, which reads the live payment before moving anything.
+   */
+  refundPayment: adminProcedure
+    .input(z.object({ orderId: z.string().min(1) }))
+    .mutation(async ({ input, ctx }) => {
+      const order = await ctx.db.payment.findUnique({
+        where: { orderId: input.orderId },
+        select: { user: { select: { name: true } } },
+      });
+
+      if (!order) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Fant ingen betaling med denne referansen.",
+        });
+      }
+
+      try {
+        const { refunded } = await refundPayment(input.orderId);
+        console.warn(
+          `[admin] refunded ${refunded} øre for ${input.orderId} (${order.user.name}) by ${ctx.session.user.id}`,
+        );
+        return { refunded, name: order.user.name };
       } catch (err) {
         throw toTRPCError(err);
       }

--- a/src/server/payment/vipps.ts
+++ b/src/server/payment/vipps.ts
@@ -279,8 +279,111 @@ async function capture(
   }
 }
 
+/**
+ * Refund a captured payment in full.
+ *
+ * Vipps only refunds money that has actually been captured, so the caller must
+ * check the snapshot first — this function assumes that has happened. The
+ * idempotency key is derived from the orderId, so a double-click or a retry
+ * refunds once, not twice.
+ */
+async function refund(
+  cfg: VippsConfig,
+  accessToken: string,
+  orderId: string,
+  amountOre: number,
+): Promise<void> {
+  const response = await fetch(
+    `${cfg.apiUrl}/epayment/v1/payments/${orderId}/refund`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": cfg.subscriptionKey,
+        "Merchant-Serial-Number": cfg.merchantSerialNumber,
+        "Idempotency-Key": idempotencyKey(orderId, "refund"),
+      },
+      body: JSON.stringify({
+        modificationAmount: { currency: "NOK", value: amountOre },
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.error("Vipps refund error:", response.status, body);
+    // 403 here almost always means the API key lacks refund permission on the
+    // merchant account — say so, since no amount of retrying will fix it.
+    if (response.status === 403) {
+      throw new VippsError(
+        "Vipps avviste refusjonen (403). Sjekk at API-nøkkelen har refusjonstilgang på salgsstedet.",
+      );
+    }
+    throw new VippsError("Kunne ikke refundere betalingen i Vipps");
+  }
+}
+
+/**
+ * Refund a payment in full and unmark the owning user as paid.
+ *
+ * Vipps is the source of truth: we read the live payment first and refuse if
+ * there is nothing left to refund, so a double submit can't move money twice.
+ * `isVerified` is deliberately left alone — it also gates account access that
+ * an admin may have granted for other reasons, and revoking it here would be a
+ * surprising side effect of a payment action.
+ */
+export async function refundPayment(
+  orderId: string,
+): Promise<{ refunded: number }> {
+  const cfg = requireConfig();
+  const accessToken = await getAccessToken(cfg);
+  const payment = await getPayment(cfg, accessToken, orderId);
+
+  const { capturedAmount, refundedAmount } = payment.aggregate;
+  const refundable = capturedAmount.value - refundedAmount.value;
+
+  if (capturedAmount.value <= 0) {
+    throw new VippsError(
+      "Betalingen er ikke trukket i Vipps, så det finnes ingenting å refundere.",
+    );
+  }
+  if (refundable <= 0) {
+    throw new VippsError("Betalingen er allerede refundert i sin helhet.");
+  }
+
+  await refund(cfg, accessToken, orderId, refundable);
+
+  const order = await db.payment.findUnique({
+    where: { orderId },
+    select: { userId: true },
+  });
+  const userId = order?.userId ?? parseUserIdFromOrderId(orderId);
+
+  await db.payment.updateMany({
+    where: { orderId },
+    data: { status: "REFUNDED" },
+  });
+
+  if (userId) {
+    await db.user.update({ where: { id: userId }, data: { hasPaid: false } });
+  }
+
+  return { refunded: refundable };
+}
+
 /** Map a live Vipps payment to our stored status. */
 function toStatus(payment: VippsPayment): PaymentStatus {
+  // Checked before the capture branch: a fully refunded order still reports a
+  // non-zero `capturedAmount`, so without this a later sync would flip it back
+  // to CAPTURED and re-mark the user as paid.
+  if (
+    payment.aggregate.refundedAmount.value > 0 &&
+    payment.aggregate.refundedAmount.value >=
+      payment.aggregate.capturedAmount.value
+  ) {
+    return "REFUNDED";
+  }
   if (payment.aggregate.capturedAmount.value >= PAYMENT_AMOUNT_ORE) {
     return "CAPTURED";
   }


### PR DESCRIPTION
Gjør det mulig å refundere en trukket Vipps-betaling i sin helhet direkte fra betalingsoversikten i adminpanelet.

## Hva

**Vipps-laget** (`src/server/payment/vipps.ts`)
- `refundPayment(orderId)` mot `POST /epayment/v1/payments/{ref}/refund`. Samme idempotency-derivering som `capture()`, så dobbeltklikk eller retry refunderer én gang.
- Leser live-betalingen fra Vipps først og nekter hvis ingenting er trukket eller alt allerede er refundert.
- 403 gir en egen feilmelding om manglende refusjonstilgang på salgsstedet — den mest sannsynlige produksjonsfeilen.
- `toStatus()` sjekker refusjon **før** capture. En fullt refundert ordre rapporterer fortsatt et `capturedAmount`, så uten dette ville neste «Synk mot Vipps» skrive ordren tilbake til `CAPTURED` og markere brukeren som betalt igjen.

**API** — `admin.refundPayment`, admin-only, 404 på ukjent referanse, logger hvem som refunderte hva.

**Database** — ny `PaymentStatus.REFUNDED` + migrasjon.

**UI** — knappen vises kun når Vipps faktisk har penger å betale tilbake. To steg: rød knapp → varselpanel som sier at handlingen ikke kan angres, hvem som får pengene tilbake, at de trekkes fra TIHLDE sin konto og at personen blir markert som ikke betalt og må betale på nytt. Deretter «Ja, refunder 380 kr» eller «Avbryt».

Brukeren settes til `hasPaid = false`. `isVerified` røres ikke, siden den også styrer tilgang admin kan ha gitt av andre grunner.

## Før merge til prod

- [ ] **Bekreft at Vipps-API-nøkkelen har refusjonstilgang på salgsstedet (MSN).** Er den ikke det, får man 403 i produksjon selv om koden er riktig.
- [ ] **Kjør `prisma migrate deploy` manuelt mot Neon** etter deploy — Vercel gjør det ikke.

## Testing

- `tsc --noEmit`, `next build` og lint passerer (0 errors).
- Migrasjonen kjørt rent mot lokal dev-DB.
- **Ikke visuelt verifisert** — `/admin` krever admin-sesjon. Bekreftelsespanelet bør klikkes gjennom manuelt før merge.
- **Ingen faktisk refusjon er utført** mot Vipps. Selve refusjonskallet er ikke kjørt end-to-end og bør testes mot testmiljøet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)