### PR TITLE
fix(ui): fjern "Min side" fra brukermenyen

### DIFF
--- a/src/components/layout/user-area.tsx
+++ b/src/components/layout/user-area.tsx
@@ -49,11 +49,6 @@ export const UserArea = ({
     router.push("/admin");
   };
 
-  const goToMyPage = () => {
-    setOpen(false);
-    router.push("/min-side");
-  };
-
   return (
     <div
       {...props}
@@ -115,13 +110,6 @@ export const UserArea = ({
 
             {isAuthenticated ? (
               <div className="flex flex-col gap-2">
-                <Button
-                  variant="outline"
-                  className="border-border/60 bg-muted/40 text-foreground hover:bg-muted/60 w-full"
-                  onClick={goToMyPage}
-                >
-                  Min side
-                </Button>
                 {admin ? (
                   <Button
                     variant="outline"


### PR DESCRIPTION
«Min side» pekte på `/min-side`, og den ruta har aldri eksistert – et klikk ga rett og slett 404. Siden brukes ikke til noe, så knappen og `goToMyPage`-handleren er fjernet i stedet for at ruta lages.

Alt lå i én fil (`src/components/layout/user-area.tsx`); ingen andre referanser til `/min-side` fantes i kodebasen.

Innlogget bruker ser nå bare «Admin» (hvis admin) og «Logg ut» i profilmenyen.

## Verifisering

- Sjekket i nettleser som innlogget admin: menyen viser Admin + Logg ut, ingen hull i layouten.
- `tsc --noEmit` rent, `bun run test` 171/171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)