### PR TITLE
feat(auth): la innelåste brukere velge et passord mens de er innlogget

### DIFF
--- a/src/app/(authenticated)/layout.tsx
+++ b/src/app/(authenticated)/layout.tsx
@@ -1,7 +1,7 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import React from "react";
-import { auth } from "~/server/auth/config";
+import { auth, needsLocalPassword } from "~/server/auth/config";
 import AllergySync from "~/components/allergy-sync";
 import VippsPaymentOverlay from "~/components/vipps-payment-overlay";
 
@@ -16,6 +16,12 @@ export default async function AuthenticatedLayout({
 
   if (!session?.user) {
     redirect("/registrering");
+  }
+
+  // Accounts that would be locked out the moment this session expires get one
+  // blocking stop: choose a password while we can still tell who they are.
+  if (needsLocalPassword(session)) {
+    redirect("/velg-passord");
   }
 
   if (!session.user.isVerified) {

--- a/src/app/api/auth/set-password/route.ts
+++ b/src/app/api/auth/set-password/route.ts
@@ -1,0 +1,55 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth, needsLocalPassword } from "~/server/auth/config";
+import { hashPassword } from "~/server/auth/password";
+import { db } from "~/server/db";
+
+/**
+ * Let a logged-in user choose a local password for this app.
+ *
+ * Only for accounts that depend on the local login bridge: they registered
+ * here before we started storing a password hash, so nothing can authenticate
+ * them once the current session expires. The live session is what proves who
+ * they are — asking for a username alone would let anyone claim an account,
+ * since the username is their Feide name and not a secret.
+ *
+ * The password is local to this app; tihlde.org keeps whatever password the
+ * account already has there.
+ */
+
+const bodySchema = z.object({
+  password: z.string().min(8, "Passordet må være minst 8 tegn."),
+});
+
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return NextResponse.json({ error: "Du er ikke logget inn." }, { status: 401 });
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ugyldig passord." },
+      { status: 400 },
+    );
+  }
+
+  if (!needsLocalPassword(session)) {
+    // Either they already have a local password, or TIHLDE authenticates them
+    // and owns their password. Nothing to do here in both cases.
+    return NextResponse.json(
+      { error: "Kontoen din trenger ikke et eget passord her." },
+      { status: 400 },
+    );
+  }
+
+  await db.user.update({
+    where: { id: session.user.id },
+    data: { passwordHash: await hashPassword(parsed.data.password) },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/velg-passord/page.tsx
+++ b/src/app/velg-passord/page.tsx
@@ -1,0 +1,63 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import Footer from "~/components/layout/footer/footer";
+import { Card, CardDescription, CardTitle } from "~/components/ui/card";
+import { auth, needsLocalPassword } from "~/server/auth/config";
+
+import { VelgPassordForm } from "./velg-passord-form";
+
+/**
+ * One-off page for accounts that registered here before we stored a password
+ * hash. They are logged in right now, but nothing could let them back in once
+ * the session expires — so we ask them to pick a password while the live
+ * session still proves who they are. Lives outside the (authenticated) group
+ * so the layout's redirect here cannot loop.
+ */
+export default async function VelgPassordPage() {
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  if (!session?.user) redirect("/logg-inn");
+  // Nothing to do for anyone else — don't strand them on a dead-end page.
+  if (!needsLocalPassword(session)) redirect("/");
+
+  return (
+    <div
+      className="flex min-h-screen flex-col"
+      style={{
+        backgroundColor: "var(--page-bg)",
+        backgroundImage: "var(--page-bg-image)",
+      }}
+    >
+      <main className="flex flex-1 items-center justify-center px-4 py-8">
+        <div className="w-full max-w-xl">
+          <Card>
+            <div className="flex flex-col gap-6 p-8 sm:p-12">
+              <div className="flex flex-col gap-2">
+                <CardTitle className="text-3xl font-bold">
+                  Velg et passord
+                </CardTitle>
+                <CardDescription>
+                  Brukeren din på tihlde.org venter fortsatt på godkjenning, og
+                  fram til den er godkjent kan du ikke logge inn her med
+                  TIHLDE-passordet ditt. Velg et passord du bruker her, så
+                  kommer du inn igjen neste gang.
+                </CardDescription>
+                <CardDescription>
+                  Du logger inn med brukernavnet ditt,{" "}
+                  <span className="font-semibold text-foreground">
+                    {session.user.tihldeUserId}
+                  </span>
+                  . Passordet gjelder bare denne siden — passordet ditt på
+                  tihlde.org endres ikke.
+                </CardDescription>
+              </div>
+
+              <VelgPassordForm />
+            </div>
+          </Card>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/velg-passord/velg-passord-form.tsx
+++ b/src/app/velg-passord/velg-passord-form.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+export function VelgPassordForm() {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    const formData = new FormData(e.currentTarget);
+    const password = formData.get("password") as string;
+    const repeat = formData.get("password_repeat") as string;
+
+    if (password !== repeat) {
+      setError("Passordene er ikke like.");
+      return;
+    }
+
+    setLoading(true);
+    const res = await fetch("/api/auth/set-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
+
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      setError(body?.error ?? "Noe gikk galt. Prøv igjen.");
+      setLoading(false);
+      return;
+    }
+
+    router.push("/");
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="password">Nytt passord</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="minst 8 tegn"
+          required
+          minLength={8}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="password_repeat">Gjenta passordet</Label>
+        <Input
+          id="password_repeat"
+          name="password_repeat"
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={8}
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      <Button type="submit" disabled={loading} className="w-full">
+        {loading ? "Lagrer..." : "Lagre passord"}
+      </Button>
+    </form>
+  );
+}

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -80,6 +80,23 @@ export async function deleteSession(token: string) {
 }
 
 /**
+ * True when the signed-in user has no way back in once this session expires.
+ *
+ * Applies to accounts that registered here before we stored a password hash:
+ * TIHLDE rejects them until an admin approves the account (so the session has
+ * no TIHLDE token), and we have nothing local to check either. They are asked
+ * to choose a password while the session still proves who they are.
+ *
+ * Derived rather than a hardcoded list of usernames, so it stays correct as
+ * accounts get approved and as new ones appear.
+ */
+export function needsLocalPassword(
+  session: NonNullable<Awaited<ReturnType<typeof getSession>>>,
+): boolean {
+  return !session.user.passwordHash && !session.session.tihldeToken;
+}
+
+/**
  * Mirrors the better-auth `auth.api.getSession` interface the app relies on.
  * Returns `{ user, session } | null`.
  */

--- a/tests/integration/auth-set-password.route.test.ts
+++ b/tests/integration/auth-set-password.route.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { POST as setPassword } from "~/app/api/auth/set-password/route";
+import { SESSION_COOKIE, createSession } from "~/server/auth/config";
+import { hashPassword, verifyPassword } from "~/server/auth/password";
+
+import { createUser, db } from "../helpers/db";
+import { resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+const post = (body: unknown) =>
+  setPassword(
+    new Request("https://fadderuka.test/api/auth/set-password", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+
+/**
+ * Sign a user in and hand the route the session cookie. The handler reads it
+ * through `next/headers`, so it has to go on the mocked request headers rather
+ * than on the Request itself.
+ */
+async function signIn(userId: string, tihldeToken: string | null) {
+  resetNextHeaders({ "user-agent": "vitest" });
+  const { token } = await createSession({ userId, tihldeToken });
+  resetNextHeaders({
+    "user-agent": "vitest",
+    cookie: `${SESSION_COOKIE}=${token}`,
+  });
+}
+
+describe("POST /api/auth/set-password", () => {
+  it("lar en innlogget bruker uten lokalt passord sette ett", async () => {
+    const user = await createUser({ tihldeUserId: "ventende", hasPaid: true });
+    await signIn(user.id, null);
+
+    const response = await post({ password: "mitt-nye-passord" });
+
+    expect(response.status).toBe(200);
+    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    // Kun hashen lagres, og den skal matche det brukeren skrev inn.
+    expect(stored.passwordHash).not.toContain("mitt-nye-passord");
+    await expect(
+      verifyPassword("mitt-nye-passord", stored.passwordHash),
+    ).resolves.toBe(true);
+  });
+
+  it("avviser uinnloggede", async () => {
+    resetNextHeaders({ "user-agent": "vitest" });
+
+    const response = await post({ password: "mitt-nye-passord" });
+
+    expect(response.status).toBe(401);
+    expect(await db.user.count({ where: { passwordHash: { not: null } } })).toBe(0);
+  });
+
+  it("avviser passord som er for korte", async () => {
+    const user = await createUser();
+    await signIn(user.id, null);
+
+    const response = await post({ password: "kort" });
+
+    expect(response.status).toBe(400);
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).passwordHash,
+    ).toBeNull();
+  });
+
+  it("avviser en bruker som allerede har et lokalt passord", async () => {
+    // Ellers ville ruta vært en vei til å overskrive passordet uten å kunne det
+    // gamle, for den som skulle få tak i en sesjon.
+    const user = await createUser({
+      passwordHash: await hashPassword("eksisterende-passord"),
+    });
+    await signIn(user.id, null);
+
+    const response = await post({ password: "overskrevet-passord" });
+
+    expect(response.status).toBe(400);
+    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    await expect(
+      verifyPassword("eksisterende-passord", stored.passwordHash),
+    ).resolves.toBe(true);
+  });
+
+  it("avviser en bruker som TIHLDE allerede autentiserer", async () => {
+    const user = await createUser();
+    await signIn(user.id, "tihlde-token");
+
+    const response = await post({ password: "et-lokalt-passord" });
+
+    expect(response.status).toBe(400);
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).passwordHash,
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Hvem det gjelder

Målt i prod: **6 kontoer** har aldri logget inn via TIHLDE (5 av dem har betalt). De registrerte seg her før vi begynte å lagre en passord-hash, så når sesjonen deres utløper finnes det ingenting som kan slippe dem inn igjen — TIHLDE avviser dem til kontoen godkjennes, og vi har ingen lokal hash å sjekke mot.

**Alle 6 har en aktiv sesjon akkurat nå.** Det er det som gjør denne løsningen mulig.

## Løsning

Den levende sesjonen er beviset på hvem de er. Ved neste sidelast havner de på `/velg-passord` og kommer ikke videre i appen før passordet er satt.

Dette var et bevisst valg framfor en side som bare spør om brukernavn: brukernavnet er Feide-navnet deres, ikke en hemmelighet, så den varianten ville latt hvem som helst overta de 5 betalte kontoene.

- `needsLocalPassword()` i `src/server/auth/config.ts` er den ene definisjonen av gruppa (mangler `passwordHash` + sesjon uten TIHLDE-token), brukt av både gaten og API-ruta så de ikke kan komme i utakt.
- Gruppa **utledes** i stedet for å hardkodes som en liste brukernavn, så den holder seg riktig etter hvert som kontoer godkjennes på tihlde.org.
- `POST /api/auth/set-password` krever innlogget sesjon, og avviser både de som allerede har et lokalt passord og de som TIHLDE autentiserer.
- `/velg-passord` ligger utenfor `(authenticated)`-gruppa, så redirecten fra layouten ikke kan loope.

## Tidsvindu

Sesjoner varer 7 dager og slettes ved utlogging. Den som rekker å sette passord før sin sesjon ryker er trygg; faller noen utenfor, finnes «Engangspassord» i adminpanelet som backup. **Dette bør derfor ut raskt for å ha effekt.**

## Verifisering

- `bun run test` 182/182 (5 nye rundt `/api/auth/set-password`: innlogget uten passord får satt ett, uinnlogget avvises, for kort passord avvises, eksisterende passord kan ikke overskrives, TIHLDE-autentiserte avvises). `tsc --noEmit` rent.
- Kjørt hele sløyfen i nettleser mot en bruker satt i nøyaktig samme tilstand som de 6 (ingen `passwordHash`, sesjon uten TIHLDE-token): `/aktiviteter` redirigerte til `/velg-passord`, ulike passord ga «Passordene er ikke like», lagring slapp brukeren inn i appen. Deretter slettet jeg sesjonene for å simulere utløp — innlogging med det nye passordet ga **200**, og det gamle ga **401**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)