### PR TITLE
fix(admin): gjør engangspassord tilgjengelig for betalende brukere

### DIFF
--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -327,6 +327,7 @@ export function UsersTab() {
                           <th className="!px-4 !py-3 font-medium">Gruppe</th>
                           <th className="!px-4 !py-3 font-medium">Rolle</th>
                           <th className="!px-4 !py-3 font-medium text-center">Admin</th>
+                          <th className="!px-4 !py-3 font-medium">Passord</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -412,13 +413,50 @@ export function UsersTab() {
                                   )}
                                 </button>
                               </td>
+                              {/* Betaling setter isVerified, så brukere som er
+                                  låst ute i påvente av godkjenning på
+                                  tihlde.org havner her og ikke i lista over
+                                  uverifiserte. Knappen må derfor finnes begge
+                                  steder. */}
+                              <td className="!px-4 !py-3">
+                                {tempPassword?.userId === user.id ? (
+                                  <div className="flex flex-col !gap-1">
+                                    <code className="rounded-lg border border-border bg-background !px-2 !py-1 text-xs font-semibold text-foreground">
+                                      {tempPassword.tihldeUserId} /{" "}
+                                      {tempPassword.password}
+                                    </code>
+                                    <button
+                                      type="button"
+                                      onClick={() => setTempPassword(null)}
+                                      className="self-start text-xs text-muted-foreground transition hover:text-foreground"
+                                    >
+                                      Lukk
+                                    </button>
+                                  </div>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      resetPasswordMutation.mutate({
+                                        userId: user.id,
+                                      })
+                                    }
+                                    disabled={resetPasswordMutation.isPending}
+                                    title="Lag et engangspassord for innlogging her, i påvente av godkjenning på tihlde.org"
+                                    className="inline-flex items-center !gap-1.5 rounded-lg border border-border bg-secondary !px-2.5 !py-1 text-xs font-medium text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
+                                  >
+                                    <KeyRound className="h-3.5 w-3.5" />
+                                    Engangspassord
+                                  </button>
+                                )}
+                              </td>
                             </tr>
                           );
                         })}
                         {usersInGroup.length === 0 && (
                           <tr>
                             <td
-                              colSpan={6}
+                              colSpan={7}
                               className="!px-4 !py-6 text-center text-muted-foreground"
                             >
                               Ingen brukere funnet


### PR DESCRIPTION
## Problemet

«Engangspassord»-knappen lå kun i seksjonen **«Nye uverifiserte brukere»**, som filtrerer på `!isVerified`.

Men Vipps-betaling setter `isVerified: true` ([vipps.ts:547](https://github.com/TIHLDE/Fadderuka/blob/dev/src/server/payment/vipps.ts#L547)). De som er låst ute i påvente av godkjenning på tihlde.org har betalt — så de havner i tabellen over *verifiserte* brukere, der knappen ikke fantes.

Resultat: nøyaktig den gruppa knappen ble laget for, var utenfor rekkevidde. Av de 6 låste kontoene i prod var det bare den ene ubetalte som viste knappen.

## Fiksen

Ny «Passord»-kolonne i tabellen over verifiserte brukere, med samme oppførsel som i den andre seksjonen: klikk gir brukernavn + passord vist én gang, og «Lukk» skjuler det igjen.

tRPC-prosedyren `resetUserPassword` fungerte hele tiden for hvilken som helst bruker — det var kun plasseringen i grensesnittet som utelot målgruppa. Ingen endring på server-siden, ingen migrasjon.

## Verifisering

- Reproduserte prod-situasjonen lokalt: en betalt bruker (`isVerified: true`, `passwordHash: null`) havnet som forventet blant de verifiserte, mens den ubetalte lå i den øvre seksjonen.
- Bekreftet at kolonnene nå er `Navn, E-post, Klasse, Gruppe, Rolle, Admin, Passord`, og at knappen finnes i raden.
- Klikket knappen → fikk `betalende / w6u3thxs2zea` vist i raden → logget inn via `/api/auth/login` med det passordet: **200**. Feil passord: **401**.
- `bun run test` 189/189, `tsc --noEmit` rent, `next build` OK, ingen nye lint-feil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)