### PR TITLE
test: integrasjonstester for hele serverflaten + CI på PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+# Runs on every PR into main or dev, and on pushes to those branches.
+# Enable it as a required status check in the branch protection rules so a red
+# run blocks the merge.
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+
+# A new push supersedes the previous run for the same ref.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        # 16 (>= 12) is required: the payment_refunded_status migration runs
+        # `ALTER TYPE … ADD VALUE` inside Prisma's migration transaction.
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: fadderuke_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # The suite migrates and truncates this database on every run.
+      TEST_DATABASE_URL: postgresql://postgres:password@localhost:5432/fadderuke_test
+      # `next build` and eslint's type-aware rules import ~/env, which validates
+      # at module load. Dummy values only — nothing here reaches a real service.
+      DATABASE_URL: postgresql://postgres:password@localhost:5432/fadderuke_test
+      TIHLDE_API_URL: https://api.tihlde.org
+      SKIP_ENV_VALIDATION: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.5
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: bunx prisma generate
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      # Applies the migrations to the service database before the suite runs
+      # (the suite also does this itself, but failing here gives a clearer log).
+      - name: Migrate test database
+        run: bunx prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
+
+      - name: Test
+        run: bun run test
+
+      - name: Build
+        run: bun run build

--- a/README.md
+++ b/README.md
@@ -8,23 +8,19 @@ Integrasjonstestene kjører serverkoden (tRPC-routere, route handlers,
 Vipps- og TIHLDE-klientene) mot en ekte Postgres. Ingen test treffer Vipps eller
 TIHLDE — `fetch` er stubbet.
 
-Testene trenger en egen database som de migrerer og tømmer for hver kjøring:
+Har du en lokal database kjørende, er det bare å kjøre:
 
 ```bash
-docker compose up -d db
-createdb -h localhost -p 5432 -U postgres fadderuke_test   # én gang
 bun run test
 ```
 
-Standard tilkobling er `postgresql://postgres:password@localhost:5432/fadderuke_test`
-(samme som `compose.yml`). Kjører du Postgres et annet sted, sett `TEST_DATABASE_URL`:
+Testene bruker sin egen database, avledet fra `DATABASE_URL` i `.env`: samme
+server og samme brukernavn, men med `_test` bak navnet (`fadderuke` →
+`fadderuke_test`). Databasen opprettes automatisk første gang, og migrasjonene
+kjøres før hver kjøring. Utviklingsdatabasen røres aldri.
 
-```bash
-TEST_DATABASE_URL="postgresql://postgres:<passord>@localhost:5433/fadderuke_test" bun run test
-```
-
-Testene nekter å kjøre mot en ikke-lokal database, siden de kjører `TRUNCATE` på
-alle tabellene. Migrasjonene kjøres automatisk før pakka starter.
+Trenger du å peke et annet sted, sett `TEST_DATABASE_URL`. Testene nekter å
+kjøre mot en ikke-lokal database, siden de kjører `TRUNCATE` på alle tabellene.
 
 `bun run check` kjører lint, typecheck og tester samlet — det samme som CI gjør
 på hver PR mot `main` og `dev` (se `.github/workflows/ci.yml`), i tillegg til

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # Fadderuke
 
 Nettside for fadderbarn og faddere under fadderuken.
+
+## Tester
+
+Integrasjonstestene kjører serverkoden (tRPC-routere, route handlers,
+Vipps- og TIHLDE-klientene) mot en ekte Postgres. Ingen test treffer Vipps eller
+TIHLDE — `fetch` er stubbet.
+
+Testene trenger en egen database som de migrerer og tømmer for hver kjøring:
+
+```bash
+docker compose up -d db
+createdb -h localhost -p 5432 -U postgres fadderuke_test   # én gang
+bun run test
+```
+
+Standard tilkobling er `postgresql://postgres:password@localhost:5432/fadderuke_test`
+(samme som `compose.yml`). Kjører du Postgres et annet sted, sett `TEST_DATABASE_URL`:
+
+```bash
+TEST_DATABASE_URL="postgresql://postgres:<passord>@localhost:5433/fadderuke_test" bun run test
+```
+
+Testene nekter å kjøre mot en ikke-lokal database, siden de kjører `TRUNCATE` på
+alle tabellene. Migrasjonene kjøres automatisk før pakka starter.
+
+`bun run check` kjører lint, typecheck og tester samlet — det samme som CI gjør
+på hver PR mot `main` og `dev` (se `.github/workflows/ci.yml`), i tillegg til
+`next build`.

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "tailwindcss": "^4.0.15",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.27.0",
+        "vitest": "^4.1.10",
       },
     },
   },
@@ -56,11 +57,11 @@
 
     "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -186,6 +187,8 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
     "@prisma/client": ["@prisma/client@6.19.2", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg=="],
 
     "@prisma/config": ["@prisma/config@6.19.2", "", { "dependencies": { "c12": "3.1.0", "deepmerge-ts": "7.1.5", "effect": "3.18.4", "empathic": "2.0.0" } }, "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ=="],
@@ -266,6 +269,38 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.16.1", "", {}, "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag=="],
@@ -322,7 +357,11 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -406,6 +445,20 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -435,6 +488,8 @@
     "array.prototype.tosorted": ["array.prototype.tosorted@1.1.4", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3", "es-errors": "^1.3.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA=="],
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
 
@@ -470,6 +525,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
@@ -501,6 +558,8 @@
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
@@ -564,6 +623,8 @@
 
     "es-iterator-helpers": ["es-iterator-helpers@1.3.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.1", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "math-intrinsics": "^1.1.0", "safe-array-concat": "^1.1.3" } }, "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ=="],
 
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
@@ -606,7 +667,11 @@
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -637,6 +702,8 @@
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -960,6 +1027,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -1052,6 +1121,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
@@ -1086,11 +1157,17 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -1132,9 +1209,13 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1194,6 +1275,10 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
+
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -1204,6 +1289,8 @@
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
@@ -1213,6 +1300,8 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
@@ -1262,6 +1351,10 @@
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
@@ -1306,7 +1399,19 @@
 
     "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/postcss": ["postcss@8.5.20", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build",
-    "check": "eslint . && tsc --noEmit",
+    "check": "eslint . && tsc --noEmit && vitest run",
     "db:generate": "prisma migrate dev",
     "db:migrate": "prisma migrate deploy",
     "db:push": "prisma db push",
@@ -18,6 +18,8 @@
     "lint:fix": "eslint . --fix",
     "preview": "next build && next start",
     "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -63,7 +65,8 @@
     "prisma": "^6.5.0",
     "tailwindcss": "^4.0.15",
     "typescript": "^5.8.2",
-    "typescript-eslint": "^8.27.0"
+    "typescript-eslint": "^8.27.0",
+    "vitest": "^4.1.10"
   },
   "ct3aMetadata": {
     "initVersion": "7.39.3"

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -89,7 +89,9 @@ export const createTRPCRouter = t.router;
 const timingMiddleware = t.middleware(async ({ next, path }) => {
   const start = Date.now();
 
-  if (t._config.isDev) {
+  // The artificial delay is a dev-only waterfall detector. Skipped under test,
+  // where it would add hundreds of ms to every procedure call for no benefit.
+  if (t._config.isDev && process.env.NODE_ENV !== "test") {
     // artificial delay in dev
     const waitMs = Math.floor(Math.random() * 400) + 100;
     await new Promise((resolve) => setTimeout(resolve, waitMs));

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -10,10 +10,34 @@
  * would destroy real data.
  */
 
-const DEFAULT_TEST_DATABASE_URL =
-  "postgresql://postgres:password@localhost:5432/fadderuke_test";
+/** Used when there is no `.env` to derive from (a bare checkout, like CI). */
+const FALLBACK_DATABASE_URL =
+  "postgresql://postgres:password@localhost:5432/fadderuke";
 
-const databaseUrl = process.env.TEST_DATABASE_URL ?? DEFAULT_TEST_DATABASE_URL;
+/** Suffix that turns the development database into its throwaway twin. */
+const TEST_DB_SUFFIX = "_test";
+
+/**
+ * Derive the test database from the development one: same server, same
+ * credentials, `_test` appended to the database name. That way a local `bun run
+ * test` works with no extra configuration whatever port or password the
+ * developer's Postgres runs on — and it can never be the development database
+ * itself, since the name always differs.
+ *
+ * `TEST_DATABASE_URL` overrides it (CI sets it explicitly).
+ */
+function deriveTestDatabaseUrl(): string {
+  const explicit = process.env.TEST_DATABASE_URL;
+  if (explicit) return explicit;
+
+  // Bun loads the repo's `.env`, so this is normally the development database.
+  const url = new URL(process.env.DATABASE_URL ?? FALLBACK_DATABASE_URL);
+  const name = url.pathname.replace(/^\//, "") || "fadderuke";
+  url.pathname = `/${name.endsWith(TEST_DB_SUFFIX) ? name : name + TEST_DB_SUFFIX}`;
+  return url.toString();
+}
+
+const databaseUrl = deriveTestDatabaseUrl();
 
 /**
  * Refuse to run against a non-local database unless explicitly allowed. The

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -1,0 +1,53 @@
+/**
+ * Test environment variables.
+ *
+ * Imported for its side effects as the very first thing in `tests/setup.ts`, so
+ * every value is in place before `~/env` (t3-env) validates on first import.
+ *
+ * `DATABASE_URL` is *overwritten*, never defaulted: Bun loads the repo's `.env`
+ * into `process.env`, and that points at the development database. The tests
+ * truncate every table, so pointing them at anything but a throwaway database
+ * would destroy real data.
+ */
+
+const DEFAULT_TEST_DATABASE_URL =
+  "postgresql://postgres:password@localhost:5432/fadderuke_test";
+
+const databaseUrl = process.env.TEST_DATABASE_URL ?? DEFAULT_TEST_DATABASE_URL;
+
+/**
+ * Refuse to run against a non-local database unless explicitly allowed. The
+ * suite runs `TRUNCATE` on every table — a stray `TEST_DATABASE_URL` pointing at
+ * Neon (prod) would wipe it.
+ */
+function assertSafeDatabase(url: string) {
+  if (process.env.ALLOW_REMOTE_TEST_DB === "1") return;
+  const host = new URL(url).hostname;
+  if (host !== "localhost" && host !== "127.0.0.1") {
+    throw new Error(
+      `Testene nekter å kjøre mot en ikke-lokal database (${host}). ` +
+        "Sett TEST_DATABASE_URL til en lokal testdatabase, eller " +
+        "ALLOW_REMOTE_TEST_DB=1 hvis du virkelig mener det.",
+    );
+  }
+}
+
+assertSafeDatabase(databaseUrl);
+
+process.env.DATABASE_URL = databaseUrl;
+// `NODE_ENV` is typed read-only on `ProcessEnv`, so assign through a widened
+// view. It must be set here rather than in the vitest config: `~/env` reads it
+// during module init, before any config-level env would apply.
+(process.env as Record<string, string>).NODE_ENV = "test";
+
+// Fake external services. No test may reach the real TIHLDE or Vipps APIs —
+// `fetch` is stubbed, and these hosts exist only so URL building is realistic.
+process.env.TIHLDE_API_URL = "https://tihlde.test";
+process.env.VIPPS_API_URL = "https://vipps.test";
+process.env.VIPPS_CALLBACK_URL = "https://fadderuka.test";
+process.env.VIPPS_CLIENT_ID = "test-client-id";
+process.env.VIPPS_CLIENT_SECRET = "test-client-secret";
+process.env.VIPPS_MERCHANT_SERIAL_NUMBER = "123456";
+process.env.VIPPS_SUBSCRIPTION_KEY = "test-subscription-key";
+
+export const TEST_DATABASE_URL = databaseUrl;

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,14 @@
+import { execFileSync } from "node:child_process";
+
+import { TEST_DATABASE_URL } from "./env";
+
+/**
+ * Bring the test database up to date once per `vitest run`, so the suite tests
+ * the real migrations (not `db push`) and nobody has to remember a manual step.
+ */
+export default function setup() {
+  execFileSync("bunx", ["prisma", "migrate", "deploy"], {
+    stdio: "inherit",
+    env: { ...process.env, DATABASE_URL: TEST_DATABASE_URL },
+  });
+}

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,12 +1,47 @@
 import { execFileSync } from "node:child_process";
 
+import { PrismaClient } from "@prisma/client";
+
 import { TEST_DATABASE_URL } from "./env";
+
+/**
+ * Create the test database if it doesn't exist yet.
+ *
+ * Connects to the server's built-in `postgres` database (which always exists)
+ * and issues `CREATE DATABASE`. This is what lets a fresh checkout run
+ * `bun run test` without a manual `createdb` step.
+ */
+async function ensureDatabaseExists(): Promise<void> {
+  const url = new URL(TEST_DATABASE_URL);
+  const name = url.pathname.replace(/^\//, "");
+
+  const adminUrl = new URL(url);
+  adminUrl.pathname = "/postgres";
+
+  const admin = new PrismaClient({ datasourceUrl: adminUrl.toString() });
+  try {
+    const existing = await admin.$queryRawUnsafe<{ datname: string }[]>(
+      "SELECT datname FROM pg_database WHERE datname = $1",
+      name,
+    );
+    if (existing.length === 0) {
+      // Identifiers can't be parameterised; the name is derived from our own
+      // URL, and quoting it keeps a surprising name from breaking the statement.
+      await admin.$executeRawUnsafe(`CREATE DATABASE "${name.replace(/"/g, '""')}"`);
+      console.log(`[tests] opprettet testdatabasen "${name}"`);
+    }
+  } finally {
+    await admin.$disconnect();
+  }
+}
 
 /**
  * Bring the test database up to date once per `vitest run`, so the suite tests
  * the real migrations (not `db push`) and nobody has to remember a manual step.
  */
-export default function setup() {
+export default async function setup() {
+  await ensureDatabaseExists();
+
   execFileSync("bunx", ["prisma", "migrate", "deploy"], {
     stdio: "inherit",
     env: { ...process.env, DATABASE_URL: TEST_DATABASE_URL },

--- a/tests/helpers/caller.ts
+++ b/tests/helpers/caller.ts
@@ -1,0 +1,43 @@
+import type { User } from "@prisma/client";
+
+import { createCaller } from "~/server/api/root";
+import { db } from "~/server/db";
+
+/**
+ * tRPC callers for tests.
+ *
+ * The session shape mirrors what `auth.api.getSession` returns in
+ * `src/server/auth/config.ts` — `{ user, session }` — so the procedures under
+ * test see exactly the context they see in production.
+ */
+
+function sessionFor(user: User, tihldeToken: string | null = "tihlde-token") {
+  return {
+    user,
+    session: {
+      id: `sess-${user.id}`,
+      token: `token-${user.id}`,
+      tihldeToken,
+      userId: user.id,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: null,
+      userAgent: null,
+    },
+  };
+}
+
+/** Caller authenticated as `user`. */
+export function callerFor(user: User) {
+  return createCaller({
+    db,
+    session: sessionFor(user),
+    headers: new Headers(),
+  });
+}
+
+/** Caller with no session — every protected/admin procedure must reject it. */
+export function anonCaller() {
+  return createCaller({ db, session: null, headers: new Headers() });
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,0 +1,108 @@
+import { db } from "~/server/db";
+
+/**
+ * Every table, ordered so the single TRUNCATE covers them all. CASCADE handles
+ * the foreign keys, but listing them explicitly keeps the reset honest: a new
+ * model that isn't added here will show up as leaked rows between tests.
+ */
+const TABLES = [
+  "Payment",
+  "Notification",
+  "GroupMessage",
+  "FadderGruppeMember",
+  "Session",
+  "Post",
+  "Activity",
+  "FadderGruppe",
+  "User",
+] as const;
+
+/** Wipe all data between tests. Fast enough to run per test. */
+export async function resetDb(): Promise<void> {
+  await db.$executeRawUnsafe(
+    `TRUNCATE TABLE ${TABLES.map((t) => `"${t}"`).join(", ")} RESTART IDENTITY CASCADE`,
+  );
+}
+
+let seq = 0;
+/** Unique-per-run suffix so parallel-ish fixtures never collide on unique keys. */
+const uniq = () => `${Date.now().toString(36)}${(seq += 1)}`;
+
+export async function createUser(
+  overrides: Partial<{
+    tihldeUserId: string;
+    name: string;
+    email: string | null;
+    isAdmin: boolean;
+    isVerified: boolean;
+    hasPaid: boolean;
+    studieretning: string | null;
+    klasse: string | null;
+    createdAt: Date;
+  }> = {},
+) {
+  const id = uniq();
+  return db.user.create({
+    data: {
+      tihldeUserId: overrides.tihldeUserId ?? `bruker${id}`,
+      name: overrides.name ?? `Test Bruker ${id}`,
+      email: overrides.email === undefined ? `${id}@test.no` : overrides.email,
+      isAdmin: overrides.isAdmin ?? false,
+      isVerified: overrides.isVerified ?? false,
+      hasPaid: overrides.hasPaid ?? false,
+      studieretning: overrides.studieretning ?? null,
+      klasse: overrides.klasse ?? null,
+      ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
+    },
+  });
+}
+
+export async function createAdmin(
+  overrides: Parameters<typeof createUser>[0] = {},
+) {
+  return createUser({ isAdmin: true, isVerified: true, hasPaid: true, ...overrides });
+}
+
+export async function createGruppe(name?: string) {
+  return db.fadderGruppe.create({ data: { name: name ?? `Gruppe ${uniq()}` } });
+}
+
+export async function addMember(
+  userId: string,
+  gruppeId: string,
+  role: "FADDER" | "FADDERBARN",
+) {
+  return db.fadderGruppeMember.create({ data: { userId, gruppeId, role } });
+}
+
+export async function createPayment(
+  userId: string,
+  overrides: Partial<{
+    orderId: string;
+    status:
+      | "CREATED"
+      | "AUTHORIZED"
+      | "CAPTURED"
+      | "ABORTED"
+      | "EXPIRED"
+      | "TERMINATED"
+      | "FAILED"
+      | "REFUNDED";
+    amount: number;
+    capturedAt: Date | null;
+    createdAt: Date;
+  }> = {},
+) {
+  return db.payment.create({
+    data: {
+      orderId: overrides.orderId ?? `fadderuka-${userId}-${uniq()}`,
+      userId,
+      amount: overrides.amount ?? 38_000,
+      status: overrides.status ?? "CREATED",
+      capturedAt: overrides.capturedAt ?? null,
+      ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
+    },
+  });
+}
+
+export { db };

--- a/tests/helpers/fetch-mock.ts
+++ b/tests/helpers/fetch-mock.ts
@@ -1,0 +1,169 @@
+import { vi } from "vitest";
+
+/**
+ * A tiny `fetch` stub for the two external APIs (Vipps and TIHLDE).
+ *
+ * Deliberately strict: an unmatched request throws instead of returning a
+ * default. A test that silently talks to an unstubbed endpoint would otherwise
+ * look like it passed while the code did something entirely different.
+ */
+
+export interface FetchCall {
+  method: string;
+  /** Path + query only, e.g. `/epayment/v1/payments/fadderuka-x-1`. */
+  path: string;
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+type Responder = Response | ((call: FetchCall) => Response | Promise<Response>);
+
+interface Route {
+  method: string;
+  pattern: string | RegExp;
+  responder: Responder;
+  /** Consume once (queued responses let a retry see a different result). */
+  once: boolean;
+  used: boolean;
+}
+
+/** Build a JSON `Response`, defaulting to 200. */
+export function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Build an error `Response` with a plain-text body, as Vipps/Lepton return. */
+export function text(body: string, status: number): Response {
+  return new Response(body, { status });
+}
+
+export class FetchMock {
+  private routes: Route[] = [];
+  readonly calls: FetchCall[] = [];
+
+  /** Register a handler for every matching request. */
+  on(method: string, pattern: string | RegExp, responder: Responder): this {
+    this.routes.push({
+      method: method.toUpperCase(),
+      pattern,
+      responder,
+      once: false,
+      used: false,
+    });
+    return this;
+  }
+
+  /**
+   * Register a handler consumed by the first matching request only. Later
+   * requests fall through to the next matching route — this is how a test says
+   * "first call fails, the retry succeeds".
+   */
+  once(method: string, pattern: string | RegExp, responder: Responder): this {
+    this.routes.push({
+      method: method.toUpperCase(),
+      pattern,
+      responder,
+      once: true,
+      used: false,
+    });
+    return this;
+  }
+
+  /** Calls matching a path fragment, for asserting what we sent. */
+  callsTo(pattern: string | RegExp): FetchCall[] {
+    return this.calls.filter((c) => matches(c.path, pattern));
+  }
+
+  reset(): void {
+    this.routes = [];
+    this.calls.length = 0;
+  }
+
+  /** The stand-in passed to `vi.stubGlobal("fetch", …)`. */
+  readonly handler = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const parsed = new URL(url);
+
+    const call: FetchCall = {
+      method,
+      path: `${parsed.pathname}${parsed.search}`,
+      url,
+      headers: normalizeHeaders(init?.headers),
+      body: parseBody(init?.body),
+    };
+    this.calls.push(call);
+
+    const route = this.routes.find(
+      (r) =>
+        r.method === method &&
+        matches(call.path, r.pattern) &&
+        !(r.once && r.used),
+    );
+
+    if (!route) {
+      throw new Error(
+        `Uventet fetch i test: ${method} ${call.path}\n` +
+          `Registrerte ruter: ${
+            this.routes.map((r) => `${r.method} ${String(r.pattern)}`).join(", ") ||
+            "(ingen)"
+          }`,
+      );
+    }
+    route.used = true;
+
+    const responder = route.responder;
+    const response =
+      typeof responder === "function" ? await responder(call) : responder;
+    // A Response body can only be read once; clone so a reused responder works.
+    return response.clone();
+  };
+}
+
+/**
+ * String patterns match the path exactly (query string aside). Prefix matching
+ * would make `/payments/{ref}` swallow `/payments/{ref}/capture`; use a RegExp
+ * when a test genuinely wants a fuzzy match.
+ */
+function matches(path: string, pattern: string | RegExp): boolean {
+  if (typeof pattern !== "string") return pattern.test(path);
+  return path === pattern || path.startsWith(`${pattern}?`);
+}
+
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!headers) return out;
+  new Headers(headers).forEach((value, key) => {
+    out[key.toLowerCase()] = value;
+  });
+  return out;
+}
+
+function parseBody(body: BodyInit | null | undefined): unknown {
+  if (typeof body !== "string") return body ?? null;
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return body;
+  }
+}
+
+/** The mock installed by `tests/setup.ts`; shared by every test. */
+export const fetchMock = new FetchMock();
+
+/** Install the stub. Called once from the global setup file. */
+export function installFetchMock(): void {
+  vi.stubGlobal("fetch", fetchMock.handler);
+}

--- a/tests/helpers/next-headers.ts
+++ b/tests/helpers/next-headers.ts
@@ -1,0 +1,65 @@
+/**
+ * In-memory stand-in for `next/headers`.
+ *
+ * Route handlers read the request through `cookies()`/`headers()` and write the
+ * session cookie back through the same store, so a test needs to both seed
+ * incoming values and inspect what the handler set. Mock it per test file with:
+ *
+ *   vi.mock("next/headers", () => import("../helpers/next-headers"));
+ */
+
+export interface SetCookie {
+  name: string;
+  value: string;
+  options: Record<string, unknown>;
+}
+
+class CookieJar {
+  private values = new Map<string, string>();
+  /** Cookies the handler wrote, in order — asserted on directly by tests. */
+  readonly set_: SetCookie[] = [];
+  readonly deleted: string[] = [];
+
+  get(name: string): { name: string; value: string } | undefined {
+    const value = this.values.get(name);
+    return value === undefined ? undefined : { name, value };
+  }
+
+  set(name: string, value: string, options: Record<string, unknown> = {}): void {
+    this.values.set(name, value);
+    this.set_.push({ name, value, options });
+  }
+
+  delete(name: string): void {
+    this.values.delete(name);
+    this.deleted.push(name);
+  }
+
+  seed(name: string, value: string): void {
+    this.values.set(name, value);
+  }
+
+  reset(): void {
+    this.values.clear();
+    this.set_.length = 0;
+    this.deleted.length = 0;
+  }
+}
+
+export const cookieJar = new CookieJar();
+export let requestHeaders = new Headers();
+
+/** Reset the store between tests and optionally seed incoming request headers. */
+export function resetNextHeaders(init?: HeadersInit): void {
+  cookieJar.reset();
+  requestHeaders = new Headers(init);
+}
+
+/** The cookie the handler most recently set under `name`. */
+export function lastSetCookie(name: string): SetCookie | undefined {
+  return [...cookieJar.set_].reverse().find((c) => c.name === name);
+}
+
+// The `next/headers` API surface the route handlers use. Both are async there.
+export const cookies = () => Promise.resolve(cookieJar);
+export const headers = () => Promise.resolve(requestHeaders);

--- a/tests/helpers/vipps.ts
+++ b/tests/helpers/vipps.ts
@@ -1,0 +1,64 @@
+import { PAYMENT_AMOUNT_ORE } from "~/server/payment/vipps";
+
+import { fetchMock, json } from "./fetch-mock";
+
+/**
+ * Canned Vipps ePayment responses.
+ *
+ * Every Vipps call starts with an access-token request, so `stubVipps()` always
+ * registers that leg — a test that forgets it would fail on the token call
+ * rather than on the behaviour it means to check.
+ */
+
+export const ORE = PAYMENT_AMOUNT_ORE;
+
+export type VippsState =
+  | "CREATED"
+  | "AUTHORIZED"
+  | "TERMINATED"
+  | "ABORTED"
+  | "EXPIRED";
+
+/** Build the `GET /epayment/v1/payments/{ref}` body Vipps returns. */
+export function vippsPayment(opts: {
+  state: VippsState;
+  authorized?: number;
+  captured?: number;
+  refunded?: number;
+  cancelled?: number;
+}) {
+  return {
+    state: opts.state,
+    aggregate: {
+      authorizedAmount: { value: opts.authorized ?? 0 },
+      capturedAmount: { value: opts.captured ?? 0 },
+      refundedAmount: { value: opts.refunded ?? 0 },
+      cancelledAmount: { value: opts.cancelled ?? 0 },
+    },
+  };
+}
+
+/** Register the access-token leg. Safe to call more than once per test. */
+export function stubVippsToken(): void {
+  fetchMock.on("POST", "/accesstoken/get", json({ access_token: "vipps-token" }));
+}
+
+/**
+ * Stub a full settle flow for one order: token, status lookup and capture.
+ * `capture` defaults to succeeding.
+ */
+export function stubVippsPayment(
+  orderId: string,
+  payment: ReturnType<typeof vippsPayment>,
+  opts: { captureStatus?: number } = {},
+): void {
+  stubVippsToken();
+  fetchMock.on("GET", `/epayment/v1/payments/${orderId}`, json(payment));
+  fetchMock.on(
+    "POST",
+    `/epayment/v1/payments/${orderId}/capture`,
+    opts.captureStatus && opts.captureStatus >= 400
+      ? json({ detail: "nope" }, opts.captureStatus)
+      : json({ ok: true }),
+  );
+}

--- a/tests/integration/activity-router.test.ts
+++ b/tests/integration/activity-router.test.ts
@@ -1,0 +1,193 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import { anonCaller, callerFor } from "../helpers/caller";
+import { createAdmin, createUser, db } from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+
+async function expectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toSatisfy(
+    (err: unknown) => err instanceof TRPCError && err.code === code,
+    `forventet TRPCError med kode ${code}`,
+  );
+}
+
+const localActivity = (overrides: Partial<{ title: string; date: Date }> = {}) => ({
+  title: overrides.title ?? "Grillfest",
+  description: "Beskrivelse",
+  location: "Samfundet",
+  date: overrides.date ?? new Date("2026-08-10T18:00:00Z"),
+});
+
+/** Stub the TIHLDE events endpoints: list + one detail per event. */
+function stubTihldeEvents(
+  events: { id: number; title: string; start_date: string; category: string }[],
+) {
+  fetchMock.on(
+    "GET",
+    "/events/",
+    json({
+      results: events.map((e) => ({
+        id: e.id,
+        title: e.title,
+        start_date: e.start_date,
+        location: "TIHLDE-kontoret",
+        image: "",
+        category: { id: 1, text: e.category },
+      })),
+    }),
+  );
+  for (const e of events) {
+    fetchMock.on(
+      "GET",
+      `/events/${e.id}/`,
+      json({
+        id: e.id,
+        title: e.title,
+        start_date: e.start_date,
+        location: "TIHLDE-kontoret",
+        image: "",
+        category: { id: 1, text: e.category },
+        description: "Fra TIHLDE",
+      }),
+    );
+  }
+}
+
+describe("activity.getUpcoming", () => {
+  it("fletter TIHLDE-arrangementer med lokale aktiviteter, sortert på dato", async () => {
+    await db.activity.create({
+      data: localActivity({ title: "Lokal", date: new Date("2026-08-10T18:00:00Z") }),
+    });
+    stubTihldeEvents([
+      { id: 1, title: "Fadderuka-event", start_date: "2026-08-09T18:00:00Z", category: "Fadderuka" },
+      { id: 2, title: "Annet", start_date: "2026-08-08T18:00:00Z", category: "Bedpres" },
+    ]);
+
+    const events = await anonCaller().activity.getUpcoming();
+
+    // Kun Fadderuka-kategorien fra TIHLDE, og lokal aktivitet sist (senest dato).
+    expect(events.map((e) => e.title)).toEqual(["Fadderuka-event", "Lokal"]);
+    expect(events.map((e) => e.source)).toEqual(["tihlde", "local"]);
+    // Tom bilde-streng fra TIHLDE skal bli null, ikke "".
+    expect(events[0]!.imageUrl).toBeNull();
+  });
+
+  it("viser lokale aktiviteter selv om TIHLDE er nede", async () => {
+    await db.activity.create({ data: localActivity({ title: "Lokal" }) });
+    fetchMock.on("GET", "/events/", text("service unavailable", 503));
+
+    const events = await anonCaller().activity.getUpcoming();
+
+    expect(events.map((e) => e.title)).toEqual(["Lokal"]);
+  });
+
+  it("hopper over arrangementer der detaljkallet feiler", async () => {
+    stubTihldeEvents([
+      { id: 1, title: "Ok", start_date: "2026-08-09T18:00:00Z", category: "Fadderuka" },
+    ]);
+    fetchMock.reset();
+    fetchMock.on(
+      "GET",
+      "/events/",
+      json({
+        results: [
+          {
+            id: 1,
+            title: "Ok",
+            start_date: "2026-08-09T18:00:00Z",
+            location: "",
+            image: null,
+            category: { id: 1, text: "Fadderuka" },
+          },
+        ],
+      }),
+    );
+    fetchMock.on("GET", "/events/1/", text("boom", 500));
+
+    await expect(anonCaller().activity.getUpcoming()).resolves.toEqual([]);
+  });
+});
+
+describe("activity: adminmutasjoner", () => {
+  it("oppretter, oppdaterer og sletter en aktivitet", async () => {
+    const admin = await createAdmin();
+    const caller = callerFor(admin);
+
+    const created = await caller.activity.create({
+      title: "Grillfest",
+      description: "Beskrivelse",
+      location: "Samfundet",
+      imageUrl: "",
+      date: "2026-08-10T18:00:00.000Z",
+    });
+    // Tom imageUrl er tillatt av skjemaet og skal lagres som null, ikke "".
+    expect(created.imageUrl).toBeNull();
+
+    const updated = await caller.activity.update({
+      id: created.id,
+      title: "Grillfest 2",
+      description: "Ny beskrivelse",
+      location: "Samfundet",
+      imageUrl: "https://example.com/bilde.png",
+      date: "2026-08-11T18:00:00.000Z",
+    });
+    expect(updated.title).toBe("Grillfest 2");
+    expect(updated.imageUrl).toBe("https://example.com/bilde.png");
+
+    await caller.activity.delete({ id: created.id });
+    expect(await db.activity.count()).toBe(0);
+  });
+
+  it("krever admin for å endre aktiviteter", async () => {
+    const user = await createUser();
+    const input = {
+      title: "Grillfest",
+      description: "Beskrivelse",
+      location: "Samfundet",
+      date: "2026-08-10T18:00:00.000Z",
+    };
+
+    await expectCode(callerFor(user).activity.create(input), "FORBIDDEN");
+    await expectCode(anonCaller().activity.create(input), "UNAUTHORIZED");
+    await expectCode(callerFor(user).activity.delete({ id: "x" }), "FORBIDDEN");
+    expect(await db.activity.count()).toBe(0);
+  });
+
+  it("avviser ugyldig dato og tom tittel", async () => {
+    const admin = await createAdmin();
+    const caller = callerFor(admin);
+
+    await expectCode(
+      caller.activity.create({
+        title: "",
+        description: "d",
+        location: "l",
+        date: "2026-08-10T18:00:00.000Z",
+      }),
+      "BAD_REQUEST",
+    );
+    await expectCode(
+      caller.activity.create({
+        title: "t",
+        description: "d",
+        location: "l",
+        date: "10. august",
+      }),
+      "BAD_REQUEST",
+    );
+  });
+
+  it("getAll er åpen og sorterer på dato", async () => {
+    await db.activity.create({
+      data: localActivity({ title: "Sen", date: new Date("2026-08-20T18:00:00Z") }),
+    });
+    await db.activity.create({
+      data: localActivity({ title: "Tidlig", date: new Date("2026-08-01T18:00:00Z") }),
+    });
+
+    const activities = await anonCaller().activity.getAll();
+
+    expect(activities.map((a) => a.title)).toEqual(["Tidlig", "Sen"]);
+  });
+});

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -1,0 +1,382 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import { appRouter } from "~/server/api/root";
+import { PAYMENT_AMOUNT_ORE } from "~/server/payment/vipps";
+
+import { anonCaller, callerFor } from "../helpers/caller";
+import {
+  addMember,
+  createAdmin,
+  createGruppe,
+  createPayment as seedPayment,
+  createUser,
+  db,
+} from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+import { stubVippsPayment, stubVippsToken, vippsPayment } from "../helpers/vipps";
+
+async function expectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toSatisfy(
+    (err: unknown) => err instanceof TRPCError && err.code === code,
+    `forventet TRPCError med kode ${code}`,
+  );
+}
+
+/**
+ * Every admin procedure, with an input that is valid enough to reach the
+ * authorization check. Driven off the router itself, so a newly added procedure
+ * that nobody listed here fails the "alle er dekket"-test below.
+ */
+const ADMIN_PROCEDURE_INPUTS: Record<string, unknown> = {
+  getUsers: undefined,
+  setUserVerified: { userId: "x", isVerified: true },
+  setUserAdmin: { userId: "x", isAdmin: true },
+  getGrupper: undefined,
+  createGruppe: { name: "Gruppe" },
+  updateGruppe: { gruppeId: "x", name: "Gruppe" },
+  deleteGruppe: { gruppeId: "x" },
+  addMember: { userId: "x", gruppeId: "y", role: "FADDER" },
+  removeMember: { membershipId: "x" },
+  updateMemberRole: { membershipId: "x", role: "FADDER" },
+  deleteUser: { userId: "x" },
+  verifyAndAssign: { userId: "x", gruppeId: "y" },
+  getRegistrations: undefined,
+  getPayments: undefined,
+  getPaymentDetails: { orderId: "x" },
+  refundPayment: { orderId: "x" },
+  syncPayments: undefined,
+  getPaymentAmount: undefined,
+};
+
+describe("tilgangskontroll på adminProcedure", () => {
+  it("dekker alle prosedyrene i admin-routeren", () => {
+    // Sikkerhetsnett: en ny adminprosedyre uten oppføring her ville ellers
+    // sluppet unna autorisasjonstestene under.
+    const declared = Object.keys(appRouter._def.procedures)
+      .filter((path) => path.startsWith("admin."))
+      .map((path) => path.slice("admin.".length));
+
+    expect(declared.sort()).toEqual(Object.keys(ADMIN_PROCEDURE_INPUTS).sort());
+  });
+
+  it.each(Object.entries(ADMIN_PROCEDURE_INPUTS))(
+    "admin.%s avviser vanlige brukere og uinnloggede",
+    async (name, input) => {
+      const user = await createUser();
+      const asUser = callerFor(user).admin as unknown as Record<
+        string,
+        (arg?: unknown) => Promise<unknown>
+      >;
+      const asAnon = anonCaller().admin as unknown as Record<
+        string,
+        (arg?: unknown) => Promise<unknown>
+      >;
+
+      await expectCode(asUser[name]!(input), "FORBIDDEN");
+      await expectCode(asAnon[name]!(input), "UNAUTHORIZED");
+      // Ingen av avvisningene skal ha rukket å ringe Vipps.
+      expect(fetchMock.calls).toHaveLength(0);
+    },
+  );
+});
+
+describe("admin: brukere og grupper", () => {
+  it("verifiserer og avverifiserer brukere", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+
+    await callerFor(admin).admin.setUserVerified({
+      userId: user.id,
+      isVerified: true,
+    });
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).isVerified,
+    ).toBe(true);
+  });
+
+  it("nekter å slette verifiserte brukere", async () => {
+    const admin = await createAdmin();
+    const verified = await createUser({ isVerified: true });
+
+    await expectCode(
+      callerFor(admin).admin.deleteUser({ userId: verified.id }),
+      "BAD_REQUEST",
+    );
+    expect(await db.user.count({ where: { id: verified.id } })).toBe(1);
+  });
+
+  it("sletter uverifiserte brukere med alle data", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    const gruppe = await createGruppe();
+    await addMember(user.id, gruppe.id, "FADDERBARN");
+    await seedPayment(user.id);
+
+    await callerFor(admin).admin.deleteUser({ userId: user.id });
+
+    expect(await db.user.count({ where: { id: user.id } })).toBe(0);
+    expect(await db.payment.count({ where: { userId: user.id } })).toBe(0);
+    expect(await db.fadderGruppeMember.count({ where: { userId: user.id } })).toBe(0);
+  });
+
+  it("gir NOT_FOUND for en ukjent bruker", async () => {
+    const admin = await createAdmin();
+    await expectCode(
+      callerFor(admin).admin.deleteUser({ userId: "finnes-ikke" }),
+      "NOT_FOUND",
+    );
+  });
+
+  it("avviser dobbelt medlemskap i samme gruppe", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    const gruppe = await createGruppe();
+    await callerFor(admin).admin.addMember({
+      userId: user.id,
+      gruppeId: gruppe.id,
+      role: "FADDERBARN",
+    });
+
+    await expectCode(
+      callerFor(admin).admin.addMember({
+        userId: user.id,
+        gruppeId: gruppe.id,
+        role: "FADDER",
+      }),
+      "CONFLICT",
+    );
+  });
+
+  it("verifyAndAssign er idempotent og bytter ikke rolle", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    const gruppe = await createGruppe();
+    await addMember(user.id, gruppe.id, "FADDER");
+
+    await callerFor(admin).admin.verifyAndAssign({
+      userId: user.id,
+      gruppeId: gruppe.id,
+    });
+
+    const memberships = await db.fadderGruppeMember.findMany({
+      where: { userId: user.id },
+    });
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0]!.role).toBe("FADDER");
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).isVerified,
+    ).toBe(true);
+  });
+
+  it("sletter gruppe med medlemskap og meldinger", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    const gruppe = await createGruppe();
+    await addMember(user.id, gruppe.id, "FADDER");
+    await db.groupMessage.create({
+      data: { content: "hei", authorId: user.id, gruppeId: gruppe.id },
+    });
+
+    await callerFor(admin).admin.deleteGruppe({ gruppeId: gruppe.id });
+
+    expect(await db.fadderGruppe.count()).toBe(0);
+    expect(await db.groupMessage.count()).toBe(0);
+    expect(await db.fadderGruppeMember.count()).toBe(0);
+  });
+});
+
+describe("admin.getRegistrations", () => {
+  it("teller kun fadderbarn — admins og faddere holdes utenfor", async () => {
+    const admin = await createAdmin();
+    const gruppe = await createGruppe();
+    const fadder = await createUser({ name: "Fadder" });
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    const fadderbarn = await createUser({ name: "Fadderbarn" });
+    await addMember(fadderbarn.id, gruppe.id, "FADDERBARN");
+    const utenGruppe = await createUser({ name: "Uten gruppe" });
+
+    const rows = await callerFor(admin).admin.getRegistrations();
+
+    expect(rows.map((r) => r.name).sort()).toEqual(["Fadderbarn", "Uten gruppe"]);
+    expect(rows.find((r) => r.id === fadderbarn.id)?.gruppe).toBe(gruppe.name);
+    expect(rows.find((r) => r.id === utenGruppe.id)?.gruppe).toBeNull();
+  });
+
+  it("rapporterer tidligste capture-tidspunkt og summerer beløpet", async () => {
+    const admin = await createAdmin();
+    const user = await createUser({ hasPaid: true });
+    const first = new Date("2026-07-01T10:00:00Z");
+    const second = new Date("2026-07-02T10:00:00Z");
+    await seedPayment(user.id, { status: "CAPTURED", capturedAt: second });
+    await seedPayment(user.id, { status: "CAPTURED", capturedAt: first });
+
+    const [row] = await callerFor(admin).admin.getRegistrations();
+
+    expect(row?.paidAt?.toISOString()).toBe(first.toISOString());
+    expect(row?.amountPaid).toBe(2 * PAYMENT_AMOUNT_ORE);
+    expect(row?.paymentStatus).toBe("CAPTURED");
+    expect(row?.attemptCount).toBe(2);
+  });
+
+  it("faller tilbake til siste forsøk når ingenting er trukket", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    await seedPayment(user.id, {
+      status: "ABORTED",
+      createdAt: new Date("2026-07-01T10:00:00Z"),
+    });
+    await seedPayment(user.id, {
+      status: "CREATED",
+      createdAt: new Date("2026-07-02T10:00:00Z"),
+    });
+
+    const [row] = await callerFor(admin).admin.getRegistrations();
+
+    expect(row?.paymentStatus).toBe("CREATED");
+    expect(row?.paidAt).toBeNull();
+    expect(row?.amountPaid).toBe(0);
+  });
+
+  it("teller ikke en refundert betaling som betalt", async () => {
+    const admin = await createAdmin();
+    const user = await createUser({ hasPaid: false });
+    await seedPayment(user.id, {
+      status: "REFUNDED",
+      capturedAt: new Date("2026-07-01T10:00:00Z"),
+    });
+
+    const [row] = await callerFor(admin).admin.getRegistrations();
+
+    expect(row?.paymentStatus).toBe("REFUNDED");
+    expect(row?.amountPaid).toBe(0);
+    expect(row?.paidAt).toBeNull();
+    expect(row?.hasPaid).toBe(false);
+  });
+});
+
+describe("admin: betalingsoperasjoner mot Vipps", () => {
+  it("refunderer en ordre og rapporterer hvem som fikk pengene tilbake", async () => {
+    const admin = await createAdmin();
+    const user = await createUser({ name: "Ola Nordmann", hasPaid: true });
+    const order = await seedPayment(user.id, { status: "CAPTURED" });
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      `/epayment/v1/payments/${order.orderId}`,
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+        }),
+      ),
+    );
+    fetchMock.on("POST", `/epayment/v1/payments/${order.orderId}/refund`, json({}));
+
+    await expect(
+      callerFor(admin).admin.refundPayment({ orderId: order.orderId }),
+    ).resolves.toEqual({ refunded: PAYMENT_AMOUNT_ORE, name: "Ola Nordmann" });
+  });
+
+  it("gir NOT_FOUND for en ukjent referanse uten å kontakte Vipps", async () => {
+    const admin = await createAdmin();
+
+    await expectCode(
+      callerFor(admin).admin.refundPayment({ orderId: "finnes-ikke" }),
+      "NOT_FOUND",
+    );
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("gir BAD_GATEWAY når Vipps avviser refusjonen", async () => {
+    const admin = await createAdmin();
+    const user = await createUser({ hasPaid: true });
+    const order = await seedPayment(user.id, { status: "CAPTURED" });
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      `/epayment/v1/payments/${order.orderId}`,
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+        }),
+      ),
+    );
+    fetchMock.on(
+      "POST",
+      `/epayment/v1/payments/${order.orderId}/refund`,
+      text("nope", 500),
+    );
+
+    await expectCode(
+      callerFor(admin).admin.refundPayment({ orderId: order.orderId }),
+      "BAD_GATEWAY",
+    );
+  });
+
+  it("syncPayments teller sjekkede, oppgjorte og feilende ordrer", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    const ok = await seedPayment(user.id, {
+      status: "AUTHORIZED",
+      createdAt: new Date(Date.now() - 60_000),
+    });
+    const broken = await seedPayment(user.id, { status: "CREATED" });
+    // En allerede trukket ordre skal ikke plukkes opp i det hele tatt.
+    await seedPayment(user.id, { status: "CAPTURED", capturedAt: new Date() });
+
+    stubVippsPayment(
+      ok.orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+    fetchMock.on("GET", `/epayment/v1/payments/${broken.orderId}`, text("boom", 500));
+
+    await expect(callerFor(admin).admin.syncPayments()).resolves.toEqual({
+      checked: 2,
+      settled: 1,
+      failed: 1,
+    });
+  });
+
+  it("henter live status og hendelseslogg for én ordre", async () => {
+    const admin = await createAdmin();
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      "/epayment/v1/payments/ref-1",
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+        }),
+      ),
+    );
+    fetchMock.on(
+      "GET",
+      "/epayment/v1/payments/ref-1/events",
+      json([{ name: "CAPTURE", timestamp: "2026-07-01T10:00:00Z" }]),
+    );
+
+    const result = await callerFor(admin).admin.getPaymentDetails({
+      orderId: "ref-1",
+    });
+
+    expect(result.snapshot.captured).toBe(PAYMENT_AMOUNT_ORE);
+    expect(result.events).toHaveLength(1);
+  });
+
+  it("eksponerer prisen så klienten slipper å hardkode beløpet", async () => {
+    const admin = await createAdmin();
+    await expect(callerFor(admin).admin.getPaymentAmount()).resolves.toEqual({
+      amountOre: PAYMENT_AMOUNT_ORE,
+    });
+  });
+});

--- a/tests/integration/auth-login.route.test.ts
+++ b/tests/integration/auth-login.route.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as login } from "~/app/api/auth/login/route";
+import { SESSION_COOKIE } from "~/server/auth/config";
+
+import { createUser, db } from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+import { lastSetCookie, resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+const post = (body: unknown) =>
+  login(
+    new Request("https://fadderuka.test/api/auth/login", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+
+const CREDENTIALS = { user_id: "olanor", password: "hemmelig" };
+
+const PROFILE = {
+  user_id: "olanor",
+  first_name: "Ola",
+  last_name: "Nordmann",
+  email: "ola@stud.ntnu.no",
+  image: "https://tihlde.test/ola.png",
+  study: { group: { name: "Dataingeniør" } },
+  studyyear: { group: { name: "2026" } },
+};
+
+/** Stub the whole TIHLDE login chain: token, profile, permissions, memberships. */
+function stubTihldeLogin(opts: {
+  permissions?: Record<string, { read?: boolean; write?: boolean }>;
+  memberships?: { group: { slug: string } }[];
+} = {}) {
+  fetchMock.on("POST", "/auth/login/", json({ token: "tihlde-token" }));
+  fetchMock.on("GET", "/users/me/", json(PROFILE));
+  fetchMock.on(
+    "GET",
+    "/users/me/permissions/",
+    json({ permissions: opts.permissions ?? { event: { read: true } } }),
+  );
+  fetchMock.on(
+    "GET",
+    "/users/olanor/memberships/",
+    json({ results: opts.memberships ?? [] }),
+  );
+}
+
+beforeEach(() => {
+  resetNextHeaders({ "user-agent": "vitest", "x-forwarded-for": "10.0.0.1, 10.0.0.2" });
+});
+
+describe("POST /api/auth/login", () => {
+  it("oppretter bruker og sesjon, og setter en httpOnly-cookie", async () => {
+    stubTihldeLogin();
+
+    const response = await post(CREDENTIALS);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, verified: false });
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.name).toBe("Ola Nordmann");
+    expect(user.studieretning).toBe("Dataingeniør");
+    expect(user.klasse).toBe("2026");
+    expect(user.isAdmin).toBe(false);
+
+    const session = await db.session.findFirstOrThrow({ where: { userId: user.id } });
+    expect(session.tihldeToken).toBe("tihlde-token");
+    // Kun første ledd av x-forwarded-for skal lagres.
+    expect(session.ipAddress).toBe("10.0.0.1");
+    expect(session.userAgent).toBe("vitest");
+
+    const cookie = lastSetCookie(SESSION_COOKIE);
+    expect(cookie?.value).toBe(session.token);
+    expect(cookie?.options).toMatchObject({ httpOnly: true, sameSite: "lax", path: "/" });
+  });
+
+  it("gjør skrivetilgang i TIHLDE til app-admin, verifisert og betalt", async () => {
+    stubTihldeLogin({ permissions: { event: { read: true, write: true } } });
+
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isAdmin).toBe(true);
+    expect(user.isVerified).toBe(true);
+    expect(user.hasPaid).toBe(true);
+  });
+
+  it("gjør FadderKom-medlemmer til admin", async () => {
+    stubTihldeLogin({ memberships: [{ group: { slug: "fadderkom" } }] });
+
+    await post(CREDENTIALS);
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } })).isAdmin,
+    ).toBe(true);
+  });
+
+  it("fratar en vanlig innlogging admin-status", async () => {
+    await createUser({ tihldeUserId: "olanor", isAdmin: true });
+    stubTihldeLogin();
+
+    await post(CREDENTIALS);
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } })).isAdmin,
+    ).toBe(false);
+  });
+
+  it("beholder eksisterende admin når TIHLDE-oppslaget feiler", async () => {
+    await createUser({ tihldeUserId: "olanor", isAdmin: true, isVerified: true });
+    fetchMock.on("POST", "/auth/login/", json({ token: "tihlde-token" }));
+    fetchMock.on("GET", "/users/me/", json(PROFILE));
+    fetchMock.on("GET", "/users/me/permissions/", text("boom", 500));
+    fetchMock.on("GET", "/users/olanor/memberships/", text("boom", 500));
+
+    const response = await post(CREDENTIALS);
+
+    // Innloggingen skal gå igjennom, og admin-flagget stå urørt.
+    expect(response.status).toBe(200);
+    const user = await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } });
+    expect(user.isAdmin).toBe(true);
+  });
+
+  it("beholder betalingsstatusen til en vanlig bruker ved ny innlogging", async () => {
+    await createUser({ tihldeUserId: "olanor", hasPaid: true, isVerified: true });
+    stubTihldeLogin();
+
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } });
+    expect(user.hasPaid).toBe(true);
+    expect(user.isVerified).toBe(true);
+  });
+
+  it("videreformidler TIHLDEs feilmelding ved feil passord", async () => {
+    fetchMock.on(
+      "POST",
+      "/auth/login/",
+      json({ detail: "Brukernavnet eller passordet ditt var feil." }, 401),
+    );
+
+    const response = await post(CREDENTIALS);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "Brukernavnet eller passordet ditt var feil.",
+    });
+    expect(await db.session.count()).toBe(0);
+  });
+
+  it("gir 502 når TIHLDE svarer med en serverfeil", async () => {
+    fetchMock.on("POST", "/auth/login/", text("boom", 500));
+
+    expect((await post(CREDENTIALS)).status).toBe(502);
+  });
+
+  it("avviser tomt skjema uten å kontakte TIHLDE", async () => {
+    const response = await post({ user_id: "", password: "" });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+});

--- a/tests/integration/auth-register.route.test.ts
+++ b/tests/integration/auth-register.route.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as register } from "~/app/api/auth/register/route";
+import { SESSION_COOKIE } from "~/server/auth/config";
+
+import { createUser, db } from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+import { lastSetCookie, resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+const post = (body: unknown) =>
+  register(
+    new Request("https://fadderuka.test/api/auth/register", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+
+const FORM = {
+  full_name: "Ola Nordmann",
+  email: "ola@stud.ntnu.no",
+  user_id: "OlaNor",
+  password: "hemmeligpassord",
+  study: "dataingenir",
+};
+
+beforeEach(() => {
+  resetNextHeaders({ "user-agent": "vitest" });
+});
+
+describe("POST /api/auth/register", () => {
+  it("oppretter TIHLDE-konto, lokal bruker og sesjon", async () => {
+    fetchMock.on("POST", "/users/", json({}, 201));
+
+    const response = await post(FORM);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+
+    // Brukernavnet skal sendes i småbokstaver, og navnet splittes for Lepton.
+    const [call] = fetchMock.callsTo("/users/");
+    expect(call?.body).toMatchObject({
+      user_id: "olanor",
+      first_name: "Ola",
+      last_name: "Nordmann",
+      email: "ola@stud.ntnu.no",
+      study: "dataingenir",
+      class: null,
+    });
+
+    const user = await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } });
+    expect(user.studieretning).toBe("Dataingeniør");
+    expect(user.hasPaid).toBe(false);
+    expect(user.isVerified).toBe(false);
+    expect(user.isAdmin).toBe(false);
+
+    // Kontoen er ikke aktivert ennå, så sesjonen har ikke noe TIHLDE-token.
+    const session = await db.session.findFirstOrThrow({ where: { userId: user.id } });
+    expect(session.tihldeToken).toBeNull();
+    expect(lastSetCookie(SESSION_COOKIE)?.value).toBe(session.token);
+  });
+
+  it("bruker fornavnet som etternavn når navnet er ett ord", async () => {
+    fetchMock.on("POST", "/users/", json({}, 201));
+
+    await post({ ...FORM, full_name: "Ola" });
+
+    const [call] = fetchMock.callsTo("/users/");
+    expect(call?.body).toMatchObject({ first_name: "Ola", last_name: "Ola" });
+  });
+
+  it("lagrer aldri passordet lokalt", async () => {
+    fetchMock.on("POST", "/users/", json({}, 201));
+
+    await post(FORM);
+
+    const user = await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } });
+    expect(JSON.stringify(user)).not.toContain("hemmeligpassord");
+  });
+
+  it("peker på brukernavn-feltet når brukernavnet er opptatt", async () => {
+    fetchMock.on("POST", "/users/", json({ detail: { user_id: ["finnes"] } }, 400));
+
+    const response = await post(FORM);
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { field?: string; error?: string };
+    expect(body.field).toBe("user_id");
+    expect(body.error).toContain("Brukernavnet er opptatt");
+    expect(await db.user.count()).toBe(0);
+  });
+
+  it("peker på e-postfeltet når Lepton klager på e-posten", async () => {
+    fetchMock.on(
+      "POST",
+      "/users/",
+      json({ email: ["Ugyldig e-postadresse."] }, 400),
+    );
+
+    const response = await post(FORM);
+
+    await expect(response.json()).resolves.toMatchObject({ field: "email" });
+  });
+
+  it("gir 502 når Lepton feiler", async () => {
+    fetchMock.on("POST", "/users/", text("boom", 500));
+
+    expect((await post(FORM)).status).toBe(502);
+  });
+
+  it.each([
+    ["for kort passord", { password: "kort" }],
+    ["brukernavn med @", { user_id: "ola@stud.ntnu.no" }],
+    ["brukernavn over 15 tegn", { user_id: "a".repeat(16) }],
+    ["ugyldig e-post", { email: "ikke-en-epost" }],
+    ["ukjent linje", { study: "finnes-ikke" }],
+    ["tomt navn", { full_name: "   " }],
+  ])("avviser %s uten å kontakte TIHLDE", async (_label, override) => {
+    const response = await post({ ...FORM, ...override });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock.calls).toHaveLength(0);
+    expect(await db.user.count()).toBe(0);
+  });
+
+  it("oppdaterer en eksisterende lokal bruker i stedet for å duplisere", async () => {
+    await createUser({ tihldeUserId: "olanor", name: "Gammelt Navn", email: null });
+    fetchMock.on("POST", "/users/", json({}, 201));
+
+    await post(FORM);
+
+    expect(await db.user.count()).toBe(1);
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } })).name,
+    ).toBe("Ola Nordmann");
+  });
+});

--- a/tests/integration/auth-session.route.test.ts
+++ b/tests/integration/auth-session.route.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as logout } from "~/app/api/auth/logout/route";
+import { POST as saveAllergy } from "~/app/api/profile/allergy/route";
+import {
+  SESSION_COOKIE,
+  auth,
+  createSession,
+  deleteSession,
+} from "~/server/auth/config";
+
+import { createUser, db } from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+import { cookieJar, resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+beforeEach(() => {
+  resetNextHeaders();
+});
+
+describe("sesjonslaget", () => {
+  it("finner en gyldig sesjon fra cookien", async () => {
+    const user = await createUser();
+    const { token } = await createSession({ userId: user.id, tihldeToken: "t" });
+
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: `${SESSION_COOKIE}=${token}; annet=verdi` }),
+    });
+
+    expect(session?.user.id).toBe(user.id);
+    expect(session?.session.tihldeToken).toBe("t");
+  });
+
+  it("gir null uten cookie eller med ukjent token", async () => {
+    await expect(auth.api.getSession({ headers: new Headers() })).resolves.toBeNull();
+    await expect(
+      auth.api.getSession({
+        headers: new Headers({ cookie: `${SESSION_COOKIE}=finnes-ikke` }),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("avviser og rydder bort en utløpt sesjon", async () => {
+    const user = await createUser();
+    const { token } = await createSession({ userId: user.id });
+    await db.session.update({
+      where: { token },
+      data: { expiresAt: new Date(Date.now() - 1000) },
+    });
+
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: `${SESSION_COOKIE}=${token}` }),
+    });
+
+    expect(session).toBeNull();
+    expect(await db.session.count({ where: { token } })).toBe(0);
+  });
+
+  it("gir hver sesjon et unikt token", async () => {
+    const user = await createUser();
+    const a = await createSession({ userId: user.id });
+    const b = await createSession({ userId: user.id });
+
+    expect(a.token).not.toBe(b.token);
+    expect(a.token).toHaveLength(64);
+  });
+
+  it("deleteSession fjerner sesjonen", async () => {
+    const user = await createUser();
+    const { token } = await createSession({ userId: user.id });
+
+    await deleteSession(token);
+
+    expect(await db.session.count()).toBe(0);
+  });
+});
+
+describe("POST /api/auth/logout", () => {
+  it("sletter sesjonsraden og cookien", async () => {
+    const user = await createUser();
+    const { token } = await createSession({ userId: user.id });
+    cookieJar.seed(SESSION_COOKIE, token);
+
+    const response = await logout();
+
+    expect(response.status).toBe(200);
+    expect(await db.session.count()).toBe(0);
+    expect(cookieJar.deleted).toContain(SESSION_COOKIE);
+  });
+
+  it("er trygg å kalle uten sesjon", async () => {
+    const response = await logout();
+
+    expect(response.status).toBe(200);
+    expect(cookieJar.deleted).toContain(SESSION_COOKIE);
+  });
+});
+
+describe("POST /api/profile/allergy", () => {
+  const post = (body: unknown) =>
+    saveAllergy(
+      new Request("https://fadderuka.test/api/profile/allergy", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    );
+
+  async function signIn(tihldeToken: string | null) {
+    const user = await createUser({ tihldeUserId: "olanor" });
+    const { token } = await createSession({ userId: user.id, tihldeToken });
+    resetNextHeaders({ cookie: `${SESSION_COOKIE}=${token}` });
+    return user;
+  }
+
+  it("skriver allergien til TIHLDE når sesjonen har token", async () => {
+    await signIn("tihlde-token");
+    fetchMock.on("PATCH", "/users/olanor/", json({}));
+
+    const response = await post({ allergy: "Nøtter" });
+
+    await expect(response.json()).resolves.toEqual({ synced: true });
+    const [call] = fetchMock.callsTo("/users/olanor/");
+    expect(call?.body).toEqual({ allergy: "Nøtter" });
+    expect(call?.headers["x-csrf-token"]).toBe("tihlde-token");
+  });
+
+  it("ber klienten beholde bufferen når kontoen ikke er aktivert", async () => {
+    await signIn(null);
+
+    const response = await post({ allergy: "Nøtter" });
+
+    await expect(response.json()).resolves.toEqual({ synced: false });
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("krever innlogging", async () => {
+    resetNextHeaders();
+
+    expect((await post({ allergy: "Nøtter" })).status).toBe(401);
+  });
+
+  it("avviser tom allergi", async () => {
+    await signIn("tihlde-token");
+
+    expect((await post({ allergy: "  " })).status).toBe(400);
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("videreformidler TIHLDEs statuskode ved feil", async () => {
+    await signIn("tihlde-token");
+    fetchMock.on("PATCH", "/users/olanor/", text("nope", 403));
+
+    expect((await post({ allergy: "Nøtter" })).status).toBe(403);
+  });
+});

--- a/tests/integration/gruppe-router.test.ts
+++ b/tests/integration/gruppe-router.test.ts
@@ -1,0 +1,259 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import { anonCaller, callerFor } from "../helpers/caller";
+import {
+  addMember,
+  createAdmin,
+  createGruppe,
+  createUser,
+  db,
+} from "../helpers/db";
+
+async function expectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toSatisfy(
+    (err: unknown) => err instanceof TRPCError && err.code === code,
+    `forventet TRPCError med kode ${code}`,
+  );
+}
+
+describe("gruppe.getMyGruppe", () => {
+  it("gir medlemskapet med alle gruppemedlemmene", async () => {
+    const gruppe = await createGruppe("Gruppe 1");
+    const fadder = await createUser({ name: "Fadder" });
+    const barn = await createUser({ name: "Barn" });
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    await addMember(barn.id, gruppe.id, "FADDERBARN");
+
+    const membership = await callerFor(barn).gruppe.getMyGruppe();
+
+    expect(membership?.role).toBe("FADDERBARN");
+    expect(membership?.gruppe.name).toBe("Gruppe 1");
+    expect(membership?.gruppe.members.map((m) => m.user.name).sort()).toEqual([
+      "Barn",
+      "Fadder",
+    ]);
+  });
+
+  it("gir null for en bruker uten gruppe", async () => {
+    const user = await createUser();
+    await expect(callerFor(user).gruppe.getMyGruppe()).resolves.toBeNull();
+  });
+
+  it("krever innlogging", async () => {
+    await expectCode(anonCaller().gruppe.getMyGruppe(), "UNAUTHORIZED");
+  });
+});
+
+describe("gruppe.getMessages", () => {
+  it("gir bare meldingene i den valgte kanalen", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    await db.groupMessage.createMany({
+      data: [
+        { content: "kunngjøring", authorId: fadder.id, gruppeId: gruppe.id, channel: "ANNOUNCEMENT" },
+        { content: "chat", authorId: fadder.id, gruppeId: gruppe.id, channel: "CHAT" },
+      ],
+    });
+
+    const messages = await callerFor(fadder).gruppe.getMessages({
+      gruppeId: gruppe.id,
+      channel: "CHAT",
+    });
+
+    expect(messages.map((m) => m.content)).toEqual(["chat"]);
+  });
+
+  it("stenger ute brukere som ikke er medlem", async () => {
+    const gruppe = await createGruppe();
+    const outsider = await createUser();
+
+    await expectCode(
+      callerFor(outsider).gruppe.getMessages({
+        gruppeId: gruppe.id,
+        channel: "CHAT",
+      }),
+      "FORBIDDEN",
+    );
+  });
+
+  it("slipper admin inn i alle grupper", async () => {
+    const gruppe = await createGruppe();
+    const admin = await createAdmin();
+
+    await expect(
+      callerFor(admin).gruppe.getMessages({
+        gruppeId: gruppe.id,
+        channel: "CHAT",
+      }),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("gruppe.postMessage", () => {
+  it("lar en fadder poste kunngjøringer", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+
+    const created = await callerFor(fadder).gruppe.postMessage({
+      gruppeId: gruppe.id,
+      content: "Oppmøte kl 18",
+      channel: "ANNOUNCEMENT",
+    });
+
+    expect(created.content).toBe("Oppmøte kl 18");
+    expect(created.author.id).toBe(fadder.id);
+  });
+
+  it("lar et fadderbarn chatte, men ikke kunngjøre", async () => {
+    const gruppe = await createGruppe();
+    const barn = await createUser();
+    await addMember(barn.id, gruppe.id, "FADDERBARN");
+    const caller = callerFor(barn);
+
+    await expect(
+      caller.gruppe.postMessage({
+        gruppeId: gruppe.id,
+        content: "hei",
+        channel: "CHAT",
+      }),
+    ).resolves.toMatchObject({ channel: "CHAT" });
+
+    await expectCode(
+      caller.gruppe.postMessage({
+        gruppeId: gruppe.id,
+        content: "hei",
+        channel: "ANNOUNCEMENT",
+      }),
+      "FORBIDDEN",
+    );
+  });
+
+  it("stenger ute brukere som ikke er medlem", async () => {
+    const gruppe = await createGruppe();
+    const outsider = await createUser();
+
+    await expectCode(
+      callerFor(outsider).gruppe.postMessage({
+        gruppeId: gruppe.id,
+        content: "hei",
+        channel: "CHAT",
+      }),
+      "FORBIDDEN",
+    );
+    expect(await db.groupMessage.count()).toBe(0);
+  });
+
+  it("varsler de andre medlemmene, men ikke avsenderen", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser({ name: "Kari" });
+    const barn1 = await createUser();
+    const barn2 = await createUser();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    await addMember(barn1.id, gruppe.id, "FADDERBARN");
+    await addMember(barn2.id, gruppe.id, "FADDERBARN");
+
+    await callerFor(fadder).gruppe.postMessage({
+      gruppeId: gruppe.id,
+      content: "Oppmøte kl 18",
+      channel: "ANNOUNCEMENT",
+    });
+
+    const notifications = await db.notification.findMany();
+    expect(notifications).toHaveLength(2);
+    expect(notifications.map((n) => n.userId).sort()).toEqual(
+      [barn1.id, barn2.id].sort(),
+    );
+    expect(notifications[0]!.message).toContain("Kari");
+    expect(notifications[0]!.message).toContain("kunngjøring");
+  });
+
+  it("merker chat-varsler som melding", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser();
+    const barn = await createUser();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    await addMember(barn.id, gruppe.id, "FADDERBARN");
+
+    await callerFor(fadder).gruppe.postMessage({
+      gruppeId: gruppe.id,
+      content: "hei",
+      channel: "CHAT",
+    });
+
+    const notification = await db.notification.findFirstOrThrow();
+    expect(notification.message).toContain("melding");
+  });
+
+  it("avviser tomme og altfor lange meldinger", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    const caller = callerFor(fadder);
+
+    await expectCode(
+      caller.gruppe.postMessage({ gruppeId: gruppe.id, content: "" }),
+      "BAD_REQUEST",
+    );
+    await expectCode(
+      caller.gruppe.postMessage({ gruppeId: gruppe.id, content: "a".repeat(2001) }),
+      "BAD_REQUEST",
+    );
+  });
+});
+
+describe("gruppe.deleteMessage", () => {
+  it("lar forfatteren slette sin egen melding", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    const message = await db.groupMessage.create({
+      data: { content: "hei", authorId: fadder.id, gruppeId: gruppe.id },
+    });
+
+    await callerFor(fadder).gruppe.deleteMessage({ messageId: message.id });
+
+    expect(await db.groupMessage.count()).toBe(0);
+  });
+
+  it("lar admin slette andres meldinger", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser();
+    const admin = await createAdmin();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    const message = await db.groupMessage.create({
+      data: { content: "hei", authorId: fadder.id, gruppeId: gruppe.id },
+    });
+
+    await callerFor(admin).gruppe.deleteMessage({ messageId: message.id });
+
+    expect(await db.groupMessage.count()).toBe(0);
+  });
+
+  it("nekter andre medlemmer å slette", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createUser();
+    const barn = await createUser();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    await addMember(barn.id, gruppe.id, "FADDERBARN");
+    const message = await db.groupMessage.create({
+      data: { content: "hei", authorId: fadder.id, gruppeId: gruppe.id },
+    });
+
+    await expectCode(
+      callerFor(barn).gruppe.deleteMessage({ messageId: message.id }),
+      "FORBIDDEN",
+    );
+    expect(await db.groupMessage.count()).toBe(1);
+  });
+
+  it("gir NOT_FOUND for en melding som ikke finnes", async () => {
+    const user = await createUser();
+    await expectCode(
+      callerFor(user).gruppe.deleteMessage({ messageId: "finnes-ikke" }),
+      "NOT_FOUND",
+    );
+  });
+});

--- a/tests/integration/notification-router.test.ts
+++ b/tests/integration/notification-router.test.ts
@@ -1,0 +1,87 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import { anonCaller, callerFor } from "../helpers/caller";
+import { createGruppe, createUser, db } from "../helpers/db";
+
+async function expectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toSatisfy(
+    (err: unknown) => err instanceof TRPCError && err.code === code,
+    `forventet TRPCError med kode ${code}`,
+  );
+}
+
+async function notify(userId: string, gruppeId: string, message: string, read = false) {
+  return db.notification.create({ data: { userId, gruppeId, message, read } });
+}
+
+describe("notification", () => {
+  it("lister bare brukerens egne varsler, nyeste først", async () => {
+    const gruppe = await createGruppe();
+    const user = await createUser();
+    const other = await createUser();
+    await notify(user.id, gruppe.id, "første");
+    await notify(user.id, gruppe.id, "andre");
+    await notify(other.id, gruppe.id, "andres");
+
+    const list = await callerFor(user).notification.list();
+
+    expect(list.map((n) => n.message)).toEqual(["andre", "første"]);
+  });
+
+  it("teller bare uleste varsler", async () => {
+    const gruppe = await createGruppe();
+    const user = await createUser();
+    await notify(user.id, gruppe.id, "ulest");
+    await notify(user.id, gruppe.id, "lest", true);
+
+    await expect(callerFor(user).notification.unreadCount()).resolves.toBe(1);
+  });
+
+  it("markerer ett varsel som lest", async () => {
+    const gruppe = await createGruppe();
+    const user = await createUser();
+    const notification = await notify(user.id, gruppe.id, "hei");
+
+    await callerFor(user).notification.markRead({ id: notification.id });
+
+    expect(
+      (await db.notification.findUniqueOrThrow({ where: { id: notification.id } })).read,
+    ).toBe(true);
+  });
+
+  it("kan ikke markere en annens varsel som lest", async () => {
+    const gruppe = await createGruppe();
+    const user = await createUser();
+    const other = await createUser();
+    const notification = await notify(other.id, gruppe.id, "hei");
+
+    // updateMany er scopet på userId, så kallet lykkes men treffer ingenting.
+    await expect(
+      callerFor(user).notification.markRead({ id: notification.id }),
+    ).resolves.toEqual({ count: 0 });
+    expect(
+      (await db.notification.findUniqueOrThrow({ where: { id: notification.id } })).read,
+    ).toBe(false);
+  });
+
+  it("markerer alle egne varsler som lest, og ingen andres", async () => {
+    const gruppe = await createGruppe();
+    const user = await createUser();
+    const other = await createUser();
+    await notify(user.id, gruppe.id, "a");
+    await notify(user.id, gruppe.id, "b");
+    await notify(other.id, gruppe.id, "c");
+
+    await callerFor(user).notification.markAllRead();
+
+    expect(await db.notification.count({ where: { read: false } })).toBe(1);
+    expect(await db.notification.count({ where: { userId: other.id, read: false } })).toBe(1);
+  });
+
+  it("krever innlogging", async () => {
+    await expectCode(anonCaller().notification.list(), "UNAUTHORIZED");
+    await expectCode(anonCaller().notification.unreadCount(), "UNAUTHORIZED");
+    await expectCode(anonCaller().notification.markAllRead(), "UNAUTHORIZED");
+  });
+});

--- a/tests/integration/payment-router.test.ts
+++ b/tests/integration/payment-router.test.ts
@@ -1,0 +1,182 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import { PAYMENT_AMOUNT_ORE } from "~/server/payment/vipps";
+
+import { anonCaller, callerFor } from "../helpers/caller";
+import { createPayment as seedPayment, createUser, db } from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+import { stubVippsPayment, stubVippsToken, vippsPayment } from "../helpers/vipps";
+
+/** Assert that a tRPC call rejects with a specific error code. */
+async function expectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toSatisfy(
+    (err: unknown) => err instanceof TRPCError && err.code === code,
+    `forventet TRPCError med kode ${code}`,
+  );
+}
+
+describe("payment.getStatus", () => {
+  it("speiler brukerens betalings- og verifiseringsstatus", async () => {
+    const user = await createUser({ hasPaid: true, isVerified: true });
+    await expect(callerFor(user).payment.getStatus()).resolves.toEqual({
+      hasPaid: true,
+      isVerified: true,
+    });
+  });
+
+  it("krever innlogging", async () => {
+    await expectCode(anonCaller().payment.getStatus(), "UNAUTHORIZED");
+  });
+});
+
+describe("payment.initiatePayment", () => {
+  it("oppretter en ordre og returnerer Vipps' redirect-URL", async () => {
+    const user = await createUser({ name: "Ola Nordmann" });
+    stubVippsToken();
+    fetchMock.on(
+      "POST",
+      "/epayment/v1/payments",
+      json({ redirectUrl: "https://vipps.test/checkout/abc" }),
+    );
+
+    const result = await callerFor(user).payment.initiatePayment();
+
+    expect(result.redirectUrl).toBe("https://vipps.test/checkout/abc");
+
+    const order = await db.payment.findFirstOrThrow({ where: { userId: user.id } });
+    expect(order.amount).toBe(PAYMENT_AMOUNT_ORE);
+    expect(order.status).toBe("CREATED");
+    expect(order.orderId).toContain(user.id);
+
+    // Navnet må følge med, ellers ser ikke admin hvem som betalte i Vipps-portalen.
+    const [call] = fetchMock.callsTo("/epayment/v1/payments");
+    expect(call?.body).toMatchObject({
+      paymentDescription: "Ola Nordmann - Fadderuka",
+    });
+  });
+
+  it("avviser brukere som allerede har betalt", async () => {
+    const user = await createUser({ hasPaid: true });
+    await expectCode(callerFor(user).payment.initiatePayment(), "BAD_REQUEST");
+    expect(await db.payment.count()).toBe(0);
+  });
+
+  it("gir BAD_GATEWAY når Vipps svarer med feil", async () => {
+    const user = await createUser();
+    stubVippsToken();
+    fetchMock.on("POST", "/epayment/v1/payments", text("boom", 500));
+
+    await expectCode(callerFor(user).payment.initiatePayment(), "BAD_GATEWAY");
+    // Ingen ordre skal lagres når Vipps aldri opprettet betalingen.
+    expect(await db.payment.count()).toBe(0);
+  });
+
+  it("krever innlogging", async () => {
+    await expectCode(anonCaller().payment.initiatePayment(), "UNAUTHORIZED");
+  });
+});
+
+describe("payment.confirmPayment", () => {
+  it("bekrefter en betaling som Vipps rapporterer som trukket", async () => {
+    const user = await createUser();
+    const orderId = `fadderuka-${user.id}-${Date.now()}`;
+    await seedPayment(user.id, { orderId });
+    stubVippsPayment(
+      orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+
+    await expect(
+      callerFor(user).payment.confirmPayment({ orderId }),
+    ).resolves.toEqual({ success: true });
+    expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid).toBe(true);
+  });
+
+  it("nekter å bekrefte en annen brukers ordre", async () => {
+    const user = await createUser();
+    const other = await createUser();
+    const orderId = `fadderuka-${other.id}-${Date.now()}`;
+
+    await expectCode(
+      callerFor(user).payment.confirmPayment({ orderId }),
+      "FORBIDDEN",
+    );
+    // Sikkerhetsgrensen skal slå til før vi i det hele tatt ringer Vipps.
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("gir BAD_REQUEST når Vipps ikke har trukket betalingen", async () => {
+    const user = await createUser();
+    const orderId = `fadderuka-${user.id}-${Date.now()}`;
+    await seedPayment(user.id, { orderId });
+    stubVippsPayment(orderId, vippsPayment({ state: "ABORTED" }));
+
+    await expectCode(
+      callerFor(user).payment.confirmPayment({ orderId }),
+      "BAD_REQUEST",
+    );
+  });
+});
+
+describe("payment.checkMyPayment", () => {
+  it("finner en betaling blant brukerens egne åpne ordrer", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id, { status: "AUTHORIZED" });
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+
+    await expect(callerFor(user).payment.checkMyPayment()).resolves.toEqual({
+      found: true,
+    });
+  });
+
+  it("lar én feilende ordre ikke stoppe resten av sjekken", async () => {
+    const user = await createUser();
+    // Nyeste først i løkka: den feilende sjekkes før den gyldige.
+    const good = await seedPayment(user.id, {
+      status: "AUTHORIZED",
+      createdAt: new Date(Date.now() - 60_000),
+    });
+    const broken = await seedPayment(user.id, { status: "CREATED" });
+
+    stubVippsToken();
+    fetchMock.on("GET", `/epayment/v1/payments/${broken.orderId}`, text("boom", 500));
+    fetchMock.on(
+      "GET",
+      `/epayment/v1/payments/${good.orderId}`,
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+        }),
+      ),
+    );
+
+    await expect(callerFor(user).payment.checkMyPayment()).resolves.toEqual({
+      found: true,
+    });
+  });
+
+  it("ser ikke på andre brukeres ordrer", async () => {
+    const user = await createUser();
+    const other = await createUser();
+    await seedPayment(other.id, { status: "AUTHORIZED" });
+
+    await expect(callerFor(user).payment.checkMyPayment()).resolves.toEqual({
+      found: false,
+    });
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+});

--- a/tests/integration/tihlde-client.test.ts
+++ b/tests/integration/tihlde-client.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TihldeAuthError,
+  isAdminFromPermissions,
+  isMemberOfGroup,
+  mapProfile,
+  tihldeCreateUser,
+  tihldeGetMe,
+  tihldeGetMemberships,
+  tihldeGetPermissions,
+  tihldeLogin,
+} from "~/server/auth/tihlde";
+
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+
+describe("tihldeLogin", () => {
+  it("sender legitimasjonen og returnerer tokenet", async () => {
+    fetchMock.on("POST", "/auth/login/", json({ token: "abc" }));
+
+    await expect(tihldeLogin("olanor", "hemmelig")).resolves.toBe("abc");
+    const [call] = fetchMock.callsTo("/auth/login/");
+    expect(call?.body).toEqual({ user_id: "olanor", password: "hemmelig" });
+  });
+
+  it("videreformidler TIHLDEs norske feilmelding med statuskoden", async () => {
+    fetchMock.on("POST", "/auth/login/", json({ detail: "Feil passord." }, 401));
+
+    await expect(tihldeLogin("olanor", "feil")).rejects.toMatchObject({
+      message: "Feil passord.",
+      status: 401,
+    });
+  });
+
+  it("faller tilbake til en standardmelding når svaret ikke er JSON", async () => {
+    fetchMock.on("POST", "/auth/login/", text("<html>", 500));
+
+    await expect(tihldeLogin("olanor", "x")).rejects.toThrow(
+      /Brukernavnet eller passordet/,
+    );
+  });
+
+  it("kaster når svaret mangler token", async () => {
+    fetchMock.on("POST", "/auth/login/", json({}));
+
+    await expect(tihldeLogin("olanor", "x")).rejects.toThrow(TihldeAuthError);
+  });
+});
+
+describe("tihldeCreateUser", () => {
+  const input = {
+    user_id: "olanor",
+    password: "hemmeligpassord",
+    first_name: "Ola",
+    last_name: "Nordmann",
+    email: "ola@stud.ntnu.no",
+    study: "dataingenir",
+    class: null,
+  };
+
+  it("oppretter kontoen", async () => {
+    fetchMock.on("POST", "/users/", json({}, 201));
+
+    await expect(tihldeCreateUser(input)).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["detail som streng", { detail: "Noe gikk galt." }, "Noe gikk galt."],
+    [
+      "feltfeil på toppnivå",
+      { email: ["Ugyldig e-post."] },
+      "Ugyldig e-post.",
+    ],
+    [
+      "feltfeil nestet under detail",
+      { detail: { email: ["Ugyldig e-post."] } },
+      "Ugyldig e-post.",
+    ],
+  ])("leser feilmeldingen fra %s", async (_label, body, expected) => {
+    fetchMock.on("POST", "/users/", json(body, 400));
+
+    await expect(tihldeCreateUser(input)).rejects.toThrow(expected);
+  });
+
+  it("oversetter duplikat brukernavn til et innloggingshint", async () => {
+    fetchMock.on("POST", "/users/", json({ user_id: ["finnes allerede"] }, 400));
+
+    await expect(tihldeCreateUser(input)).rejects.toThrow(/Logg inn i stedet/);
+  });
+});
+
+describe("profil og tilganger", () => {
+  it("henter profilen med token-headeren", async () => {
+    fetchMock.on("GET", "/users/me/", json({ user_id: "olanor" }));
+
+    await tihldeGetMe("token-123");
+
+    expect(fetchMock.callsTo("/users/me/")[0]?.headers["x-csrf-token"]).toBe("token-123");
+  });
+
+  it("mapper profilen til våre felter", () => {
+    expect(
+      mapProfile({
+        user_id: "olanor",
+        first_name: "Ola",
+        last_name: "Nordmann",
+        email: "ola@stud.ntnu.no",
+        image: null,
+        study: { group: { name: "Dataingeniør" } },
+        studyyear: { group: { name: "2026" } },
+      }),
+    ).toEqual({
+      tihldeUserId: "olanor",
+      name: "Ola Nordmann",
+      email: "ola@stud.ntnu.no",
+      image: null,
+      studieretning: "Dataingeniør",
+      klasse: "2026",
+    });
+  });
+
+  it("faller tilbake til brukernavnet når navnet mangler", () => {
+    expect(
+      mapProfile({
+        user_id: "olanor",
+        first_name: "",
+        last_name: "",
+        email: null,
+        image: null,
+        study: null,
+        studyyear: null,
+      }),
+    ).toMatchObject({ name: "olanor", studieretning: null, klasse: null });
+  });
+
+  it("regner skrivetilgang som admin, lesetilgang som vanlig bruker", () => {
+    expect(isAdminFromPermissions({ permissions: { event: { read: true } } })).toBe(false);
+    expect(isAdminFromPermissions({ permissions: { event: { write: true } } })).toBe(true);
+    expect(
+      isAdminFromPermissions({ permissions: { event: { write_all: true } } }),
+    ).toBe(true);
+    expect(isAdminFromPermissions({ permissions: {} })).toBe(false);
+  });
+
+  it("leser medlemskap både som liste og paginert svar", async () => {
+    fetchMock.once("GET", "/users/olanor/memberships/", json({ results: [{ group: { slug: "fadderkom" } }] }));
+    await expect(tihldeGetMemberships("t", "olanor")).resolves.toEqual([
+      { group: { slug: "fadderkom" } },
+    ]);
+
+    fetchMock.on("GET", "/users/olanor/memberships/", json([{ group: { slug: "index" } }]));
+    await expect(tihldeGetMemberships("t", "olanor")).resolves.toEqual([
+      { group: { slug: "index" } },
+    ]);
+  });
+
+  it("gjenkjenner medlemskap i en gruppe på slug", () => {
+    const memberships = [{ group: { slug: "fadderkom" } }, { group: null }];
+    expect(isMemberOfGroup(memberships, "fadderkom")).toBe(true);
+    expect(isMemberOfGroup(memberships, "index")).toBe(false);
+  });
+
+  it("kaster med statuskoden når tilganger ikke kan hentes", async () => {
+    fetchMock.on("GET", "/users/me/permissions/", text("boom", 500));
+
+    await expect(tihldeGetPermissions("t")).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/tests/integration/vipps-client.test.ts
+++ b/tests/integration/vipps-client.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PAYMENT_AMOUNT_ORE,
+  VippsError,
+  buildPaymentDescription,
+  createPayment,
+  fetchPaymentEvents,
+  fetchPaymentSnapshot,
+  refundPayment,
+  settlePayment,
+} from "~/server/payment/vipps";
+
+import { createPayment as seedPayment, createUser, db } from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+import { stubVippsPayment, stubVippsToken, vippsPayment } from "../helpers/vipps";
+
+/**
+ * The Vipps layer is the app's money boundary: it decides who gets marked as
+ * paid and when money moves. Every test here drives it through a stubbed HTTP
+ * layer and asserts on the resulting database state.
+ */
+
+describe("settlePayment", () => {
+  it("fanger en reservert betaling og markerer brukeren som betalt", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id, { status: "CREATED" });
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({ state: "AUTHORIZED", authorized: PAYMENT_AMOUNT_ORE }),
+    );
+
+    const result = await settlePayment(order.orderId);
+
+    expect(result).toEqual({ paid: true, state: "AUTHORIZED" });
+    expect(fetchMock.callsTo(`/epayment/v1/payments/${order.orderId}/capture`)).toHaveLength(1);
+
+    const stored = await db.payment.findUniqueOrThrow({
+      where: { orderId: order.orderId },
+    });
+    expect(stored.status).toBe("CAPTURED");
+    expect(stored.capturedAt).toBeInstanceOf(Date);
+
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.hasPaid).toBe(true);
+    expect(after.isVerified).toBe(true);
+  });
+
+  it("fanger ikke på nytt når beløpet allerede er trukket", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id);
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+
+    await settlePayment(order.orderId);
+
+    expect(fetchMock.callsTo(`/epayment/v1/payments/${order.orderId}/capture`)).toHaveLength(0);
+  });
+
+  it("flytter ikke capturedAt ved gjentatt settle (webhook-retry / admin-sync)", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id);
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+
+    await settlePayment(order.orderId);
+    const first = await db.payment.findUniqueOrThrow({
+      where: { orderId: order.orderId },
+    });
+
+    await new Promise((r) => setTimeout(r, 25));
+    await settlePayment(order.orderId);
+    const second = await db.payment.findUniqueOrThrow({
+      where: { orderId: order.orderId },
+    });
+
+    expect(second.capturedAt?.getTime()).toBe(first.capturedAt?.getTime());
+  });
+
+  it("markerer ingen som betalt når Vipps ikke kjenner referansen", async () => {
+    const user = await createUser();
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      "/epayment/v1/payments/fadderuka-forfalsket-1",
+      json({ detail: "Not found" }, 404),
+    );
+
+    await expect(settlePayment("fadderuka-forfalsket-1")).rejects.toThrow(VippsError);
+
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.hasPaid).toBe(false);
+  });
+
+  it("markerer ikke som betalt når betalingen bare er avbrutt", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id);
+    stubVippsPayment(order.orderId, vippsPayment({ state: "ABORTED" }));
+
+    const result = await settlePayment(order.orderId);
+
+    expect(result.paid).toBe(false);
+    const stored = await db.payment.findUniqueOrThrow({
+      where: { orderId: order.orderId },
+    });
+    expect(stored.status).toBe("ABORTED");
+    expect(stored.capturedAt).toBeNull();
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.hasPaid).toBe(false);
+  });
+
+  it("faller tilbake på bruker-id-en i referansen når ordreraden mangler", async () => {
+    const user = await createUser();
+    const orderId = `fadderuka-${user.id}-${Date.now()}`;
+    stubVippsPayment(
+      orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+
+    await settlePayment(orderId);
+
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.hasPaid).toBe(true);
+  });
+
+  it("bruker ordreradens userId, ikke id-en i referansen", async () => {
+    // Betaleren eier raden; referansen inneholder en annen (eldre) bruker-id.
+    const payer = await createUser();
+    const other = await createUser();
+    const orderId = `fadderuka-${other.id}-${Date.now()}`;
+    await seedPayment(payer.id, { orderId });
+    stubVippsPayment(
+      orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+
+    await settlePayment(orderId);
+
+    expect((await db.user.findUniqueOrThrow({ where: { id: payer.id } })).hasPaid).toBe(true);
+    expect((await db.user.findUniqueOrThrow({ where: { id: other.id } })).hasPaid).toBe(false);
+  });
+
+  it("bruker en idempotensnøkkel på maks 50 tegn ved capture", async () => {
+    // Regresjonsvern: en nøkkel utledet av `${orderId}-capture` ville sprengt
+    // Vipps' grense og gitt 400.
+    const user = await createUser();
+    const order = await seedPayment(user.id);
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({ state: "AUTHORIZED", authorized: PAYMENT_AMOUNT_ORE }),
+    );
+
+    await settlePayment(order.orderId);
+
+    const [capture] = fetchMock.callsTo(
+      `/epayment/v1/payments/${order.orderId}/capture`,
+    );
+    const key = capture?.headers["idempotency-key"];
+    expect(key).toBeDefined();
+    expect(key!.length).toBeLessThanOrEqual(50);
+  });
+
+  it("kaster når Vipps avviser capture, og lar brukeren stå som ubetalt", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id);
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({ state: "AUTHORIZED", authorized: PAYMENT_AMOUNT_ORE }),
+      { captureStatus: 400 },
+    );
+
+    await expect(settlePayment(order.orderId)).rejects.toThrow(VippsError);
+    expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid).toBe(false);
+  });
+});
+
+describe("refusjon", () => {
+  it("refunderer hele beløpet og fjerner betalt-statusen", async () => {
+    const user = await createUser({ hasPaid: true, isVerified: true });
+    const order = await seedPayment(user.id, {
+      status: "CAPTURED",
+      capturedAt: new Date(),
+    });
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      `/epayment/v1/payments/${order.orderId}`,
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+        }),
+      ),
+    );
+    fetchMock.on("POST", `/epayment/v1/payments/${order.orderId}/refund`, json({}));
+
+    const result = await refundPayment(order.orderId);
+
+    expect(result).toEqual({ refunded: PAYMENT_AMOUNT_ORE });
+    const [refund] = fetchMock.callsTo(`/epayment/v1/payments/${order.orderId}/refund`);
+    expect(refund?.body).toEqual({
+      modificationAmount: { currency: "NOK", value: PAYMENT_AMOUNT_ORE },
+    });
+
+    const stored = await db.payment.findUniqueOrThrow({
+      where: { orderId: order.orderId },
+    });
+    expect(stored.status).toBe("REFUNDED");
+
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.hasPaid).toBe(false);
+    // isVerified styrer tilgang og røres bevisst ikke av en refusjon.
+    expect(after.isVerified).toBe(true);
+  });
+
+  it("nekter å refundere en betaling som aldri ble trukket", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id, { status: "AUTHORIZED" });
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      `/epayment/v1/payments/${order.orderId}`,
+      json(vippsPayment({ state: "AUTHORIZED", authorized: PAYMENT_AMOUNT_ORE })),
+    );
+
+    await expect(refundPayment(order.orderId)).rejects.toThrow(/ikke trukket/i);
+    expect(fetchMock.callsTo(`/epayment/v1/payments/${order.orderId}/refund`)).toHaveLength(0);
+  });
+
+  it("nekter å refundere to ganger", async () => {
+    const user = await createUser({ hasPaid: false });
+    const order = await seedPayment(user.id, { status: "REFUNDED" });
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      `/epayment/v1/payments/${order.orderId}`,
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+          refunded: PAYMENT_AMOUNT_ORE,
+        }),
+      ),
+    );
+
+    await expect(refundPayment(order.orderId)).rejects.toThrow(/allerede refundert/i);
+    expect(fetchMock.callsTo(`/epayment/v1/payments/${order.orderId}/refund`)).toHaveLength(0);
+  });
+
+  it("forklarer manglende refusjonstilgang når Vipps svarer 403", async () => {
+    const user = await createUser({ hasPaid: true });
+    const order = await seedPayment(user.id, { status: "CAPTURED" });
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      `/epayment/v1/payments/${order.orderId}`,
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+        }),
+      ),
+    );
+    fetchMock.on(
+      "POST",
+      `/epayment/v1/payments/${order.orderId}/refund`,
+      text("forbidden", 403),
+    );
+
+    await expect(refundPayment(order.orderId)).rejects.toThrow(/refusjonstilgang/i);
+    // Pengene flyttet seg ikke, så brukeren skal fortsatt stå som betalt.
+    expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid).toBe(true);
+  });
+
+  it("lar ikke en senere sync flippe en refundert ordre tilbake til betalt", async () => {
+    // Regresjonsvern for rekkefølgen i toStatus: en fullt refundert ordre
+    // rapporterer fortsatt et capturedAmount fra Vipps.
+    const user = await createUser({ hasPaid: false });
+    const order = await seedPayment(user.id, { status: "REFUNDED" });
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({
+        state: "AUTHORIZED",
+        authorized: PAYMENT_AMOUNT_ORE,
+        captured: PAYMENT_AMOUNT_ORE,
+        refunded: PAYMENT_AMOUNT_ORE,
+      }),
+    );
+
+    const result = await settlePayment(order.orderId);
+
+    expect(result.paid).toBe(false);
+    expect(
+      (await db.payment.findUniqueOrThrow({ where: { orderId: order.orderId } })).status,
+    ).toBe("REFUNDED");
+    expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid).toBe(false);
+  });
+});
+
+describe("createPayment", () => {
+  it("sender riktig beløp, referanse og retur-URL, og returnerer redirectUrl", async () => {
+    stubVippsToken();
+    fetchMock.on(
+      "POST",
+      "/epayment/v1/payments",
+      json({ redirectUrl: "https://vipps.test/checkout/abc" }),
+    );
+
+    const result = await createPayment("fadderuka-bruker1-123", {
+      paymentDescription: "Ola Nordmann - Fadderuka",
+    });
+
+    expect(result.redirectUrl).toBe("https://vipps.test/checkout/abc");
+    const [call] = fetchMock.callsTo("/epayment/v1/payments");
+    expect(call?.body).toMatchObject({
+      amount: { currency: "NOK", value: PAYMENT_AMOUNT_ORE },
+      reference: "fadderuka-bruker1-123",
+      userFlow: "WEB_REDIRECT",
+      paymentDescription: "Ola Nordmann - Fadderuka",
+    });
+    expect((call?.body as { returnUrl: string }).returnUrl).toContain(
+      "orderId=fadderuka-bruker1-123",
+    );
+    // Uten telefonnummer skal Vipps selv spørre om det i WEB_REDIRECT-flyten.
+    expect(call?.body).not.toHaveProperty("customer");
+  });
+
+  it("sender telefonnummeret i E.164 når vi har det", async () => {
+    stubVippsToken();
+    fetchMock.on("POST", "/epayment/v1/payments", json({ redirectUrl: "https://x" }));
+
+    await createPayment("fadderuka-bruker1-123", { phoneNumber: "40404040" });
+
+    const [call] = fetchMock.callsTo("/epayment/v1/payments");
+    expect(call?.body).toMatchObject({ customer: { phoneNumber: "4740404040" } });
+  });
+
+  it("kaster VippsError når Vipps avviser opprettelsen", async () => {
+    stubVippsToken();
+    fetchMock.on("POST", "/epayment/v1/payments", text("bad request", 400));
+
+    await expect(createPayment("fadderuka-bruker1-123")).rejects.toThrow(VippsError);
+  });
+
+  it("kaster VippsError når tilgangstokenet ikke kan hentes", async () => {
+    fetchMock.on("POST", "/accesstoken/get", text("unauthorized", 401));
+
+    await expect(createPayment("fadderuka-bruker1-123")).rejects.toThrow(
+      /tilgangstoken/i,
+    );
+  });
+});
+
+describe("buildPaymentDescription", () => {
+  it("leder med betalerens navn", () => {
+    expect(buildPaymentDescription({ name: "Ola Nordmann" })).toBe(
+      "Ola Nordmann - Fadderuka",
+    );
+  });
+
+  it("faller tilbake til en generisk tekst uten navn", () => {
+    expect(buildPaymentDescription()).toBe("Fadderuka - TIHLDE");
+    expect(buildPaymentDescription({ name: "   " })).toBe("Fadderuka - TIHLDE");
+  });
+
+  it("kutter til Vipps' 100-tegnsgrense", () => {
+    expect(buildPaymentDescription({ name: "A".repeat(200) })).toHaveLength(100);
+  });
+});
+
+describe("admin-innsyn i en betaling", () => {
+  it("leser live status fra Vipps", async () => {
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      "/epayment/v1/payments/ref-1",
+      json(
+        vippsPayment({
+          state: "AUTHORIZED",
+          authorized: PAYMENT_AMOUNT_ORE,
+          captured: PAYMENT_AMOUNT_ORE,
+          refunded: 100,
+          cancelled: 0,
+        }),
+      ),
+    );
+
+    await expect(fetchPaymentSnapshot("ref-1")).resolves.toEqual({
+      state: "AUTHORIZED",
+      authorized: PAYMENT_AMOUNT_ORE,
+      captured: PAYMENT_AMOUNT_ORE,
+      refunded: 100,
+      cancelled: 0,
+    });
+  });
+
+  it("normaliserer hendelsesloggen på tvers av Vipps' feltnavn", async () => {
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      "/epayment/v1/payments/ref-1/events",
+      json([
+        { name: "CREATED", amount: { value: 38_000 }, timestamp: "2026-07-01T10:00:00Z", success: true },
+        { paymentAction: "CAPTURE", timeStamp: "2026-07-01T10:05:00Z" },
+        {},
+      ]),
+    );
+
+    await expect(fetchPaymentEvents("ref-1")).resolves.toEqual([
+      { action: "CREATED", amount: 38_000, timestamp: "2026-07-01T10:00:00Z", success: true },
+      { action: "CAPTURE", amount: null, timestamp: "2026-07-01T10:05:00Z", success: true },
+      { action: "UKJENT", amount: null, timestamp: null, success: true },
+    ]);
+  });
+});

--- a/tests/integration/vipps-webhook.route.test.ts
+++ b/tests/integration/vipps-webhook.route.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { POST as webhook } from "~/app/api/vipps/webhook/route";
+import { PAYMENT_AMOUNT_ORE } from "~/server/payment/vipps";
+
+import { createPayment as seedPayment, createUser, db } from "../helpers/db";
+import { fetchMock, json, text } from "../helpers/fetch-mock";
+import { stubVippsPayment, stubVippsToken, vippsPayment } from "../helpers/vipps";
+
+const post = (body: unknown) =>
+  webhook(
+    new Request("https://fadderuka.test/api/vipps/webhook", {
+      method: "POST",
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+  );
+
+describe("POST /api/vipps/webhook", () => {
+  it("gjør opp betalingen referansen peker på", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id, { status: "AUTHORIZED" });
+    stubVippsPayment(
+      order.orderId,
+      vippsPayment({ state: "AUTHORIZED", authorized: PAYMENT_AMOUNT_ORE }),
+    );
+
+    const response = await post({ reference: order.orderId });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid).toBe(true);
+  });
+
+  it("godtar også feltnavnet orderId", async () => {
+    const user = await createUser();
+    const order = await seedPayment(user.id);
+    stubVippsPayment(order.orderId, vippsPayment({ state: "ABORTED" }));
+
+    expect((await post({ orderId: order.orderId })).status).toBe(200);
+  });
+
+  it("markerer ingen som betalt basert på payloadens egen påstand", async () => {
+    // Sikkerhetsgrensen: vi stoler kun på Vipps' eget API, ikke på innholdet i
+    // webhooken. En forfalsket "CAPTURED" må ikke gi betalt-status.
+    const user = await createUser();
+    const order = await seedPayment(user.id);
+    stubVippsPayment(order.orderId, vippsPayment({ state: "CREATED" }));
+
+    await post({
+      reference: order.orderId,
+      state: "CAPTURED",
+      aggregate: { capturedAmount: { value: PAYMENT_AMOUNT_ORE } },
+    });
+
+    expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid).toBe(false);
+  });
+
+  it("svarer 400 uten referanse", async () => {
+    const response = await post({ noe: "annet" });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("svarer 400 på ugyldig JSON", async () => {
+    expect((await post("ikke json")).status).toBe(400);
+  });
+
+  it("svarer 500 så Vipps prøver på nytt når oppgjøret feiler", async () => {
+    stubVippsToken();
+    fetchMock.on("GET", "/epayment/v1/payments/ukjent-ref", text("boom", 500));
+
+    const response = await post({ reference: "ukjent-ref" });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ ok: false });
+  });
+
+  it("markerer ingen som betalt for en ukjent referanse", async () => {
+    const user = await createUser();
+    stubVippsToken();
+    fetchMock.on(
+      "GET",
+      "/epayment/v1/payments/fadderuka-forfalsket-1",
+      json({ detail: "Not found" }, 404),
+    );
+
+    await post({ reference: "fadderuka-forfalsket-1" });
+
+    expect((await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid).toBe(false);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,23 @@
+// Must come first: sets DATABASE_URL and the fake service URLs before `~/env`
+// is imported (and validated) anywhere downstream.
+import "./env";
+
+import { afterAll, afterEach, beforeEach } from "vitest";
+
+import { db, resetDb } from "./helpers/db";
+import { fetchMock, installFetchMock } from "./helpers/fetch-mock";
+
+installFetchMock();
+
+beforeEach(async () => {
+  await resetDb();
+  fetchMock.reset();
+});
+
+afterEach(() => {
+  fetchMock.reset();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+});

--- a/tests/stubs/server-only.ts
+++ b/tests/stubs/server-only.ts
@@ -1,0 +1,3 @@
+// Stand-in for the `server-only` package, which throws when imported outside a
+// Next server build. Aliased in `vitest.config.ts`.
+export {};

--- a/tests/unit/csv.test.ts
+++ b/tests/unit/csv.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { toCsv, toDateAndTime } from "~/lib/csv";
+
+describe("toCsv", () => {
+  it("skriver header og rader semikolonseparert", () => {
+    const csv = toCsv([{ navn: "Ola", antall: 2 }], [
+      { header: "Navn", value: (r) => r.navn },
+      { header: "Antall", value: (r) => r.antall },
+    ]);
+    expect(csv).toBe("Navn;Antall\r\nOla;2");
+  });
+
+  it("quoter felt som inneholder separator, linjeskift eller anførselstegn", () => {
+    const csv = toCsv(
+      [{ v: 'Ola; "Kari"' }, { v: "linje1\nlinje2" }],
+      [{ header: "V", value: (r) => r.v }],
+    );
+    const [, first, second] = csv.split("\r\n");
+    expect(first).toBe('"Ola; ""Kari"""');
+    expect(second).toBe('"linje1\nlinje2"');
+  });
+
+  it("skriver tom streng for null og undefined", () => {
+    const csv = toCsv(
+      [{ a: null, b: undefined }],
+      [
+        { header: "A", value: (r) => r.a },
+        { header: "B", value: (r) => r.b },
+      ],
+    );
+    expect(csv).toBe("A;B\r\n;");
+  });
+
+  it("gir bare header når det ikke finnes rader", () => {
+    expect(toCsv([], [{ header: "A", value: () => "" }])).toBe("A");
+  });
+});
+
+describe("toDateAndTime", () => {
+  it("formaterer i norsk tid (sommertid, UTC+2)", () => {
+    expect(toDateAndTime(new Date("2026-07-19T10:30:00Z"))).toEqual({
+      date: "2026-07-19",
+      time: "12:30",
+    });
+  });
+
+  it("formaterer i norsk tid (vintertid, UTC+1)", () => {
+    expect(toDateAndTime(new Date("2026-01-15T23:30:00Z"))).toEqual({
+      date: "2026-01-16",
+      time: "00:30",
+    });
+  });
+
+  it("godtar ISO-strenger", () => {
+    expect(toDateAndTime("2026-07-19T10:30:00Z").time).toBe("12:30");
+  });
+
+  it("gir tomme felt for null og ugyldig dato", () => {
+    expect(toDateAndTime(null)).toEqual({ date: "", time: "" });
+    expect(toDateAndTime("ikke en dato")).toEqual({ date: "", time: "" });
+  });
+});

--- a/tests/unit/order-id.test.ts
+++ b/tests/unit/order-id.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOrderId,
+  parseUserIdFromOrderId,
+} from "~/server/payment/vipps";
+
+describe("orderId", () => {
+  it("er rundturs-stabil for cuid-er", () => {
+    const userId = "cmd1x2y3z0000abcdefghijkl";
+    expect(parseUserIdFromOrderId(buildOrderId(userId))).toBe(userId);
+  });
+
+  it("holder seg innenfor Vipps' 50-tegns referansegrense", () => {
+    // Vipps avviser lengre referanser med 400 — jf. kommentaren i vipps.ts.
+    expect(buildOrderId("cmd1x2y3z0000abcdefghijkl").length).toBeLessThanOrEqual(50);
+  });
+
+  it("gir null for referanser som ikke er våre", () => {
+    expect(parseUserIdFromOrderId("noe-helt-annet")).toBeNull();
+    expect(parseUserIdFromOrderId("fadderuka-uten-timestamp")).toBeNull();
+    expect(parseUserIdFromOrderId("")).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    // Resolves the `~/*` alias from tsconfig.json natively (Vite 7+).
+    tsconfigPaths: true,
+    alias: {
+      // Server modules import `server-only`, which throws outside a Next
+      // build. Swap it for an empty module so the same code runs under Vitest.
+      "server-only": fileURLToPath(
+        new URL("./tests/stubs/server-only.ts", import.meta.url),
+      ),
+    },
+  },
+  test: {
+    environment: "node",
+    globals: true,
+    setupFiles: ["./tests/setup.ts"],
+    globalSetup: ["./tests/global-setup.ts"],
+    include: ["tests/**/*.test.ts"],
+    // One shared test database: files must not run concurrently, or their
+    // `resetDb()` calls would truncate each other's rows mid-test.
+    fileParallelism: false,
+    // Prisma migrations + a cold Prisma Client can exceed the 5s default.
+    testTimeout: 20_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
Repoet hadde ingen tester og ingen CI. Denne PR-en legger til en integrasjonstestpakke over hele serverflaten, og en GitHub Actions-workflow som kjører den på hver PR mot `main` og `dev`.

## Hva testes

168 tester som kjører serverkoden mot en ekte Postgres. `fetch` er stubbet, så ingen test treffer Vipps eller TIHLDE.

- **Vipps-klienten** — capture, refusjon, idempotens (`capturedAt` flyttes ikke ved retry), at en ukjent referanse aldri markerer noen som betalt, og at REFUNDED-grenen i `toStatus` ligger foran capture-grenen slik at en sync ikke flipper en refundert ordre tilbake til betalt.
- **tRPC-routerne** — payment, admin, gruppe, activity, notification. Autorisasjon testes tabellstyrt over hver enkelt adminprosedyre, med en sjekk som feiler hvis en ny prosedyre legges til uten dekning.
- **Route handlers** — login (inkl. admin-utledning fra permissions/FadderKom), registrering, logout, allergi-synk og Vipps-webhooken (en forfalsket payload markerer ikke betalt).
- **Sesjonslaget og csv-eksporten.**

## CI

`.github/workflows/ci.yml`: postgres 16 som service, bun, `prisma migrate deploy`, deretter lint → typecheck → test → build.

Etter merge må `verify` slås på som required status check i branch protection for `main` og `dev` — det kan ikke gjøres fra koden.

## Verifisert

- `bun run lint`, `bun run typecheck`, `bun run test` (168/168) og `bun run build` er grønne lokalt.
- Bevisst regresjonssjekk: fjernet `capturedAt: null`-guarden, fjernet FADDER-sjekken for kunngjøringer og flyttet REFUNDED-grenen i `toStatus` — hver enkelt ga rød test. Rullet tilbake etterpå.

🤖 Generated with [Claude Code](https://claude.com/claude-code)