### PR TITLE
fix(registrering): gjør det tydelig at Feide-brukernavn ikke er et krav

### DIFF
--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -161,7 +161,10 @@ export default function RegistreringPage() {
 
                 <div className="grid gap-2">
                   <Label htmlFor="reg-user-id">
-                    Feide-brukernavn <span className="text-destructive">*</span>
+                    Brukernavn <span className="text-destructive">*</span>{" "}
+                    <span className="text-muted-foreground font-normal">
+                      (helst Feide)
+                    </span>
                   </Label>
                   <Input
                     id="reg-user-id"
@@ -170,12 +173,14 @@ export default function RegistreringPage() {
                     autoComplete="username"
                     required
                     maxLength={15}
-                    placeholder="Skriv her..."
+                    placeholder="olanord"
                     aria-invalid={errorField === "user_id"}
                     className="h-12"
                   />
                   <p className="text-muted-foreground text-xs">
-                    Ditt brukernavn på NTNU
+                    Bruk helst Feide-brukernavnet ditt (student-e-post uten
+                    @stud.ntnu.no). Har du ikke fått det ennå, kan du velge et
+                    annet brukernavn.
                   </p>
                 </div>
 


### PR DESCRIPTION
## Problem

Studenter misforstår registreringsskjemaet og tror de **må** ha et Feide-brukernavn for å registrere seg.

Kilden er etiketten `Feide-brukernavn *` på `/registrering`: den røde stjernen står rett ved ordet «Feide», så det leses som at Feide-kontoen er kravet. Det skjer ingen Feide-innlogging i flyten i det hele tatt — feltet er bare en tekststreng som blir `user_id` på TIHLDE-brukeren.

## Endring

Kun tekst i [src/app/registrering/page.tsx](https://github.com/TIHLDE/Fadderuka/blob/dev/src/app/registrering/page.tsx). Ingen logikk- eller API-endringer.

| | Før | Etter |
|---|---|---|
| Etikett | `Feide-brukernavn *` | `Brukernavn *` + dempet `(helst Feide)` |
| Placeholder | `Skriv her...` | `olanord` |
| Hjelpetekst | «Ditt brukernavn på NTNU» | «Bruk helst Feide-brukernavnet ditt (student-e-post uten @stud.ntnu.no). Har du ikke fått det ennå, kan du velge et annet brukernavn.» |

Anbefalingen om å bruke Feide-brukernavnet står fortsatt først — «helst» er det som bærer forskjellen — men stjernen gjelder nå feltet, ikke Feide.

## Testing

- `npm run typecheck` ✅
- `npm run lint` ✅ (0 errors, 7 forhåndseksisterende warnings)
- `npm run build` ✅
- Verifisert visuelt i dev-server på `/registrering`, både desktop (hjelpetekst på 2 linjer) og mobil 375px (4 linjer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)