### PR TITLE
fix(auth): gi kun FadderKom admin + integrasjonstester

### DIFF
--- a/prisma/migrations/20260720120000_admin_override/migration.sql
+++ b/prisma/migrations/20260720120000_admin_override/migration.sql
@@ -1,0 +1,2 @@
+-- Manual admin decision from the admin panel. NULL = derive from TIHLDE at login.
+ALTER TABLE "User" ADD COLUMN "adminOverride" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,10 @@ model User {
     isVerified    Boolean   @default(false)
     hasPaid       Boolean   @default(false)
     isAdmin       Boolean   @default(false)
+    // Manual admin decision from the admin panel. `null` means "derive from
+    // TIHLDE on every login" (the default); `true`/`false` pins the user and
+    // survives logins, so a manual grant or revocation is not overwritten.
+    adminOverride Boolean?
     createdAt     DateTime  @default(now())
     updatedAt     DateTime  @updatedAt
     sessions      Session[]

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -10,12 +10,10 @@ import {
 import { db } from "~/server/db";
 import {
   TihldeAuthError,
-  isAdminFromPermissions,
   isMemberOfGroup,
   mapProfile,
   tihldeGetMe,
   tihldeGetMemberships,
-  tihldeGetPermissions,
   tihldeLogin,
 } from "~/server/auth/tihlde";
 
@@ -42,30 +40,40 @@ export async function POST(request: Request) {
     const profile = await tihldeGetMe(token);
     const mapped = mapProfile(profile);
 
-    // 2. Derive admin status live from TIHLDE (as Kvark does). A user is an
-    //    app admin if they hold write permissions OR are a member of the
-    //    FadderKom committee. Admins are automatically app admins and skip
-    //    payment, so we also mark them verified/paid. A fetch failure must not
-    //    block login — and must not silently revoke an existing admin — so on
-    //    error we leave admin-related flags untouched.
+    // 2. Decide admin status. A manual decision in the admin panel
+    //    (`adminOverride`) always wins and survives every login; otherwise we
+    //    derive it live from TIHLDE, where the sole criterion is membership in
+    //    the FadderKom committee. Deliberately NOT based on TIHLDE write
+    //    permissions: those are handed out to every committee member, which
+    //    made anyone holding any verv an admin of this app.
+    //
+    //    Admins skip payment, so we also mark them verified/paid. A fetch
+    //    failure must not block login — and must not silently revoke an
+    //    existing admin — so on error we leave admin-related flags untouched.
+    const existing = await db.user.findUnique({
+      where: { tihldeUserId: mapped.tihldeUserId },
+      select: { adminOverride: true },
+    });
+
+    const grantFor = (isAdmin: boolean) =>
+      isAdmin
+        ? { isAdmin: true, isVerified: true, hasPaid: true }
+        : { isAdmin: false };
+
     let adminGrant: {
       isAdmin?: boolean;
       isVerified?: boolean;
       hasPaid?: boolean;
     } = {};
-    try {
-      const [perms, memberships] = await Promise.all([
-        tihldeGetPermissions(token),
-        tihldeGetMemberships(token, profile.user_id),
-      ]);
-      const isAdmin =
-        isAdminFromPermissions(perms) ||
-        isMemberOfGroup(memberships, ADMIN_GROUP_SLUG);
-      adminGrant = isAdmin
-        ? { isAdmin: true, isVerified: true, hasPaid: true }
-        : { isAdmin: false };
-    } catch (err) {
-      console.error("[auth/login] admin derivation failed", err);
+    if (existing?.adminOverride != null) {
+      adminGrant = grantFor(existing.adminOverride);
+    } else {
+      try {
+        const memberships = await tihldeGetMemberships(token, profile.user_id);
+        adminGrant = grantFor(isMemberOfGroup(memberships, ADMIN_GROUP_SLUG));
+      } catch (err) {
+        console.error("[auth/login] admin derivation failed", err);
+      }
     }
 
     // 3. Upsert the local user, keyed by TIHLDE user_id. Payment flags for

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -10,15 +10,18 @@ import {
 import { db } from "~/server/db";
 import {
   TihldeAuthError,
-  isMemberOfGroup,
+  isMemberOfAnyGroup,
   mapProfile,
   tihldeGetMe,
   tihldeGetMemberships,
   tihldeLogin,
 } from "~/server/auth/tihlde";
 
-/** TIHLDE group whose members are always app admins. */
-const ADMIN_GROUP_SLUG = "fadderkom";
+/**
+ * TIHLDE groups whose members are always app admins: FadderKom runs Fadderuka,
+ * and Index drifter appen. Membership in any *other* committee grants nothing.
+ */
+const ADMIN_GROUP_SLUGS = ["fadderkom", "index"];
 
 const bodySchema = z.object({
   user_id: z.string().min(1, "Brukernavn er påkrevd."),
@@ -43,9 +46,9 @@ export async function POST(request: Request) {
     // 2. Decide admin status. A manual decision in the admin panel
     //    (`adminOverride`) always wins and survives every login; otherwise we
     //    derive it live from TIHLDE, where the sole criterion is membership in
-    //    the FadderKom committee. Deliberately NOT based on TIHLDE write
-    //    permissions: those are handed out to every committee member, which
-    //    made anyone holding any verv an admin of this app.
+    //    one of the committees that run the app. Deliberately NOT based on
+    //    TIHLDE write permissions: those are handed out to every committee
+    //    member, which made anyone holding any verv an admin of this app.
     //
     //    Admins skip payment, so we also mark them verified/paid. A fetch
     //    failure must not block login — and must not silently revoke an
@@ -70,7 +73,7 @@ export async function POST(request: Request) {
     } else {
       try {
         const memberships = await tihldeGetMemberships(token, profile.user_id);
-        adminGrant = grantFor(isMemberOfGroup(memberships, ADMIN_GROUP_SLUG));
+        adminGrant = grantFor(isMemberOfAnyGroup(memberships, ADMIN_GROUP_SLUGS));
       } catch (err) {
         console.error("[auth/login] admin derivation failed", err);
       }
@@ -112,7 +115,7 @@ export async function POST(request: Request) {
     });
 
     // `verified` lets the registration page skip straight to the app for users
-    // who don't owe a payment (admins/FadderKom are auto-verified above).
+    // who don't owe a payment (admins are auto-verified above).
     return NextResponse.json({ ok: true, verified: user.isVerified });
   } catch (err) {
     if (err instanceof TihldeAuthError) {

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -67,13 +67,19 @@ export const adminRouter = createTRPCRouter({
       });
     }),
 
-  /** Promote or demote admin status */
+  /**
+   * Promote or demote admin status.
+   *
+   * Also pins the decision via `adminOverride` so it survives the next login —
+   * without it, login would re-derive admin status from TIHLDE and overwrite
+   * whatever was set here.
+   */
   setUserAdmin: adminProcedure
     .input(z.object({ userId: z.string(), isAdmin: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       return ctx.db.user.update({
         where: { id: input.userId },
-        data: { isAdmin: input.isAdmin },
+        data: { isAdmin: input.isAdmin, adminOverride: input.isAdmin },
       });
     }),
 

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -223,12 +223,14 @@ export async function tihldeGetMemberships(
   return all;
 }
 
-/** Whether the user is a member of the group with the given slug. */
-export function isMemberOfGroup(
+/** Whether the user is a member of any of the groups with the given slugs. */
+export function isMemberOfAnyGroup(
   memberships: TihldeMembership[],
-  slug: string,
+  slugs: readonly string[],
 ): boolean {
-  return memberships.some((m) => m.group?.slug === slug);
+  return memberships.some(
+    (m) => m.group?.slug != null && slugs.includes(m.group.slug),
+  );
 }
 
 /**

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -170,77 +170,57 @@ export async function tihldeGetMe(token: string): Promise<TihldeProfile> {
   return (await res.json()) as TihldeProfile;
 }
 
-interface PermissionEntry {
-  read?: boolean;
-  write?: boolean;
-  write_all?: boolean;
-  destroy?: boolean;
-}
-
-interface TihldePermissions {
-  permissions: Record<string, PermissionEntry>;
-}
-
-/** Fetch the authenticated user's global TIHLDE permissions. */
-export async function tihldeGetPermissions(
-  token: string,
-): Promise<TihldePermissions> {
-  const res = await fetch(apiUrl("/users/me/permissions/"), {
-    headers: { [TOKEN_HEADER]: token },
-    cache: "no-store",
-  });
-
-  if (!res.ok) {
-    throw new TihldeAuthError(
-      await readDetail(res, "Kunne ikke hente brukerens tillatelser."),
-      res.status,
-    );
-  }
-
-  return (await res.json()) as TihldePermissions;
-}
-
-/**
- * Whether a TIHLDE user counts as an admin for this app.
- *
- * Mirrors Kvark's `hasWritePermission`: a user with `write` or `write_all` on
- * any permission app holds an elevated/backend role (board, committee, HS,
- * Index, …). Regular members get read-only permissions and are not admins.
- */
-export function isAdminFromPermissions(perms: TihldePermissions): boolean {
-  return Object.values(perms.permissions ?? {}).some(
-    (p) => p?.write === true || p?.write_all === true,
-  );
-}
-
 interface TihldeMembership {
   group: { slug?: string; name?: string } | null;
 }
 
+/** Safety net so a malformed `next` chain can never loop forever. */
+const MAX_MEMBERSHIP_PAGES = 20;
+
 /**
- * Fetch the user's group memberships. The endpoint is paginated (25 per page);
- * we read the first page, which is enough to detect committee membership.
+ * Fetch *all* of the user's group memberships.
+ *
+ * The endpoint is paginated (25 per page), and admin status hinges on finding
+ * one specific group, so we must follow every page: a user in many groups could
+ * otherwise have FadderKom on page 2 and silently lose admin.
  */
 export async function tihldeGetMemberships(
   token: string,
   userId: string,
 ): Promise<TihldeMembership[]> {
-  const res = await fetch(
-    apiUrl(`/users/${encodeURIComponent(userId)}/memberships/`),
-    { headers: { [TOKEN_HEADER]: token }, cache: "no-store" },
+  const all: TihldeMembership[] = [];
+  let url: string | null = apiUrl(
+    `/users/${encodeURIComponent(userId)}/memberships/`,
   );
 
-  if (!res.ok) {
-    throw new TihldeAuthError(
-      await readDetail(res, "Kunne ikke hente gruppemedlemskap."),
-      res.status,
-    );
+  for (let page = 0; url && page < MAX_MEMBERSHIP_PAGES; page++) {
+    const res: Response = await fetch(url, {
+      headers: { [TOKEN_HEADER]: token },
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      throw new TihldeAuthError(
+        await readDetail(res, "Kunne ikke hente gruppemedlemskap."),
+        res.status,
+      );
+    }
+
+    const body = (await res.json()) as
+      | { results?: TihldeMembership[]; next?: string | null }
+      | TihldeMembership[];
+
+    if (Array.isArray(body)) {
+      // Unpaginated response — everything is already here.
+      all.push(...body);
+      break;
+    }
+
+    all.push(...(body.results ?? []));
+    url = body.next ?? null;
   }
 
-  const body = (await res.json()) as
-    | { results?: TihldeMembership[] }
-    | TihldeMembership[];
-  return Array.isArray(body) ? body : (body.results ?? []);
+  return all;
 }
 
 /** Whether the user is a member of the group with the given slug. */

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -34,6 +34,7 @@ export async function createUser(
     name: string;
     email: string | null;
     isAdmin: boolean;
+    adminOverride: boolean | null;
     isVerified: boolean;
     hasPaid: boolean;
     studieretning: string | null;
@@ -48,6 +49,7 @@ export async function createUser(
       name: overrides.name ?? `Test Bruker ${id}`,
       email: overrides.email === undefined ? `${id}@test.no` : overrides.email,
       isAdmin: overrides.isAdmin ?? false,
+      adminOverride: overrides.adminOverride ?? null,
       isVerified: overrides.isVerified ?? false,
       hasPaid: overrides.hasPaid ?? false,
       studieretning: overrides.studieretning ?? null,

--- a/tests/integration/auth-login.route.test.ts
+++ b/tests/integration/auth-login.route.test.ts
@@ -29,18 +29,12 @@ const PROFILE = {
   studyyear: { group: { name: "2026" } },
 };
 
-/** Stub the whole TIHLDE login chain: token, profile, permissions, memberships. */
+/** Stub the whole TIHLDE login chain: token, profile, memberships. */
 function stubTihldeLogin(opts: {
-  permissions?: Record<string, { read?: boolean; write?: boolean }>;
   memberships?: { group: { slug: string } }[];
 } = {}) {
   fetchMock.on("POST", "/auth/login/", json({ token: "tihlde-token" }));
   fetchMock.on("GET", "/users/me/", json(PROFILE));
-  fetchMock.on(
-    "GET",
-    "/users/me/permissions/",
-    json({ permissions: opts.permissions ?? { event: { read: true } } }),
-  );
   fetchMock.on(
     "GET",
     "/users/olanor/memberships/",
@@ -80,8 +74,8 @@ describe("POST /api/auth/login", () => {
     expect(cookie?.options).toMatchObject({ httpOnly: true, sameSite: "lax", path: "/" });
   });
 
-  it("gjør skrivetilgang i TIHLDE til app-admin, verifisert og betalt", async () => {
-    stubTihldeLogin({ permissions: { event: { read: true, write: true } } });
+  it("gjør FadderKom-medlemmer til admin, verifisert og betalt", async () => {
+    stubTihldeLogin({ memberships: [{ group: { slug: "fadderkom" } }] });
 
     await post(CREDENTIALS);
 
@@ -93,14 +87,41 @@ describe("POST /api/auth/login", () => {
     expect(user.hasPaid).toBe(true);
   });
 
-  it("gjør FadderKom-medlemmer til admin", async () => {
+  it("gjør IKKE medlemmer av andre komiteer til admin", async () => {
+    stubTihldeLogin({
+      memberships: [{ group: { slug: "index" } }, { group: { slug: "sosialen" } }],
+    });
+
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isAdmin).toBe(false);
+    expect(user.hasPaid).toBe(false);
+  });
+
+  it("lar et manuelt satt admin-flagg overleve innlogging", async () => {
+    await createUser({ tihldeUserId: "olanor", isAdmin: true, adminOverride: true });
+    stubTihldeLogin();
+
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } });
+    expect(user.isAdmin).toBe(true);
+    // Ingen grunn til å spørre TIHLDE når avgjørelsen allerede er tatt manuelt.
+    expect(fetchMock.callsTo("/users/olanor/memberships/")).toHaveLength(0);
+  });
+
+  it("lar en manuell fratakelse overleve innlogging som FadderKom-medlem", async () => {
+    await createUser({ tihldeUserId: "olanor", isAdmin: false, adminOverride: false });
     stubTihldeLogin({ memberships: [{ group: { slug: "fadderkom" } }] });
 
     await post(CREDENTIALS);
 
     expect(
       (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } })).isAdmin,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("fratar en vanlig innlogging admin-status", async () => {
@@ -118,7 +139,6 @@ describe("POST /api/auth/login", () => {
     await createUser({ tihldeUserId: "olanor", isAdmin: true, isVerified: true });
     fetchMock.on("POST", "/auth/login/", json({ token: "tihlde-token" }));
     fetchMock.on("GET", "/users/me/", json(PROFILE));
-    fetchMock.on("GET", "/users/me/permissions/", text("boom", 500));
     fetchMock.on("GET", "/users/olanor/memberships/", text("boom", 500));
 
     const response = await post(CREDENTIALS);

--- a/tests/integration/auth-login.route.test.ts
+++ b/tests/integration/auth-login.route.test.ts
@@ -87,9 +87,19 @@ describe("POST /api/auth/login", () => {
     expect(user.hasPaid).toBe(true);
   });
 
+  it("gjør Index-medlemmer til admin", async () => {
+    stubTihldeLogin({ memberships: [{ group: { slug: "index" } }] });
+
+    await post(CREDENTIALS);
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } })).isAdmin,
+    ).toBe(true);
+  });
+
   it("gjør IKKE medlemmer av andre komiteer til admin", async () => {
     stubTihldeLogin({
-      memberships: [{ group: { slug: "index" } }, { group: { slug: "sosialen" } }],
+      memberships: [{ group: { slug: "sosialen" } }, { group: { slug: "promo" } }],
     });
 
     await post(CREDENTIALS);

--- a/tests/integration/tihlde-client.test.ts
+++ b/tests/integration/tihlde-client.test.ts
@@ -2,13 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   TihldeAuthError,
-  isAdminFromPermissions,
   isMemberOfGroup,
   mapProfile,
   tihldeCreateUser,
   tihldeGetMe,
   tihldeGetMemberships,
-  tihldeGetPermissions,
   tihldeLogin,
 } from "~/server/auth/tihlde";
 
@@ -133,15 +131,6 @@ describe("profil og tilganger", () => {
     ).toMatchObject({ name: "olanor", studieretning: null, klasse: null });
   });
 
-  it("regner skrivetilgang som admin, lesetilgang som vanlig bruker", () => {
-    expect(isAdminFromPermissions({ permissions: { event: { read: true } } })).toBe(false);
-    expect(isAdminFromPermissions({ permissions: { event: { write: true } } })).toBe(true);
-    expect(
-      isAdminFromPermissions({ permissions: { event: { write_all: true } } }),
-    ).toBe(true);
-    expect(isAdminFromPermissions({ permissions: {} })).toBe(false);
-  });
-
   it("leser medlemskap både som liste og paginert svar", async () => {
     fetchMock.once("GET", "/users/olanor/memberships/", json({ results: [{ group: { slug: "fadderkom" } }] }));
     await expect(tihldeGetMemberships("t", "olanor")).resolves.toEqual([
@@ -160,9 +149,32 @@ describe("profil og tilganger", () => {
     expect(isMemberOfGroup(memberships, "index")).toBe(false);
   });
 
-  it("kaster med statuskoden når tilganger ikke kan hentes", async () => {
-    fetchMock.on("GET", "/users/me/permissions/", text("boom", 500));
+  it("følger pagineringen så medlemskap på side 2 ikke går tapt", async () => {
+    fetchMock.once(
+      "GET",
+      "/users/olanor/memberships/",
+      json({
+        results: [{ group: { slug: "index" } }],
+        next: "https://tihlde.test/users/olanor/memberships/?page=2",
+      }),
+    );
+    fetchMock.once(
+      "GET",
+      "/users/olanor/memberships/",
+      json({ results: [{ group: { slug: "fadderkom" } }], next: null }),
+    );
 
-    await expect(tihldeGetPermissions("t")).rejects.toMatchObject({ status: 500 });
+    const memberships = await tihldeGetMemberships("t", "olanor");
+
+    expect(memberships).toHaveLength(2);
+    expect(isMemberOfGroup(memberships, "fadderkom")).toBe(true);
+  });
+
+  it("kaster med statuskoden når medlemskap ikke kan hentes", async () => {
+    fetchMock.on("GET", "/users/olanor/memberships/", text("boom", 500));
+
+    await expect(tihldeGetMemberships("t", "olanor")).rejects.toMatchObject({
+      status: 500,
+    });
   });
 });

--- a/tests/integration/tihlde-client.test.ts
+++ b/tests/integration/tihlde-client.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   TihldeAuthError,
-  isMemberOfGroup,
+  isMemberOfAnyGroup,
   mapProfile,
   tihldeCreateUser,
   tihldeGetMe,
@@ -143,10 +143,12 @@ describe("profil og tilganger", () => {
     ]);
   });
 
-  it("gjenkjenner medlemskap i en gruppe på slug", () => {
+  it("gjenkjenner medlemskap i en av flere grupper på slug", () => {
     const memberships = [{ group: { slug: "fadderkom" } }, { group: null }];
-    expect(isMemberOfGroup(memberships, "fadderkom")).toBe(true);
-    expect(isMemberOfGroup(memberships, "index")).toBe(false);
+    expect(isMemberOfAnyGroup(memberships, ["fadderkom"])).toBe(true);
+    expect(isMemberOfAnyGroup(memberships, ["index"])).toBe(false);
+    expect(isMemberOfAnyGroup(memberships, ["index", "fadderkom"])).toBe(true);
+    expect(isMemberOfAnyGroup(memberships, [])).toBe(false);
   });
 
   it("følger pagineringen så medlemskap på side 2 ikke går tapt", async () => {
@@ -167,7 +169,7 @@ describe("profil og tilganger", () => {
     const memberships = await tihldeGetMemberships("t", "olanor");
 
     expect(memberships).toHaveLength(2);
-    expect(isMemberOfGroup(memberships, "fadderkom")).toBe(true);
+    expect(isMemberOfAnyGroup(memberships, ["fadderkom"])).toBe(true);
   });
 
   it("kaster med statuskoden når medlemskap ikke kan hentes", async () => {


### PR DESCRIPTION
Slår sammen to ting som henger sammen: integrasjonstestene for serverflaten, og en sikkerhetsfiks i admin-utledningen som testene fanger.

## Sikkerhetsfiksen

Admin ble utledet fra TIHLDE-skriverettigheter (en port av Kvarks `hasWritePermission`). Lepton deler ut `write` til vanlige medlemmer av undergrupper og komiteer, så kriteriet betydde i praksis **"har et verv i TIHLDE"** — ikke "er administrator".

Konsekvens: en bruker uten noen tilknytning til FadderKom ble full app-admin, med tilgang til brukerlister, betalingsstatus og Vipps-refusjoner. Oppdaget på en konkret prod-bruker.

Kvark bruker den samme sjekken kun til å avgjøre om admin-*inngangen* skal vises, og gater hver enkelt side på sin egen permission-app. Vi hadde kopiert portvakten og hoppet over sjekkene bak.

**Endringer:**

- `tihldeGetPermissions` / `isAdminFromPermissions` er fjernet. Admin gis nå kun til medlemmer av gruppene **`fadderkom`** (arrangør) og **`index`** (drifter appen).
- Ny kolonne `User.adminOverride` (`null` = utled fra TIHLDE, `true`/`false` = låst manuelt). Adminpanelets admin-toggle hadde ingen varig effekt før — login skrev over `isAdmin` ved hver innlogging.
- `tihldeGetMemberships` følger pagineringen. Med medlemskap som eneste kriterium ville side 1-begrensningen ellers gitt vilkårlig tap av admin for folk i mange grupper.

## Integrasjonstester

171 tester over hele serverflaten (auth, tRPC-routere, Vipps), med egen testdatabase som utledes fra `.env` og opprettes automatisk. CI kjører dem på PR.

## Før merge til prod

Migrasjonen `20260720120000_admin_override` **må kjøres manuelt** mot Neon (`prisma migrate deploy`) — Vercel kjører den ikke, og login krasjer på manglende kolonne uten den.

Merk også at alle nåværende admins som fikk statusen via skriverettigheter og *ikke* står i `fadderkom` eller `index`, mister admin ved neste innlogging. De som skal beholde den trenger `adminOverride: true`.

## Verifisert

`tsc --noEmit` rent · `vitest run` 171/171 · `npm run build` OK · lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)