### PR TITLE
fix(admin): gi adminpanelet full sidebredde og fjern beløp-kolonnen

### DIFF
--- a/src/app/(authenticated)/admin/betalinger-tab.tsx
+++ b/src/app/(authenticated)/admin/betalinger-tab.tsx
@@ -602,7 +602,6 @@ export function BetalingerTab() {
                 {sortableHeader("gruppe", "Faddergruppe")}
                 <th className="!px-4 !py-3 font-medium">Rolle</th>
                 {sortableHeader("status", "Betaling")}
-                <th className="!px-4 !py-3 font-medium">Beløp</th>
                 {sortableHeader("registrert", "Påmeldt")}
                 {sortableHeader("betalt", "Betalt")}
               </tr>
@@ -641,9 +640,6 @@ export function BetalingerTab() {
                     <td className="!px-4 !py-3">
                       <StatusBadge status={r.paymentStatus} hasPaid={r.hasPaid} />
                     </td>
-                    <td className="!px-4 !py-3 text-muted-foreground">
-                      {r.amountPaid > 0 ? kr(r.amountPaid) : "—"}
-                    </td>
                     <td className="!px-4 !py-3 whitespace-nowrap text-muted-foreground">
                       {formatDateTime(r.registeredAt)}
                     </td>
@@ -653,7 +649,7 @@ export function BetalingerTab() {
                   </tr>
                   {expandedId === r.id && (
                     <tr className="border-b border-border">
-                      <td colSpan={10} className="bg-muted/30 !px-4 !py-4">
+                      <td colSpan={9} className="bg-muted/30 !px-4 !py-4">
                         {r.orderId ? (
                           <div className="!space-y-2">
                             <p className="font-mono text-xs text-muted-foreground">
@@ -676,7 +672,7 @@ export function BetalingerTab() {
               {filtered.length === 0 && (
                 <tr>
                   <td
-                    colSpan={10}
+                    colSpan={9}
                     className="!px-4 !py-8 text-center text-muted-foreground"
                   >
                     Ingen påmeldte funnet

--- a/src/app/(authenticated)/admin/page.tsx
+++ b/src/app/(authenticated)/admin/page.tsx
@@ -23,7 +23,7 @@ export default async function AdminPage() {
     >
 
       <div className="max-w-page relative mx-auto flex w-full flex-1 flex-col !px-4 !pt-24 !pb-16 md:!px-6">
-        <div className="mx-auto flex w-full max-w-[1040px] flex-col !gap-8">
+        <div className="mx-auto flex w-full flex-col !gap-8">
           <section className="!space-y-3">
             <h1 className="font-heading text-4xl leading-[1.15] font-semibold tracking-tight text-foreground md:text-5xl">
               Adminpanel


### PR DESCRIPTION
## Hva

- Fjerner `max-w-[1040px]`-innsnevringen i `admin/page.tsx`, så adminpanelet bruker samme sidebredde som resten av appen (`max-w-page` = `min(80rem, 90%)`, opptil 1280px).
- Fjerner «Beløp»-kolonnen fra betalingstabellen (header + celle) og justerer `colSpan` fra 10 → 9 i de utvidede radene og tom-tilstanden.

## Hvorfor

Betalingstabellen i adminpanelet var for smal til å vises i sin helhet — de siste kolonnene ble kuttet av. Panelet lå på en egen 1040px-grense inni en container som allerede tillater 1280px. Beløp-kolonnen tok plass uten å gi noe, siden alle betaler samme sum.

## Verdt å vite for review

- Bredden endres for **hele** adminpanelet, ikke bare Betalinger-fanen (Brukere, Faddergrupper, Aktiviteter blir også bredere).
- Beløp er fortsatt med i CSV-eksporten og i statistikk-kortene (Innbetalt / Utestående) — kun tabellkolonnen er fjernet.

## Verifisering

- `npm run typecheck` — 0 feil i `src/`
- `npm run build` — grønt

🤖 Generated with [Claude Code](https://claude.com/claude-code)