### PR TITLE
feat(auth): la brukere bytte ut engangspassordet med sitt eget

### DIFF
--- a/prisma/migrations/20260720180000_password_is_temporary/migration.sql
+++ b/prisma/migrations/20260720180000_password_is_temporary/migration.sql
@@ -1,0 +1,3 @@
+-- Marks an admin-issued one-time password, so the user is prompted to replace
+-- it with one of their own instead of keeping the generated string.
+ALTER TABLE "User" ADD COLUMN "passwordIsTemporary" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,9 @@ model User {
     // awaits approval, so they can log back in before tihlde.org activates
     // them. Cleared on the first successful TIHLDE login.
     passwordHash  String?
+    // True when passwordHash is an admin-issued one-time password. The user is
+    // asked to replace it with one of their own on the next page load.
+    passwordIsTemporary Boolean @default(false)
     createdAt     DateTime  @default(now())
     updatedAt     DateTime  @updatedAt
     sessions      Session[]

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -327,6 +327,7 @@ export function UsersTab() {
                           <th className="!px-4 !py-3 font-medium">Gruppe</th>
                           <th className="!px-4 !py-3 font-medium">Rolle</th>
                           <th className="!px-4 !py-3 font-medium text-center">Admin</th>
+                          <th className="!px-4 !py-3 font-medium">Passord</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -412,13 +413,50 @@ export function UsersTab() {
                                   )}
                                 </button>
                               </td>
+                              {/* Betaling setter isVerified, så brukere som er
+                                  låst ute i påvente av godkjenning på
+                                  tihlde.org havner her og ikke i lista over
+                                  uverifiserte. Knappen må derfor finnes begge
+                                  steder. */}
+                              <td className="!px-4 !py-3">
+                                {tempPassword?.userId === user.id ? (
+                                  <div className="flex flex-col !gap-1">
+                                    <code className="rounded-lg border border-border bg-background !px-2 !py-1 text-xs font-semibold text-foreground">
+                                      {tempPassword.tihldeUserId} /{" "}
+                                      {tempPassword.password}
+                                    </code>
+                                    <button
+                                      type="button"
+                                      onClick={() => setTempPassword(null)}
+                                      className="self-start text-xs text-muted-foreground transition hover:text-foreground"
+                                    >
+                                      Lukk
+                                    </button>
+                                  </div>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      resetPasswordMutation.mutate({
+                                        userId: user.id,
+                                      })
+                                    }
+                                    disabled={resetPasswordMutation.isPending}
+                                    title="Lag et engangspassord for innlogging her, i påvente av godkjenning på tihlde.org"
+                                    className="inline-flex items-center !gap-1.5 rounded-lg border border-border bg-secondary !px-2.5 !py-1 text-xs font-medium text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
+                                  >
+                                    <KeyRound className="h-3.5 w-3.5" />
+                                    Engangspassord
+                                  </button>
+                                )}
+                              </td>
                             </tr>
                           );
                         })}
                         {usersInGroup.length === 0 && (
                           <tr>
                             <td
-                              colSpan={6}
+                              colSpan={7}
                               className="!px-4 !py-6 text-center text-muted-foreground"
                             >
                               Ingen brukere funnet

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -159,6 +159,7 @@ export async function POST(request: Request) {
         studieretning: mapped.studieretning,
         klasse: mapped.klasse,
         passwordHash: null,
+        passwordIsTemporary: false,
         ...adminGrant,
       },
     });

--- a/src/app/api/auth/set-password/route.ts
+++ b/src/app/api/auth/set-password/route.ts
@@ -48,7 +48,10 @@ export async function POST(request: Request) {
 
   await db.user.update({
     where: { id: session.user.id },
-    data: { passwordHash: await hashPassword(parsed.data.password) },
+    data: {
+      passwordHash: await hashPassword(parsed.data.password),
+      passwordIsTemporary: false,
+    },
   });
 
   return NextResponse.json({ ok: true });

--- a/src/app/velg-passord/page.tsx
+++ b/src/app/velg-passord/page.tsx
@@ -20,6 +20,10 @@ export default async function VelgPassordPage() {
   // Nothing to do for anyone else — don't strand them on a dead-end page.
   if (!needsLocalPassword(session)) redirect("/");
 
+  // Two ways to land here, and the wording has to match: either an admin just
+  // handed them a one-time password, or they have none at all.
+  const hasTempPassword = session.user.passwordIsTemporary;
+
   return (
     <div
       className="flex min-h-screen flex-col"
@@ -34,13 +38,17 @@ export default async function VelgPassordPage() {
             <div className="flex flex-col gap-6 p-8 sm:p-12">
               <div className="flex flex-col gap-2">
                 <CardTitle className="text-3xl font-bold">
-                  Velg et passord
+                  {hasTempPassword ? "Velg ditt eget passord" : "Velg et passord"}
                 </CardTitle>
                 <CardDescription>
-                  Brukeren din på tihlde.org venter fortsatt på godkjenning, og
-                  fram til den er godkjent kan du ikke logge inn her med
-                  TIHLDE-passordet ditt. Velg et passord du bruker her, så
-                  kommer du inn igjen neste gang.
+                  {hasTempPassword
+                    ? `Du logget inn med et engangspassord du fikk av
+                       fadderkomiteen. Velg nå et passord du selv husker — det
+                       erstatter engangspassordet.`
+                    : `Brukeren din på tihlde.org venter fortsatt på godkjenning,
+                       og fram til den er godkjent kan du ikke logge inn her med
+                       TIHLDE-passordet ditt. Velg et passord du bruker her, så
+                       kommer du inn igjen neste gang.`}
                 </CardDescription>
                 <CardDescription>
                   Du logger inn med brukernavnet ditt,{" "}

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -84,7 +84,11 @@ export const adminRouter = createTRPCRouter({
       const password = generateTempPassword();
       const user = await ctx.db.user.update({
         where: { id: input.userId },
-        data: { passwordHash: await hashPassword(password) },
+        data: {
+          passwordHash: await hashPassword(password),
+          // Brukeren blir bedt om å bytte det ut ved neste sidelast.
+          passwordIsTemporary: true,
+        },
         select: { tihldeUserId: true },
       });
       return { tihldeUserId: user.tihldeUserId, password };

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -80,12 +80,15 @@ export async function deleteSession(token: string) {
 }
 
 /**
- * True when the signed-in user has no way back in once this session expires.
+ * True when the signed-in user should choose a local password for this app.
  *
- * Applies to accounts that registered here before we stored a password hash:
- * TIHLDE rejects them until an admin approves the account (so the session has
- * no TIHLDE token), and we have nothing local to check either. They are asked
- * to choose a password while the session still proves who they are.
+ * Two cases, both limited to accounts TIHLDE does not authenticate yet (no
+ * token on the session, because tihlde.org has not approved them):
+ *
+ *  - No password at all: they registered here before we stored a hash, so
+ *    nothing would let them back in once this session expires.
+ *  - An admin-issued one-time password: it got them in, but it is a random
+ *    string nobody wants to keep, so they are asked to replace it.
  *
  * Derived rather than a hardcoded list of usernames, so it stays correct as
  * accounts get approved and as new ones appear.
@@ -93,7 +96,8 @@ export async function deleteSession(token: string) {
 export function needsLocalPassword(
   session: NonNullable<Awaited<ReturnType<typeof getSession>>>,
 ): boolean {
-  return !session.user.passwordHash && !session.session.tihldeToken;
+  if (session.session.tihldeToken) return false;
+  return !session.user.passwordHash || session.user.passwordIsTemporary;
 }
 
 /**

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -41,6 +41,7 @@ export async function createUser(
     studieretning: string | null;
     klasse: string | null;
     passwordHash: string | null;
+    passwordIsTemporary: boolean;
     createdAt: Date;
   }> = {},
 ) {
@@ -57,6 +58,7 @@ export async function createUser(
       studieretning: overrides.studieretning ?? null,
       klasse: overrides.klasse ?? null,
       passwordHash: overrides.passwordHash ?? null,
+      passwordIsTemporary: overrides.passwordIsTemporary ?? false,
       ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
     },
   });

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -114,6 +114,8 @@ describe("admin: brukere og grupper", () => {
     await expect(verifyPassword(result.password, stored.passwordHash)).resolves.toBe(
       true,
     );
+    // Merket som midlertidig, så brukeren blir bedt om å velge sitt eget.
+    expect(stored.passwordIsTemporary).toBe(true);
   });
 
   it("lager et nytt engangspassord hver gang", async () => {

--- a/tests/integration/auth-set-password.route.test.ts
+++ b/tests/integration/auth-set-password.route.test.ts
@@ -68,6 +68,25 @@ describe("POST /api/auth/set-password", () => {
     ).toBeNull();
   });
 
+  it("lar en bruker bytte ut et admin-utstedt engangspassord", async () => {
+    // Poenget med engangspassordet: det skal ikke bli det de sitter med.
+    const user = await createUser({
+      passwordHash: await hashPassword("engangspassord"),
+      passwordIsTemporary: true,
+    });
+    await signIn(user.id, null);
+
+    const response = await post({ password: "mitt-egne-passord" });
+
+    expect(response.status).toBe(200);
+    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    await expect(verifyPassword("mitt-egne-passord", stored.passwordHash)).resolves.toBe(true);
+    // Det gamle engangspassordet skal ikke lenger gjelde ...
+    await expect(verifyPassword("engangspassord", stored.passwordHash)).resolves.toBe(false);
+    // ... og passordet er ikke midlertidig lenger, så de slipper å velge igjen.
+    expect(stored.passwordIsTemporary).toBe(false);
+  });
+
   it("avviser en bruker som allerede har et lokalt passord", async () => {
     // Ellers ville ruta vært en vei til å overskrive passordet uten å kunne det
     // gamle, for den som skulle få tak i en sesjon.


### PR DESCRIPTION
> **Bygger på #88** — den er inkludert i denne grenen (samme commit `aba4617`), siden hele flyten er umulig å teste uten at knappen er tilgjengelig for betalende brukere. Merges #88 først, blir dette bare det ene tilleggs-commiten.

## Problemet

Engangspassordet holdt ikke det navnet lovet. Så snart en admin utstedte det, var `passwordHash` ikke lenger `null` — og da:

- slo `needsLocalPassword()` av, så brukeren ble aldri sendt til `/velg-passord`
- avviste `/api/auth/set-password` dem med 400 («Kontoen din trenger ikke et eget passord her»)

Resultatet: studenten satt igjen med en tilfeldig 12-tegns streng ut fadderuka, uten noen vei til å velge sitt eget.

## Fiksen

Nytt felt `User.passwordIsTemporary` merker admin-utstedte passord:

- `resetUserPassword` setter det til `true`
- `needsLocalPassword()` sender dem til `/velg-passord` også når passordet er midlertidig
- `/api/auth/set-password` godtar dem, og setter flagget til `false`
- TIHLDE-innlogging nullstiller både `passwordHash` og flagget, som før

Sikkerhetsegenskapen fra #85 består: et **selvvalgt** passord kan fortsatt ikke overskrives via denne ruta, så en stjålet sesjon kan ikke låse den ekte brukeren ute. Det er kun det midlertidige passordet som kan byttes — og det er hele poenget med det.

Teksten på `/velg-passord` er tilpasset de to måtene man havner der på («Velg ditt eget passord» / «Du logget inn med et engangspassord du fikk av fadderkomiteen»).

## Verifisering

Kjørte hele kjeden i nettleser slik en student vil oppleve den:

1. Admin klikker «Engangspassord» på en betalt, utestengt bruker → `student / jju8sput5sf8`
2. Studenten logger inn med det → **200**
3. Går inn i appen → sendes til `/velg-passord` med engangspassord-teksten
4. Velger `mitt-valgte-passord` → slippes inn i appen
5. Slettet sesjonene for å simulere utløp: eget passord → **200**, gammelt engangspassord → **401**
6. Ny navigasjon inn i appen → ingen ny spørring, lander på `/aktiviteter`

`bun run test` 190/190 (2 nye assertions: engangspassord merkes midlertidig, og kan byttes ut mens det gamle slutter å gjelde). `tsc --noEmit` rent, `next build` OK, ingen nye lint-feil.

## Før merge

Krever migrasjonen `20260720180000_password_is_temporary` i prod (`prisma migrate deploy`) — én ny kolonne med default `false`, rører ingen eksisterende data. Si fra når den er merget, så tar jeg den.

🤖 Generated with [Claude Code](https://claude.com/claude-code)