### PR TITLE
feat(betaling): frita faddere fra betaling, og herde auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,21 @@ VIPPS_MERCHANT_SERIAL_NUMBER=""   # Found under "Keys" in merchant portal
 VIPPS_SUBSCRIPTION_KEY=""         # "Primary key" from API subscription
 VIPPS_API_URL="https://apitest.vipps.no"   # Use https://api.vipps.no in production
 VIPPS_CALLBACK_URL="http://localhost:3000" # Public URL Vipps redirects to after payment
+# Shared secret from the Vipps Webhooks API registration. Optional, but without
+# it anyone who guesses an order reference can trigger a capture.
+VIPPS_WEBHOOK_SECRET=""
+
+# Fadderuka
+# Admission year of this year's 1. klasse — the students fadderuka is run for.
+# Everyone admitted earlier is in 2. klasse or higher and is a fadder, who never
+# pays. Set this each year; unset, it is derived from the calendar (new cohort
+# from July). See src/server/fadder.ts.
+FADDERUKE_COHORT_YEAR="2026"
+
+# Encrypts the TIHLDE API tokens held for logged-in users — a live credential
+# for their real TIHLDE account. Generate with `openssl rand -hex 32`.
+# Without it the tokens are not stored at all, which disables allergy sync.
+SESSION_ENCRYPTION_KEY=""
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env

--- a/docs/auth-photon-oauth.md
+++ b/docs/auth-photon-oauth.md
@@ -1,0 +1,108 @@
+# Fra passord-proxy til «Logg inn med TIHLDE»
+
+Utredning av å bytte Fadderukas innlogging fra dagens Lepton-proxy til OAuth2/OIDC
+mot Photon. Ingen kode er skrevet — dette er grunnlaget for å bestemme om og når.
+
+## Dagens løsning
+
+`POST /api/auth/login` tar imot brukernavn og passord i klartekst, sender dem
+videre til Lepton (`POST /auth/login/`), og lagrer API-tokenet vi får tilbake i
+`Session.tihldeToken`.
+
+Det fungerer, og det er ryddig skrevet. Men det har tre egenskaper som ikke lar
+seg fikse innenfor modellen:
+
+1. **Vi ser passordene.** Appen håndterer TIHLDE-passord i klartekst på vei
+   gjennom. Ingen mengde omhu i koden endrer at et sikkerhetsbrudd i Fadderuka
+   eksponerer TIHLDE-kontoer. En kompromittert avhengighet i byggekjeden ville
+   holdt.
+2. **Vi oppbevarer en levende legitimasjon.** `tihldeToken` gir full tilgang til
+   brukerens TIHLDE-konto, utløper ikke hos oss, og invalideres ikke når de
+   logger ut. Det er nå kryptert i ro, men problemet er at vi har det i det hele
+   tatt.
+3. **Vi er en åpen orakelflate mot Lepton.** Rate limiting demper det, men
+   endepunktet er per definisjon en maskin som svarer på «er dette passordet
+   riktig for denne TIHLDE-brukeren?».
+
+I tillegg har appen måttet bygge sitt eget engangspassord-system for studenter
+som venter på godkjenning på tihlde.org — `passwordHash`, `passwordIsTemporary`,
+`/velg-passord`, `admin.resetUserPassword`. Det er reell kompleksitet som finnes
+kun fordi innloggingen er koblet til Leptons godkjenningsløp.
+
+## Hva Photon allerede kan
+
+Photon er ikke bare en ny backend — den er allerede satt opp som
+identitetsleverandør. I `packages/auth/src/index.ts` kjører Better Auth med:
+
+- `oauthProvider()` fra `@better-auth/oauth-provider`, med login- og
+  samtykkeside konfigurert
+- `jwt()` for signerte access tokens
+- Feide-innlogging (OIDC mot Dataporten) via `feidePlugin`
+- RBAC med permissions, roller og grupper i sesjonen
+- Tabellene `oauth_client`, `oauth_access_token`, `oauth_refresh_token` i
+  `packages/db/src/schema/auth.ts`
+- OAuth-metadata publisert via `createOAuthServerMetadata` /
+  `createOAuthOpenIDConfigMetadata`
+
+Det betyr at Photon kan være innloggingsleverandør for Fadderuka **i dag**.
+Fadderuka må registreres som OAuth-klient; ingen ny funksjonalitet trengs på
+Photon-siden for selve innloggingen.
+
+## Hva byttet ville fjerne
+
+| Fjernes | Hvorfor |
+|---|---|
+| Passordhåndtering i Fadderuka | Brukeren skriver passordet hos Photon, aldri hos oss |
+| `Session.tihldeToken` + kryptering | Vi får et scoped access token, ikke en kontonøkkel |
+| `src/server/auth/token-crypto.ts` | Har ikke lenger noe å beskytte |
+| Rate limiting på innlogging | Ikke lenger vår innlogging å beskytte |
+| Engangspassord-systemet | `passwordHash`, `passwordIsTemporary`, `/velg-passord`, `resetUserPassword` |
+| `POST /users/` som registreringsvei | Kontoopprettelse skjer hos Photon/Feide |
+
+Grovt anslag: rundt 600 linjer produksjonskode og fire databasekolonner utgår.
+
+## Hva det koster
+
+**Photon må ha dataene.** Migreringen fra Lepton er gjort (alle brukere ligger i
+prod), men Fadderuka snakker i dag med `api.tihlde.org` (Lepton), ikke Photon.
+Byttet forutsetter at Photon er den autoritative innloggingen for TIHLDE — det
+er en større beslutning enn denne appen.
+
+**Nye studenter er det egentlige problemet.** Fadderukas registreringsløp finnes
+fordi ferske studenter *ikke har* TIHLDE-bruker ennå. En OAuth-innlogging løser
+ikke det: de må fortsatt kunne opprette konto. Photon har egenregistrering med
+`@stud.ntnu.no`-krav og e-postverifisering (`STUD_NTNU_EMAIL_PATTERN` i
+`packages/auth/src/index.ts`), som er en bedre løsning enn dagens
+pending-godkjenning — men flyten må designes: rekker en student å verifisere
+e-post og betale i samme økt på stand?
+
+**Kullet må komme med.** Fadder-fritaket avhenger av `klasse` (opptaksår) fra
+Lepton-profilen. Photon har tilsvarende via gruppemedlemskap, men feltet må
+eksponeres i sesjonen eller i et scope Fadderuka får lese. Uten det faller
+regelen «faddere går i 2. klasse eller mer» ned på manuell markering.
+
+**Klientregistrering mangler UI.** `oauth_client`-tabellen finnes, men det er
+ingen adminflate for å opprette klienter — første klient må inn manuelt i
+databasen. Lite arbeid, men det er ikke gjort.
+
+## Anbefalt rekkefølge
+
+1. **Ikke bytt før fadderuka.** Dagens løsning er herdet nå (kryptering, rate
+   limiting, ekte betalingsmur). Å bytte identitetsleverandør uker før 2000
+   studenter skal logge inn er feil risiko å ta.
+2. **Avklar først om Photon skal være TIHLDEs innlogging.** Dette spørsmålet er
+   større enn Fadderuka, og svaret avgjør alt annet her.
+3. **Registrer Fadderuka som OAuth-klient i Photon** og kjør innlogging for
+   *eksisterende* medlemmer over OAuth, mens nyregistrering blir stående på
+   dagens vei. Da får faddere (som alltid har konto) den trygge flyten først, og
+   de er nettopp gruppen der passord-proxyen er mest unødvendig.
+4. **Flytt nyregistrering sist**, når e-postverifiseringsløpet er testet på
+   stand med ekte nettforhold.
+
+## Åpne spørsmål
+
+- Skal Fadderuka ha egen brukertabell etterpå, eller lese alt fra Photon?
+  Faddergrupper, betalinger og varsler er Fadderuka-spesifikke og bør bli
+  liggende — men da må `tihldeUserId` byttes mot Photons bruker-id.
+- Hvordan håndteres utlogging? Photon-sesjonen varer 30 dager; Fadderukas 7.
+- Trenger Fadderuka egne scopes, eller holder standard profil + grupper?

--- a/prisma/migrations/20260802164023_fadder_exemption/migration.sql
+++ b/prisma/migrations/20260802164023_fadder_exemption/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "fadderOverride" BOOLEAN,
+ADD COLUMN     "isFadder" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20260802170000_fadder_backfill/migration.sql
+++ b/prisma/migrations/20260802170000_fadder_backfill/migration.sql
@@ -1,0 +1,31 @@
+-- Backfill the fadder exemption for users who already exist.
+--
+-- Without this, an existing fadder stays on the paying side until their next
+-- login re-derives the flag — and would be shown a payment prompt in the
+-- meantime. Only the unambiguous case is handled here: anyone holding a FADDER
+-- role in a faddergruppe. Cohort-based derivation needs this year's admission
+-- year, which lives in the environment rather than in SQL, and is applied on
+-- the next login for everyone else.
+UPDATE "User" u
+SET "isFadder" = true,
+    "isVerified" = true
+WHERE EXISTS (
+    SELECT 1 FROM "FadderGruppeMember" m
+    WHERE m."userId" = u.id AND m.role = 'FADDER'
+);
+
+-- Undo the old conflation of "is an admin" with "has paid".
+--
+-- Login used to grant admins `hasPaid = true` so they'd skip the paywall. That
+-- made the field mean two different things, and left anyone later demoted from
+-- admin looking permanently paid. Access now comes from the exemption instead,
+-- so `hasPaid` can go back to meaning money actually changed hands — which is
+-- true only where a captured payment exists.
+UPDATE "User" u
+SET "hasPaid" = false
+WHERE u."hasPaid" = true
+  AND u."isAdmin" = true
+  AND NOT EXISTS (
+    SELECT 1 FROM "Payment" p
+    WHERE p."userId" = u.id AND p.status = 'CAPTURED'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,14 @@ model User {
     // True when passwordHash is an admin-issued one-time password. The user is
     // asked to replace it with one of their own on the next page load.
     passwordIsTemporary Boolean @default(false)
+    // Whether this user is a fadder — i.e. someone who never owes money for
+    // fadderuka. Derived on every login from the study cohort and any FADDER
+    // group membership (see `src/server/fadder.ts`), and persisted so every
+    // payment guard reads one field instead of re-deriving it.
+    isFadder      Boolean   @default(false)
+    // Manual fadder decision from the admin panel, same contract as
+    // `adminOverride`: `null` derives, `true`/`false` pins and survives logins.
+    fadderOverride Boolean?
     createdAt     DateTime  @default(now())
     updatedAt     DateTime  @updatedAt
     sessions      Session[]

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -64,6 +64,28 @@ export function UsersTab() {
     },
   });
 
+  const fadderMutation = api.admin.setUserFadder.useMutation({
+    onSuccess: (result) => {
+      void utils.admin.getUsers.invalidate();
+      void utils.admin.getRegistrations.invalidate();
+      // A fadder who paid before being marked is owed the money back, and the
+      // admin is the only one who can start that — so say it here rather than
+      // leaving it to be noticed in the payment overview.
+      toast({
+        title: result.needsRefund
+          ? `${result.name} er fritatt — men har allerede betalt`
+          : "Betalingsstatus oppdatert",
+        description: result.needsRefund
+          ? "Refunder betalingen fra Betalinger-fanen."
+          : undefined,
+        variant: result.needsRefund ? "destructive" : undefined,
+      });
+    },
+    onError: (error) => {
+      toast({ title: "Feil", description: error.message, variant: "destructive" });
+    },
+  });
+
   const updateRoleMutation = api.admin.updateMemberRole.useMutation({
     onSuccess: () => {
       void utils.admin.getUsers.invalidate();
@@ -344,6 +366,7 @@ export function UsersTab() {
                           <th className="!px-4 !py-3 font-medium">Klasse</th>
                           <th className="!px-4 !py-3 font-medium">Gruppe</th>
                           <th className="!px-4 !py-3 font-medium">Rolle</th>
+                          <th className="!px-4 !py-3 font-medium">Betaling</th>
                           <th className="!px-4 !py-3 font-medium text-center">Admin</th>
                           <th className="!px-4 !py-3 font-medium">Passord</th>
                         </tr>
@@ -406,6 +429,33 @@ export function UsersTab() {
                                 ) : (
                                   <span className="text-muted-foreground">—</span>
                                 )}
+                              </td>
+                              {/* Faddere betaler ikke. Utledes fra kullet, så
+                                  denne bryteren er unntaket for tilfellene
+                                  regelen ikke ser — og den låser valget. */}
+                              <td className="!px-4 !py-3">
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    fadderMutation.mutate({
+                                      userId: user.id,
+                                      isFadder: !user.isFadder,
+                                    })
+                                  }
+                                  disabled={fadderMutation.isPending}
+                                  className={`rounded-full !px-3 !py-1 text-xs font-semibold transition ${
+                                    user.isFadder
+                                      ? "bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20"
+                                      : "bg-amber-500/10 text-amber-400 hover:bg-amber-500/20"
+                                  }`}
+                                  title={
+                                    user.isFadder
+                                      ? "Fritatt for betaling. Klikk for å markere som betalende."
+                                      : "Skal betale. Klikk for å markere som fadder."
+                                  }
+                                >
+                                  {user.isFadder ? "Fritatt" : "Skal betale"}
+                                </button>
                               </td>
                               <td className="!px-4 !py-3 text-center">
                                 <button

--- a/src/app/(authenticated)/layout.tsx
+++ b/src/app/(authenticated)/layout.tsx
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import React from "react";
 import { auth, needsLocalPassword } from "~/server/auth/config";
+import { hasAppAccess } from "~/server/fadder";
 import AllergySync from "~/components/allergy-sync";
 import VippsPaymentOverlay from "~/components/vipps-payment-overlay";
 
@@ -24,10 +25,13 @@ export default async function AuthenticatedLayout({
     redirect("/velg-passord");
   }
 
-  if (!session.user.isVerified) {
+  // No access yet: show the payment prompt INSTEAD of the app, not on top of
+  // it. Rendering `children` here server-rendered the whole app behind the
+  // overlay, so removing one element in devtools was enough to read everything
+  // without paying. Faddere and admins owe nothing and never reach this branch.
+  if (!hasAppAccess(session.user)) {
     return (
       <>
-        {children}
         <AllergySync />
         <VippsPaymentOverlay />
       </>

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -14,6 +14,7 @@ import {
   recordFailedLogin,
 } from "~/server/auth/rate-limit";
 import { db } from "~/server/db";
+import { deriveIsFadder } from "~/server/fadder";
 import {
   TihldeAuthError,
   isMemberOfAnyGroup,
@@ -116,42 +117,58 @@ export async function POST(request: Request) {
     //    TIHLDE write permissions: those are handed out to every committee
     //    member, which made anyone holding any verv an admin of this app.
     //
-    //    Admins skip payment, so we also mark them verified/paid. A fetch
-    //    failure must not block login — and must not silently revoke an
-    //    existing admin — so on error we leave admin-related flags untouched.
+    //    Admins run the app rather than attend as fadderbarn, so being one is
+    //    an exemption from payment. Note it grants access (`isVerified`) but
+    //    never `hasPaid`: that field means "money actually changed hands", and
+    //    faking it here is what previously left demoted admins looking paid
+    //    forever. A fetch failure must not block login — and must not silently
+    //    revoke an existing admin — so on error we leave the flag untouched.
     const existing = await db.user.findUnique({
       where: { tihldeUserId: mapped.tihldeUserId },
-      select: { adminOverride: true },
+      select: {
+        adminOverride: true,
+        fadderOverride: true,
+        memberships: { where: { role: "FADDER" }, select: { id: true } },
+      },
     });
 
-    const grantFor = (isAdmin: boolean) =>
-      isAdmin
-        ? { isAdmin: true, isVerified: true, hasPaid: true }
-        : { isAdmin: false };
-
-    let adminGrant: {
-      isAdmin?: boolean;
-      isVerified?: boolean;
-      hasPaid?: boolean;
-    } = {};
+    let adminGrant: { isAdmin?: boolean } = {};
     if (existing?.adminOverride != null) {
-      adminGrant = grantFor(existing.adminOverride);
+      adminGrant = { isAdmin: existing.adminOverride };
     } else {
       try {
         const memberships = await tihldeGetMemberships(token, profile.user_id);
-        adminGrant = grantFor(isMemberOfAnyGroup(memberships, ADMIN_GROUP_SLUGS));
+        adminGrant = {
+          isAdmin: isMemberOfAnyGroup(memberships, ADMIN_GROUP_SLUGS),
+        };
       } catch (err) {
         console.error("[auth/login] admin derivation failed", err);
       }
     }
 
-    // 3. Upsert the local user, keyed by TIHLDE user_id. Payment flags for
-    //    non-admins are owned by us (earned via Vipps) and left untouched.
-    //    TIHLDE now authenticates this account, so the local registration
-    //    password hash has served its purpose and is dropped.
+    // 3. Decide whether this user owes anything at all. Only fadderbarn pay,
+    //    and a fadder is by definition in 2. klasse or higher — so the study
+    //    cohort we just read from TIHLDE settles it without anyone having to
+    //    be assigned to a group first. That is what keeps a fadder from ever
+    //    seeing a payment prompt, including on their very first login.
+    const isFadder = deriveIsFadder({
+      fadderOverride: existing?.fadderOverride,
+      klasse: mapped.klasse,
+      hasFadderMembership: (existing?.memberships.length ?? 0) > 0,
+    });
+
+    // Exempt users get access outright; everyone else keeps whatever
+    // verification they have earned by paying.
+    const isExempt = isFadder || adminGrant.isAdmin === true;
+    const accessGrant = isExempt ? { isVerified: true } : {};
+
+    // 4. Upsert the local user, keyed by TIHLDE user_id. Payment flags for
+    //    non-exempt users are owned by us (earned via Vipps) and left
+    //    untouched. TIHLDE now authenticates this account, so the local
+    //    registration password hash has served its purpose and is dropped.
     const user = await db.user.upsert({
       where: { tihldeUserId: mapped.tihldeUserId },
-      create: { ...mapped, ...adminGrant },
+      create: { ...mapped, ...adminGrant, ...accessGrant, isFadder },
       update: {
         name: mapped.name,
         email: mapped.email,
@@ -160,11 +177,13 @@ export async function POST(request: Request) {
         klasse: mapped.klasse,
         passwordHash: null,
         passwordIsTemporary: false,
+        isFadder,
         ...adminGrant,
+        ...accessGrant,
       },
     });
 
-    // 4. Mint our own session and set the httpOnly cookie. Proving they know
+    // 5. Mint our own session and set the httpOnly cookie. Proving they know
     //    the password also clears whatever failures came before.
     await issueSession(user.id, token);
     await clearLoginFailures(parsed.data.user_id, ip);

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -17,6 +17,7 @@ import { db } from "~/server/db";
 import { deriveIsFadder } from "~/server/fadder";
 import {
   TihldeAuthError,
+  TihldeUnavailableError,
   isMemberOfAnyGroup,
   mapProfile,
   tihldeGetMe,
@@ -192,6 +193,27 @@ export async function POST(request: Request) {
     // who don't owe a payment (admins are auto-verified above).
     return NextResponse.json({ ok: true, verified: user.isVerified });
   } catch (err) {
+    // TIHLDE unreachable. A self-registered student may still have a local
+    // password, so try that before giving up — it is exactly the situation the
+    // local hash exists for, and it keeps people in the app during an outage.
+    if (err instanceof TihldeUnavailableError) {
+      console.error("[auth/login] TIHLDE unreachable", err.cause);
+
+      const local = await tryLocalLogin(
+        parsed.data.user_id,
+        parsed.data.password,
+      );
+      if (local) {
+        await clearLoginFailures(parsed.data.user_id, ip);
+        return local;
+      }
+
+      return NextResponse.json(
+        { error: err.message },
+        { status: 503, headers: { "Retry-After": "30" } },
+      );
+    }
+
     if (err instanceof TihldeAuthError) {
       // 401/403 from TIHLDE → the account may simply not be approved on
       // tihlde.org yet, so try the local registration password first.
@@ -212,7 +234,10 @@ export async function POST(request: Request) {
     }
     console.error("[auth/login] unexpected error", err);
     return NextResponse.json(
-      { error: "Noe gikk galt ved innlogging." },
+      {
+        error:
+          "Noe gikk galt hos oss under innloggingen. Prøv igjen — går det ikke, si fra til en fadder.",
+      },
       { status: 500 },
     );
   }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -12,6 +12,10 @@ import {
   createSession,
 } from "~/server/auth/config";
 import { hashPassword } from "~/server/auth/password";
+import {
+  checkRegisterRateLimit,
+  recordRegisterAttempt,
+} from "~/server/auth/rate-limit";
 import { TihldeAuthError, tihldeCreateUser } from "~/server/auth/tihlde";
 import { db } from "~/server/db";
 
@@ -70,6 +74,26 @@ export async function POST(request: Request) {
   const { first, last } = splitName(full_name);
   const studieretning = studyLabelForSlug(study);
 
+  // This route creates real TIHLDE accounts, so an unthrottled one is an open
+  // account-creation proxy for tihlde.org running under our IP. Checked before
+  // we call Lepton, so a blocked attempt costs neither side anything.
+  const hdrs = await headers();
+  const ip = hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
+
+  const limit = await checkRegisterRateLimit(ip);
+  if (limit.blocked) {
+    return NextResponse.json(
+      {
+        error: `For mange registreringer herfra. Prøv igjen om ${limit.retryAfterMinutes} minutter.`,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(limit.retryAfterMinutes * 60) },
+      },
+    );
+  }
+  await recordRegisterAttempt(ip);
+
   try {
     // 1. Create the real TIHLDE account (pending admin approval). class:null —
     //    the study membership is enough; the year group may not exist yet.
@@ -109,11 +133,10 @@ export async function POST(request: Request) {
 
     // 3. Mint our own session (no TIHLDE token — the account isn't activated
     //    yet) and set the httpOnly cookie so they're logged into the app.
-    const hdrs = await headers();
     const { token: sessionToken, expiresAt } = await createSession({
       userId: user.id,
       tihldeToken: null,
-      ipAddress: hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+      ipAddress: ip,
       userAgent: hdrs.get("user-agent"),
     });
 

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -16,8 +16,13 @@ import {
   checkRegisterRateLimit,
   recordRegisterAttempt,
 } from "~/server/auth/rate-limit";
-import { TihldeAuthError, tihldeCreateUser } from "~/server/auth/tihlde";
+import {
+  TihldeAuthError,
+  TihldeUnavailableError,
+  tihldeCreateUser,
+} from "~/server/auth/tihlde";
 import { db } from "~/server/db";
+import { isUniqueConstraintError, uniqueConstraintField } from "~/server/db-errors";
 
 /**
  * Self-registration for brand-new students during fadderuka.
@@ -94,26 +99,50 @@ export async function POST(request: Request) {
   }
   await recordRegisterAttempt(ip);
 
-  try {
-    // 1. Create the real TIHLDE account (pending admin approval). class:null —
-    //    the study membership is enough; the year group may not exist yet.
-    await tihldeCreateUser({
-      user_id: userId,
-      password,
-      first_name: first,
-      last_name: last,
-      email,
-      study,
-      class: null,
-    });
+  // 1. Refuse a duplicate before anything irreversible happens, and say who
+  //    they already are. Registering twice is the single most common way to
+  //    fail here: a student whose Vipps payment didn't complete comes back and
+  //    signs up again, often with a different username. Their own first
+  //    registration then owns the email, and the unique constraint used to
+  //    surface as "Noe gikk galt" — which reads as "you did something wrong"
+  //    rather than "you already have an account".
+  const clash = await db.user.findFirst({
+    where: {
+      OR: [
+        { tihldeUserId: userId },
+        { email: { equals: email, mode: "insensitive" } },
+      ],
+    },
+    select: { tihldeUserId: true, email: true },
+  });
 
-    // 2. Mirror into our local user table, keyed by the TIHLDE user_id. Payment
-    //    flags are ours (earned via Vipps) and start false. The password hash
-    //    lets them log back in before tihlde.org approves the account.
+  if (clash) {
+    const sameUsername = clash.tihldeUserId === userId;
+    return NextResponse.json(
+      {
+        error: sameUsername
+          ? `Du er allerede registrert som «${clash.tihldeUserId}». Logg inn i stedet — har du glemt passordet, spør en fadder om å nullstille det.`
+          : `E-posten er allerede brukt av brukeren «${clash.tihldeUserId}». Logg inn som «${clash.tihldeUserId}», eller registrer deg med en annen e-post.`,
+        field: sameUsername ? "user_id" : "email",
+        // The client sends them to the login page rather than making them
+        // guess what to change.
+        existingUserId: clash.tihldeUserId,
+      },
+      { status: 409 },
+    );
+  }
+
+  try {
+    // 2. Create OUR row first, because it is the one we can undo.
+    //
+    //    This used to run after `tihldeCreateUser`, and the ordering was the
+    //    real damage in the incident above: the TIHLDE account was already
+    //    created on tihlde.org by the time the local insert failed, leaving
+    //    orphaned accounts nobody could clean up from here. A local row, by
+    //    contrast, is ours to delete — see the rollback below.
     const passwordHash = await hashPassword(password);
-    const user = await db.user.upsert({
-      where: { tihldeUserId: userId },
-      create: {
+    const user = await db.user.create({
+      data: {
         tihldeUserId: userId,
         name: full_name,
         email,
@@ -123,15 +152,32 @@ export async function POST(request: Request) {
         isAdmin: false,
         passwordHash,
       },
-      update: {
-        name: full_name,
-        email,
-        studieretning,
-        passwordHash,
-      },
     });
 
-    // 3. Mint our own session (no TIHLDE token — the account isn't activated
+    // 3. Create the real TIHLDE account (pending admin approval). class:null —
+    //    the study membership is enough; the year group may not exist yet.
+    //    On failure the local row is rolled back, so a retry starts clean
+    //    instead of hitting the duplicate check above.
+    try {
+      await tihldeCreateUser({
+        user_id: userId,
+        password,
+        first_name: first,
+        last_name: last,
+        email,
+        study,
+        class: null,
+      });
+    } catch (err) {
+      await db.user
+        .delete({ where: { id: user.id } })
+        .catch((cleanupErr) =>
+          console.error("[auth/register] rollback failed", cleanupErr),
+        );
+      throw err;
+    }
+
+    // 4. Mint our own session (no TIHLDE token — the account isn't activated
     //    yet) and set the httpOnly cookie so they're logged into the app.
     const { token: sessionToken, expiresAt } = await createSession({
       userId: user.id,
@@ -152,6 +198,16 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true });
   } catch (err) {
+    // TIHLDE unreachable — nothing to do with what they typed, so say that
+    // plainly instead of sending them back to re-check the form.
+    if (err instanceof TihldeUnavailableError) {
+      console.error("[auth/register] TIHLDE unreachable", err.cause);
+      return NextResponse.json(
+        { error: err.message },
+        { status: 503, headers: { "Retry-After": "30" } },
+      );
+    }
+
     if (err instanceof TihldeAuthError) {
       // 400 from Lepton (duplicate username, bad email, …) → show the message
       // and hint the client which field it belongs to when we can tell.
@@ -163,9 +219,26 @@ export async function POST(request: Request) {
           : undefined;
       return NextResponse.json({ error: err.message, field }, { status });
     }
+
+    // A duplicate that slipped past the check above — two submits racing each
+    // other. Same advice as the pre-flight case, since it is the same problem.
+    if (isUniqueConstraintError(err)) {
+      return NextResponse.json(
+        {
+          error:
+            "Du er allerede registrert. Prøv å logge inn i stedet — har du glemt passordet, spør en fadder om å nullstille det.",
+          field: uniqueConstraintField(err),
+        },
+        { status: 409 },
+      );
+    }
+
     console.error("[auth/register] unexpected error", err);
     return NextResponse.json(
-      { error: "Noe gikk galt ved registreringen." },
+      {
+        error:
+          "Noe gikk galt hos oss under registreringen. Prøv igjen — går det ikke, si fra til en fadder.",
+      },
       { status: 500 },
     );
   }

--- a/src/app/api/vipps/webhook/route.ts
+++ b/src/app/api/vipps/webhook/route.ts
@@ -1,24 +1,56 @@
 import { NextResponse } from "next/server";
 
+import { env } from "~/env";
 import { settlePayment } from "~/server/payment/vipps";
+import {
+  verifyVippsWebhookSignature,
+  webhookPartsFromRequest,
+} from "~/server/payment/webhook-signature";
 
 /**
  * Vipps ePayment webhook. Registered separately via the Webhooks API; Vipps
  * POSTs an event whenever a payment changes state (AUTHORIZED, CAPTURED,
  * ABORTED, EXPIRED, …).
  *
- * We do NOT trust the payload's claimed state — we take only the `reference`
- * and re-verify against the Vipps API inside `settlePayment`, which is our
- * security boundary. A forged request therefore can't mark anyone paid: an
- * unknown reference 404s and captures require our own credentials. (HMAC
- * signature validation can be layered on once the webhook secret is provisioned
- * in env, but it isn't required for correctness given the re-verification.)
+ * Two independent guards, in order:
+ *
+ *  1. The HMAC signature, when `VIPPS_WEBHOOK_SECRET` is configured. Without it
+ *     anyone who knows (or guesses) an order reference can make us capture a
+ *     reservation ahead of schedule.
+ *  2. Re-verification against the Vipps API inside `settlePayment`. We never
+ *     trust the payload's claimed state — only its `reference` — so even a
+ *     valid-looking event cannot mark someone paid who has not paid.
+ *
+ * The secret is optional so the webhook keeps working before it is provisioned;
+ * guard 2 alone is what made that safe, and still is.
  */
 export async function POST(request: Request) {
-  const body = (await request.json().catch(() => null)) as {
-    reference?: unknown;
-    orderId?: unknown;
-  } | null;
+  // Read the raw body BEFORE parsing: the signature covers the raw bytes, and
+  // a body can only be consumed once.
+  const rawBody = await request.text();
+
+  const secret = env.VIPPS_WEBHOOK_SECRET;
+  if (secret) {
+    const authentic = verifyVippsWebhookSignature(
+      webhookPartsFromRequest(request, rawBody),
+      secret,
+    );
+    if (!authentic) {
+      console.warn("[vipps/webhook] rejected request with invalid signature");
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+  }
+
+  const body = (() => {
+    try {
+      return JSON.parse(rawBody) as {
+        reference?: unknown;
+        orderId?: unknown;
+      };
+    } catch {
+      return null;
+    }
+  })();
 
   const reference =
     typeof body?.reference === "string"

--- a/src/app/logg-inn/page.tsx
+++ b/src/app/logg-inn/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
 import Footer from "~/components/layout/footer/footer";
 import { Button } from "~/components/ui/button";
 import { Card, CardDescription, CardTitle } from "~/components/ui/card";
@@ -10,10 +10,13 @@ import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { authClient } from "~/lib/auth-client";
 
-export default function LoggInnPage() {
+function LoggInnSkjema() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  // Registreringssiden sender hit med brukernavnet når noen prøvde å
+  // registrere seg på nytt — da slipper de å huske hva de valgte.
+  const prefilledUserId = useSearchParams().get("user_id") ?? "";
 
   const handleLogin = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -89,6 +92,7 @@ export default function LoggInnPage() {
                     type="text"
                     autoComplete="username"
                     required
+                    defaultValue={prefilledUserId}
                     placeholder="ditt TIHLDE-brukernavn"
                     className="h-12"
                   />
@@ -136,5 +140,18 @@ export default function LoggInnPage() {
       </main>
       <Footer />
     </div>
+  );
+}
+
+/**
+ * `useSearchParams` opts the tree into client-side rendering, so Next requires
+ * a Suspense boundary around it. Without one the whole page would have to be
+ * dynamic.
+ */
+export default function LoggInnPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoggInnSkjema />
+    </Suspense>
   );
 }

--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -17,6 +17,8 @@ import { api } from "~/trpc/react";
 export default function RegistreringPage() {
   const [error, setError] = useState<string | null>(null);
   const [errorField, setErrorField] = useState<string | null>(null);
+  /** Set when they already have an account, so we can link straight to login. */
+  const [existingUserId, setExistingUserId] = useState<string | null>(null);
   const [study, setStudy] = useState<string>("");
   const [loading, setLoading] = useState(false);
 
@@ -28,6 +30,7 @@ export default function RegistreringPage() {
     e.preventDefault();
     setError(null);
     setErrorField(null);
+    setExistingUserId(null);
 
     const formData = new FormData(e.currentTarget);
     const full_name = (formData.get("full_name") as string)?.trim();
@@ -44,7 +47,11 @@ export default function RegistreringPage() {
 
     setLoading(true);
 
-    const { error: registerError, field } = await authClient.register({
+    const {
+      error: registerError,
+      field,
+      existingUserId: existing,
+    } = await authClient.register({
       full_name,
       email,
       user_id,
@@ -55,6 +62,7 @@ export default function RegistreringPage() {
     if (registerError) {
       setError(registerError);
       setErrorField(field ?? null);
+      setExistingUserId(existing ?? null);
       setLoading(false);
       return;
     }
@@ -127,8 +135,20 @@ export default function RegistreringPage() {
                 <div
                   className="bg-destructive/10 text-destructive rounded-md px-4 py-3 text-sm"
                   style={{ marginBottom: "1.5rem" }}
+                  role="alert"
                 >
                   {error}
+                  {/* Når feilen er "du har alt en bruker", er innlogging det
+                      eneste som hjelper — så vi tilbyr veien dit i stedet for
+                      å la dem gjette hvilket felt de skal endre. */}
+                  {existingUserId && (
+                    <Link
+                      href={`/logg-inn?user_id=${encodeURIComponent(existingUserId)}`}
+                      className="mt-2 block font-semibold underline"
+                    >
+                      Gå til innlogging som «{existingUserId}»
+                    </Link>
+                  )}
                 </div>
               )}
 

--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { TRPCClientError } from "@trpc/client";
 import Link from "next/link";
 import { useState } from "react";
+import type { AppRouter } from "~/server/api/root";
 import Footer from "~/components/layout/footer/footer";
 import { Button } from "~/components/ui/button";
 import { Card, CardDescription, CardTitle } from "~/components/ui/card";
@@ -73,6 +75,16 @@ export default function RegistreringPage() {
       const { redirectUrl } = await initiatePayment.mutateAsync();
       window.location.href = redirectUrl;
     } catch (err) {
+      // The server refuses to charge anyone who owes nothing. Someone who
+      // turns out to be a fadder is simply let into the app instead of being
+      // shown a payment error for a bill that doesn't exist.
+      if (
+        err instanceof TRPCClientError &&
+        (err as TRPCClientError<AppRouter>).data?.code === "FORBIDDEN"
+      ) {
+        window.location.href = "/";
+        return;
+      }
       setError(
         err instanceof Error
           ? err.message

--- a/src/components/vipps-payment-overlay.tsx
+++ b/src/components/vipps-payment-overlay.tsx
@@ -45,8 +45,13 @@ export default function VippsPaymentOverlay() {
     },
   });
 
-  // Don't show overlay if user has paid or is verified
-  if (paymentStatus.data?.hasPaid || paymentStatus.data?.isVerified) {
+  // Nothing to ask for if they've paid, are already verified, or owe nothing
+  // at all — faddere and admins never see a payment prompt.
+  if (
+    paymentStatus.data?.hasPaid ||
+    paymentStatus.data?.isVerified ||
+    paymentStatus.data?.isExempt
+  ) {
     return null;
   }
 

--- a/src/env.js
+++ b/src/env.js
@@ -14,6 +14,32 @@ export const env = createEnv({
     VIPPS_SUBSCRIPTION_KEY: z.string().optional(),
     VIPPS_API_URL: z.string().url().optional(),
     VIPPS_CALLBACK_URL: z.string().url().optional(),
+    /**
+     * Shared secret Vipps signs its webhooks with, from the Webhooks API
+     * registration. Optional: until it is set the webhook keeps working by
+     * re-verifying every event against the Vipps API instead.
+     */
+    VIPPS_WEBHOOK_SECRET: z.string().optional(),
+    /**
+     * Admission year of this year's 1. klasse — the students fadderuka is run
+     * for. Everyone admitted earlier is in 2. klasse or higher and never pays.
+     * Pin it each year so the decision never rides on the server clock; left
+     * unset it is derived from the calendar (see `src/server/fadder.ts`).
+     */
+    FADDERUKE_COHORT_YEAR: z
+      .string()
+      .regex(/^\d{4}$/, "FADDERUKE_COHORT_YEAR må være et årstall, f.eks. 2026")
+      .optional(),
+    /**
+     * 32-byte hex key encrypting the TIHLDE API tokens we hold on behalf of
+     * logged-in users. Generate with `openssl rand -hex 32`. Without it the
+     * tokens are simply not stored, so allergy sync is the only thing that
+     * stops working — nothing is ever written in clear text.
+     */
+    SESSION_ENCRYPTION_KEY: z
+      .string()
+      .regex(/^[0-9a-fA-F]{64}$/, "SESSION_ENCRYPTION_KEY må være 64 hex-tegn")
+      .optional(),
   },
 
   client: {},
@@ -28,6 +54,9 @@ export const env = createEnv({
     VIPPS_SUBSCRIPTION_KEY: process.env.VIPPS_SUBSCRIPTION_KEY,
     VIPPS_API_URL: process.env.VIPPS_API_URL,
     VIPPS_CALLBACK_URL: process.env.VIPPS_CALLBACK_URL,
+    VIPPS_WEBHOOK_SECRET: process.env.VIPPS_WEBHOOK_SECRET,
+    FADDERUKE_COHORT_YEAR: process.env.FADDERUKE_COHORT_YEAR,
+    SESSION_ENCRYPTION_KEY: process.env.SESSION_ENCRYPTION_KEY,
   },
 
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -24,6 +24,12 @@ export interface RegisterInput {
 interface RegisterResult extends Result {
   /** Which form field the error belongs to, when the server could tell. */
   field?: string;
+  /**
+   * Set when the failure was "you already have an account": the username they
+   * should log in as. Lets the form offer the way out instead of leaving them
+   * to guess which field to change.
+   */
+  existingUserId?: string;
 }
 
 async function readError(res: Response, fallback: string): Promise<string> {
@@ -67,15 +73,23 @@ export const authClient = {
 
     if (!res.ok) {
       let field: string | undefined;
-      let error = "Noe gikk galt ved registreringen.";
+      let existingUserId: string | undefined;
+      // Only used if the server sent nothing parseable at all — every real
+      // failure carries its own message.
+      let error = "Fikk ikke svar fra serveren. Sjekk nettet og prøv igjen.";
       try {
-        const body = (await res.json()) as { error?: string; field?: string };
+        const body = (await res.json()) as {
+          error?: string;
+          field?: string;
+          existingUserId?: string;
+        };
         error = body?.error ?? error;
         field = body?.field;
+        existingUserId = body?.existingUserId;
       } catch {
         // keep defaults
       }
-      return { error, field };
+      return { error, field, existingUserId };
     }
     return { error: null };
   },

--- a/src/server/api/routers/activity.ts
+++ b/src/server/api/routers/activity.ts
@@ -1,23 +1,27 @@
 import { z } from "zod";
-import { adminProcedure, createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import {
+  adminProcedure,
+  createTRPCRouter,
+  verifiedProcedure,
+} from "~/server/api/trpc";
 import {
   getTihldeFadderukaEvents,
   type EventItem,
 } from "~/server/tihlde/events";
 
 export const activityRouter = createTRPCRouter({
-  getAll: publicProcedure.query(({ ctx }) => {
+  getAll: verifiedProcedure.query(({ ctx }) => {
     return ctx.db.activity.findMany({
       orderBy: { date: "asc" },
     });
   }),
 
   /**
-   * Merged, date-sorted event feed for the public pages: Fadderuka events from
+   * Merged, date-sorted event feed shown inside the app: Fadderuka events from
    * TIHLDE plus any locally-managed activities. Admins still create local
    * activities via the mutations below; TIHLDE events are read-only.
    */
-  getUpcoming: publicProcedure.query(async ({ ctx }): Promise<EventItem[]> => {
+  getUpcoming: verifiedProcedure.query(async ({ ctx }): Promise<EventItem[]> => {
     const [local, tihlde] = await Promise.all([
       ctx.db.activity.findMany({ orderBy: { date: "asc" } }),
       getTihldeFadderukaEvents(),

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
-import type { PaymentStatus } from "@prisma/client";
+import type { PaymentStatus, PrismaClient } from "@prisma/client";
 import { z } from "zod";
+import { deriveIsFadder } from "~/server/fadder";
 import {
   adminProcedure,
   createTRPCRouter,
@@ -32,6 +33,41 @@ function toTRPCError(err: unknown): TRPCError {
   });
 }
 
+/**
+ * Recompute a user's `isFadder` from their current state and store it.
+ *
+ * Called after anything that changes a group membership, so giving someone the
+ * FADDER role exempts them from payment immediately instead of only at their
+ * next login — and taking it away puts them back on the paying side unless the
+ * study cohort or a manual override says otherwise. Grants access alongside the
+ * exemption, since no payment is coming to verify them.
+ */
+async function resyncFadderStatus(
+  db: PrismaClient,
+  userId: string,
+): Promise<void> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: {
+      fadderOverride: true,
+      klasse: true,
+      memberships: { where: { role: "FADDER" }, select: { id: true } },
+    },
+  });
+  if (!user) return;
+
+  const isFadder = deriveIsFadder({
+    fadderOverride: user.fadderOverride,
+    klasse: user.klasse,
+    hasFadderMembership: user.memberships.length > 0,
+  });
+
+  await db.user.update({
+    where: { id: userId },
+    data: { isFadder, ...(isFadder ? { isVerified: true } : {}) },
+  });
+}
+
 export const adminRouter = createTRPCRouter({
   /** List all users with their verification/admin status and group memberships */
   getUsers: adminProcedure.query(async ({ ctx }) => {
@@ -46,6 +82,8 @@ export const adminRouter = createTRPCRouter({
         isVerified: true,
         isAdmin: true,
         hasPaid: true,
+        isFadder: true,
+        fadderOverride: true,
         createdAt: true,
         memberships: {
           select: {
@@ -97,17 +135,62 @@ export const adminRouter = createTRPCRouter({
   /**
    * Promote or demote admin status.
    *
-   * Also pins the decision via `adminOverride` so it survives the next login —
-   * without it, login would re-derive admin status from TIHLDE and overwrite
-   * whatever was set here.
+   * `pin` controls what happens on the next login. Pinned (the default) writes
+   * `adminOverride` so the decision survives — without it, login re-derives
+   * admin status from TIHLDE and overwrites whatever was set here. Unpinning
+   * clears the override instead, handing control back to TIHLDE group
+   * membership; that is the only way out of a pin, and without it an
+   * accidental demotion locked a FadderKom member out of admin permanently.
    */
   setUserAdmin: adminProcedure
-    .input(z.object({ userId: z.string(), isAdmin: z.boolean() }))
+    .input(
+      z.object({
+        userId: z.string(),
+        isAdmin: z.boolean(),
+        pin: z.boolean().default(true),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       return ctx.db.user.update({
         where: { id: input.userId },
-        data: { isAdmin: input.isAdmin, adminOverride: input.isAdmin },
+        data: {
+          isAdmin: input.isAdmin,
+          adminOverride: input.pin ? input.isAdmin : null,
+        },
       });
+    }),
+
+  /**
+   * Mark a user as a fadder, or as someone who owes payment after all.
+   *
+   * Faddere never pay, so this is the manual escape hatch for the cases the
+   * automatic rule cannot see: a fadder whose TIHLDE profile has no study
+   * cohort, or a 2. klasse student who is actually attending as a fadderbarn.
+   * The decision is pinned in `fadderOverride` and therefore survives every
+   * later login, exactly like `adminOverride`.
+   *
+   * Marking someone a fadder also grants access, since there is no payment
+   * coming that would otherwise verify them. It deliberately does NOT touch
+   * `hasPaid`: if they already paid, that stays true and the admin gets a
+   * refund prompt from the payment overview rather than a silently rewritten
+   * record.
+   */
+  setUserFadder: adminProcedure
+    .input(z.object({ userId: z.string(), isFadder: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const user = await ctx.db.user.update({
+        where: { id: input.userId },
+        data: {
+          isFadder: input.isFadder,
+          fadderOverride: input.isFadder,
+          ...(input.isFadder ? { isVerified: true } : {}),
+        },
+        select: { id: true, name: true, hasPaid: true },
+      });
+
+      // Surfaced by the client so a fadder who paid before being marked is
+      // never quietly left out of pocket.
+      return { ...user, needsRefund: input.isFadder && user.hasPaid };
     }),
 
   /** List all faddergrupper with member counts */
@@ -179,22 +262,28 @@ export const adminRouter = createTRPCRouter({
           message: "Brukeren er allerede medlem av denne gruppen",
         });
       }
-      return ctx.db.fadderGruppeMember.create({
+      const membership = await ctx.db.fadderGruppeMember.create({
         data: {
           userId: input.userId,
           gruppeId: input.gruppeId,
           role: input.role,
         },
       });
+      await resyncFadderStatus(ctx.db, input.userId);
+      return membership;
     }),
 
   /** Remove a member from a faddergruppe */
   removeMember: adminProcedure
     .input(z.object({ membershipId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.db.fadderGruppeMember.delete({
+      const membership = await ctx.db.fadderGruppeMember.delete({
         where: { id: input.membershipId },
       });
+      // Losing a FADDER role can put someone back on the paying side, unless
+      // their cohort or a manual override still exempts them.
+      await resyncFadderStatus(ctx.db, membership.userId);
+      return membership;
     }),
 
   /** Change a member's role within a group */
@@ -206,10 +295,12 @@ export const adminRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      return ctx.db.fadderGruppeMember.update({
+      const membership = await ctx.db.fadderGruppeMember.update({
         where: { id: input.membershipId },
         data: { role: input.role },
       });
+      await resyncFadderStatus(ctx.db, membership.userId);
+      return membership;
     }),
 
   /** Permanently delete an unverified user and all their data */
@@ -274,13 +365,14 @@ export const adminRouter = createTRPCRouter({
    */
   getRegistrations: adminProcedure.query(async ({ ctx }) => {
     const users = await ctx.db.user.findMany({
-      // Only fadderbarn pay. Admins and faddere would otherwise inflate both the
-      // sign-up count and the outstanding sum with people who never owed money.
-      // Users without a group are kept: an unassigned registration is a
-      // fadderbarn until proven otherwise, and they are exactly who to chase.
+      // Only fadderbarn pay. Admins and faddere would otherwise inflate both
+      // the sign-up count and the outstanding sum with people who never owed
+      // money. Filtering on `isFadder` rather than on group membership is what
+      // makes this agree with the actual payment guard: a fadder is exempt from
+      // their study cohort alone, long before anyone assigns them to a group.
       where: {
         isAdmin: false,
-        memberships: { none: { role: "FADDER" } },
+        isFadder: false,
       },
       select: {
         id: true,

--- a/src/server/api/routers/gruppe.ts
+++ b/src/server/api/routers/gruppe.ts
@@ -2,14 +2,14 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import {
   createTRPCRouter,
-  protectedProcedure,
+  verifiedProcedure,
 } from "~/server/api/trpc";
 
 const channelSchema = z.enum(["ANNOUNCEMENT", "CHAT"]);
 
 export const gruppeRouter = createTRPCRouter({
   /** Get the current user's faddergruppe membership(s) */
-  getMyGruppe: protectedProcedure.query(async ({ ctx }) => {
+  getMyGruppe: verifiedProcedure.query(async ({ ctx }) => {
     const membership = await ctx.db.fadderGruppeMember.findFirst({
       where: { userId: ctx.session.user.id },
       include: {
@@ -29,7 +29,7 @@ export const gruppeRouter = createTRPCRouter({
   }),
 
   /** Get messages for a group (user must be a member or admin) */
-  getMessages: protectedProcedure
+  getMessages: verifiedProcedure
     .input(z.object({ gruppeId: z.string(), channel: channelSchema }))
     .query(async ({ ctx, input }) => {
       // Check access: must be admin or member of the group
@@ -65,7 +65,7 @@ export const gruppeRouter = createTRPCRouter({
    * ANNOUNCEMENT channel: only FADDER role or admin.
    * CHAT channel: any member (FADDER or FADDERBARN) or admin.
    */
-  postMessage: protectedProcedure
+  postMessage: verifiedProcedure
     .input(
       z.object({
         gruppeId: z.string(),
@@ -135,7 +135,7 @@ export const gruppeRouter = createTRPCRouter({
     }),
 
   /** Delete a message (author or admin only) */
-  deleteMessage: protectedProcedure
+  deleteMessage: verifiedProcedure
     .input(z.object({ messageId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const message = await ctx.db.groupMessage.findUnique({

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { createTRPCRouter, verifiedProcedure } from "~/server/api/trpc";
 
 export const notificationRouter = createTRPCRouter({
-  list: protectedProcedure.query(async ({ ctx }) => {
+  list: verifiedProcedure.query(async ({ ctx }) => {
     return ctx.db.notification.findMany({
       where: { userId: ctx.session.user.id },
       orderBy: { createdAt: "desc" },
@@ -10,13 +10,13 @@ export const notificationRouter = createTRPCRouter({
     });
   }),
 
-  unreadCount: protectedProcedure.query(async ({ ctx }) => {
+  unreadCount: verifiedProcedure.query(async ({ ctx }) => {
     return ctx.db.notification.count({
       where: { userId: ctx.session.user.id, read: false },
     });
   }),
 
-  markRead: protectedProcedure
+  markRead: verifiedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       return ctx.db.notification.updateMany({
@@ -25,7 +25,7 @@ export const notificationRouter = createTRPCRouter({
       });
     }),
 
-  markAllRead: protectedProcedure.mutation(async ({ ctx }) => {
+  markAllRead: verifiedProcedure.mutation(async ({ ctx }) => {
     return ctx.db.notification.updateMany({
       where: { userId: ctx.session.user.id, read: false },
       data: { read: true },

--- a/src/server/api/routers/payment.ts
+++ b/src/server/api/routers/payment.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { isPaymentExempt } from "~/server/fadder";
 import {
   PAYMENT_AMOUNT_ORE,
   VippsError,
@@ -11,6 +12,14 @@ import {
   parseUserIdFromOrderId,
   settlePayment,
 } from "~/server/payment/vipps";
+
+/**
+ * How long an unfinished order is reused instead of a new one being minted.
+ * Long enough to cover a user bouncing between tabs or retrying after a failed
+ * redirect, short enough that a genuinely abandoned order doesn't block a fresh
+ * attempt later in the day.
+ */
+const OPEN_ORDER_REUSE_MS = 30 * 60 * 1000;
 
 /** Translate a Vipps-layer error into the tRPC error shown to the client. */
 function toTRPCError(err: unknown): TRPCError {
@@ -32,11 +41,19 @@ export const paymentRouter = createTRPCRouter({
   getStatus: protectedProcedure.query(async ({ ctx }) => {
     const user = await ctx.db.user.findUnique({
       where: { id: ctx.session.user.id },
-      select: { hasPaid: true, isVerified: true },
+      select: {
+        hasPaid: true,
+        isVerified: true,
+        isAdmin: true,
+        isFadder: true,
+      },
     });
     return {
       hasPaid: user?.hasPaid ?? false,
       isVerified: user?.isVerified ?? false,
+      // Drives the client: an exempt user must never be shown a payment
+      // prompt, so the overlay asks for this rather than inferring it.
+      isExempt: user ? isPaymentExempt(user) : false,
     };
   }),
 
@@ -46,11 +63,27 @@ export const paymentRouter = createTRPCRouter({
   initiatePayment: protectedProcedure.mutation(async ({ ctx }) => {
     const user = await ctx.db.user.findUnique({
       where: { id: ctx.session.user.id },
-      select: { hasPaid: true, name: true },
+      select: {
+        hasPaid: true,
+        name: true,
+        isAdmin: true,
+        isFadder: true,
+      },
     });
 
     if (!user) {
       throw new TRPCError({ code: "NOT_FOUND", message: "Bruker ikke funnet" });
+    }
+
+    // Faddere and admins owe nothing, and this is the guard that makes that
+    // true rather than merely displayed: hiding the button in the UI would
+    // still leave the mutation callable, and taking a fadder's money is the
+    // one outcome this flow must make impossible.
+    if (isPaymentExempt(user)) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Faddere betaler ikke for fadderuka.",
+      });
     }
 
     if (user.hasPaid) {
@@ -60,7 +93,22 @@ export const paymentRouter = createTRPCRouter({
       });
     }
 
-    const orderId = buildOrderId(ctx.session.user.id);
+    // Reuse an order this user already has open instead of minting a second
+    // one. Two tabs (or an impatient double-click) otherwise produce two live
+    // Vipps references, and both can be authorised and later captured — the
+    // user pays twice. `createPayment` is idempotent per reference on Vipps'
+    // side, so handing back the same order is safe.
+    const openOrder = await ctx.db.payment.findFirst({
+      where: {
+        userId: ctx.session.user.id,
+        status: "CREATED",
+        createdAt: { gte: new Date(Date.now() - OPEN_ORDER_REUSE_MS) },
+      },
+      orderBy: { createdAt: "desc" },
+      select: { orderId: true },
+    });
+
+    const orderId = openOrder?.orderId ?? buildOrderId(ctx.session.user.id);
 
     try {
       // Payer's name in the description so the Vipps portal shows who paid.
@@ -70,13 +118,15 @@ export const paymentRouter = createTRPCRouter({
 
       // Persist the order so the callback and webhook can settle it, and so
       // "Jeg har allerede betalt" can re-check this user's own payments.
-      await ctx.db.payment.create({
-        data: {
-          orderId,
-          userId: ctx.session.user.id,
-          amount: PAYMENT_AMOUNT_ORE,
-        },
-      });
+      if (!openOrder) {
+        await ctx.db.payment.create({
+          data: {
+            orderId,
+            userId: ctx.session.user.id,
+            amount: PAYMENT_AMOUNT_ORE,
+          },
+        });
+      }
 
       return { redirectUrl: payment.redirectUrl };
     } catch (err) {

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -13,6 +13,7 @@ import { ZodError } from "zod";
 
 import { auth } from "~/server/auth";
 import { db } from "~/server/db";
+import { hasAppAccess } from "~/server/fadder";
 
 /**
  * 1. CONTEXT
@@ -131,6 +132,37 @@ export const protectedProcedure = t.procedure
     return next({
       ctx: {
         // infers the `session` as non-nullable
+        session: { ...ctx.session, user: ctx.session.user },
+      },
+    });
+  });
+
+/**
+ * Verified (paid-or-exempt) procedure
+ *
+ * The server-side half of the paywall. The Vipps overlay is a client component
+ * layered over the page, so on its own it hides nothing: the data behind it is
+ * fetched and rendered regardless, and dismissing the overlay in devtools was
+ * enough to use the app without paying. Anything that serves fadderuka content
+ * belongs on this procedure, not on `protectedProcedure`.
+ *
+ * Access means the user has paid (`isVerified`) or owes nothing at all —
+ * faddere and admins. See `hasAppAccess`.
+ */
+export const verifiedProcedure = t.procedure
+  .use(timingMiddleware)
+  .use(({ ctx, next }) => {
+    if (!ctx.session?.user) {
+      throw new TRPCError({ code: "UNAUTHORIZED" });
+    }
+    if (!hasAppAccess(ctx.session.user)) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Du må fullføre registreringen for å se dette.",
+      });
+    }
+    return next({
+      ctx: {
         session: { ...ctx.session, user: ctx.session.user },
       },
     });

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { randomBytes } from "crypto";
 import { db } from "~/server/db";
+import { decryptToken, encryptToken } from "./token-crypto";
 
 /**
  * Custom session layer backing TIHLDE-based auth.
@@ -16,6 +17,36 @@ import { db } from "~/server/db";
 
 export const SESSION_COOKIE = "fadderuke.session_token";
 export const SESSION_MAX_AGE = 60 * 60 * 24 * 7; // 7 days, in seconds
+
+/**
+ * How much of a session's life must have passed before a read extends it.
+ *
+ * Without this the expiry was absolute: a user who logged in on the Monday of
+ * fadderuka was signed out mid-week no matter how actively they used the app.
+ * Sliding the window on use keeps active users in, while an abandoned session
+ * still dies on schedule. Rewriting on every request would mean a write per
+ * page load, hence the threshold.
+ */
+const SESSION_RENEW_AFTER_MS = (SESSION_MAX_AGE * 1000) / 4;
+
+/**
+ * Chance, per session read, of also sweeping expired rows. Sessions are only
+ * ever deleted when someone happens to present an expired one, so without a
+ * sweep the table grows without bound. Sampling keeps it to roughly one extra
+ * delete per hundred requests instead of one per request.
+ */
+const SESSION_SWEEP_PROBABILITY = 0.01;
+
+/** Delete sessions that expired a while ago. Best-effort; never blocks a request. */
+async function sweepExpiredSessions(): Promise<void> {
+  try {
+    await db.session.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+  } catch (err) {
+    console.error("[auth] expired-session sweep failed", err);
+  }
+}
 
 function parseCookie(header: string | null, name: string): string | null {
   if (!header) return null;
@@ -44,8 +75,33 @@ async function getSession({ headers }: { headers: Headers }) {
     return null;
   }
 
+  if (Math.random() < SESSION_SWEEP_PROBABILITY) {
+    void sweepExpiredSessions();
+  }
+
+  // Slide the expiry once enough of the window has been used up, so continued
+  // use keeps someone signed in. `expiresAt` is the anchor: it moves on every
+  // renewal, so the elapsed time since the last one is what it implies about
+  // the remaining life — using `createdAt` would re-renew on every single
+  // request once the session got old enough. Best-effort: a failed write costs
+  // a renewal, never the request.
+  const sinceRenewal =
+    Date.now() - (session.expiresAt.getTime() - SESSION_MAX_AGE * 1000);
+  if (sinceRenewal > SESSION_RENEW_AFTER_MS) {
+    const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000);
+    await db.session
+      .update({ where: { token }, data: { expiresAt } })
+      .catch(() => undefined);
+    session.expiresAt = expiresAt;
+  }
+
   const { user, ...rest } = session;
-  return { user, session: rest };
+  // Callers (allergy sync) expect a usable TIHLDE token, not the stored
+  // ciphertext, so decrypt on the way out.
+  return {
+    user,
+    session: { ...rest, tihldeToken: decryptToken(rest.tihldeToken) },
+  };
 }
 
 /** Create a persisted session for a user and return its cookie token. */
@@ -64,7 +120,9 @@ export async function createSession(opts: {
     data: {
       token,
       userId: opts.userId,
-      tihldeToken: opts.tihldeToken ?? null,
+      // Encrypted at rest: this is a live credential for the user's real
+      // TIHLDE account, and it outlives the session row.
+      tihldeToken: encryptToken(opts.tihldeToken ?? null),
       expiresAt,
       ipAddress: opts.ipAddress ?? null,
       userAgent: opts.userAgent ?? null,

--- a/src/server/auth/rate-limit.ts
+++ b/src/server/auth/rate-limit.ts
@@ -90,3 +90,56 @@ export async function clearLoginFailures(
   const keys = ip ? [userKey(userId), ipKey(ip)] : [userKey(userId)];
   await db.loginAttempt.deleteMany({ where: { key: { in: keys } } });
 }
+
+/**
+ * Registration throttling.
+ *
+ * `POST /api/auth/register` forwards straight to Lepton's public user-creation
+ * endpoint, so an unthrottled route here is an open account-creation proxy for
+ * TIHLDE — our IP doing the creating. Unlike login there is no "failure" to
+ * count: creating an account is the success case, and it is the successes we
+ * need to bound. So every attempt is recorded, per IP only, since a new user by
+ * definition has no username we know yet.
+ */
+const REGISTER_WINDOW_MS = 60 * 60 * 1000;
+
+/** New accounts one IP may create per hour. Generous for a shared campus NAT. */
+const MAX_REGISTRATIONS_PER_IP = 10;
+
+const registerKey = (ip: string) => `register-ip:${ip}`;
+
+/** Whether this IP has used up its registration budget. */
+export async function checkRegisterRateLimit(
+  ip: string | null,
+): Promise<RateLimitVerdict> {
+  if (!ip) return { blocked: false, retryAfterMinutes: 0 };
+
+  const since = new Date(Date.now() - REGISTER_WINDOW_MS);
+  const attempts = await db.loginAttempt.findMany({
+    where: { key: registerKey(ip), createdAt: { gte: since } },
+    select: { createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (attempts.length < MAX_REGISTRATIONS_PER_IP) {
+    return { blocked: false, retryAfterMinutes: 0 };
+  }
+
+  const msLeft = attempts[0]!.createdAt.getTime() + REGISTER_WINDOW_MS - Date.now();
+  return {
+    blocked: true,
+    retryAfterMinutes: Math.max(1, Math.ceil(msLeft / 60_000)),
+  };
+}
+
+/** Record a registration attempt and drop rows that have aged out. */
+export async function recordRegisterAttempt(ip: string | null): Promise<void> {
+  if (!ip) return;
+  await db.loginAttempt.create({ data: { key: registerKey(ip) } });
+  await db.loginAttempt.deleteMany({
+    where: {
+      key: { startsWith: "register-ip:" },
+      createdAt: { lt: new Date(Date.now() - REGISTER_WINDOW_MS) },
+    },
+  });
+}

--- a/src/server/auth/tihlde.ts
+++ b/src/server/auth/tihlde.ts
@@ -29,6 +29,59 @@ export class TihldeAuthError extends Error {
   }
 }
 
+/**
+ * Raised when TIHLDE could not be reached at all — a timeout, a dropped TLS
+ * handshake, DNS failure.
+ *
+ * Distinct from `TihldeAuthError` because it says nothing about the user's
+ * credentials, and the advice is the opposite: wait and retry rather than
+ * check what you typed. These are not rare — Lepton timed out on 192 requests
+ * across 11 users in the week before this was written, and every one of them
+ * surfaced to the student as "Noe gikk galt", which reads as "you did
+ * something wrong".
+ */
+export class TihldeUnavailableError extends TihldeAuthError {
+  constructor(readonly cause?: unknown) {
+    super(
+      "Får ikke kontakt med TIHLDE akkurat nå. Vent litt og prøv igjen — det er ikke noe galt med det du fylte inn.",
+      503,
+    );
+    this.name = "TihldeUnavailableError";
+  }
+}
+
+/**
+ * How long we wait for TIHLDE before giving up.
+ *
+ * Vercel's serverless functions have their own ceiling, and hitting that gives
+ * the user a blank platform error instead of ours. Failing first means we can
+ * say something useful.
+ */
+const TIHLDE_TIMEOUT_MS = 10_000;
+
+/**
+ * `fetch` against TIHLDE that turns transport failures into
+ * `TihldeUnavailableError` instead of letting a raw `TypeError: fetch failed`
+ * escape into a route's catch-all. Every call to Lepton goes through here.
+ */
+async function tihldeFetch(
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  try {
+    return await fetch(url, {
+      ...init,
+      // Never cache auth or profile requests.
+      cache: "no-store",
+      signal: AbortSignal.timeout(TIHLDE_TIMEOUT_MS),
+    });
+  } catch (err) {
+    // AbortError (our timeout) and TypeError (DNS, TLS, ECONNRESET) both mean
+    // the same thing to the person waiting: TIHLDE is not answering.
+    throw new TihldeUnavailableError(err);
+  }
+}
+
 /** The subset of `GET /users/me/` we map onto our local user. */
 export interface TihldeProfile {
   user_id: string;
@@ -54,7 +107,7 @@ export async function tihldeLogin(
   userId: string,
   password: string,
 ): Promise<string> {
-  const res = await fetch(apiUrl("/auth/login/"), {
+  const res = await tihldeFetch(apiUrl("/auth/login/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ user_id: userId, password }),
@@ -138,7 +191,7 @@ async function readCreateError(res: Response, fallback: string): Promise<string>
 export async function tihldeCreateUser(
   input: TihldeCreateUserInput,
 ): Promise<void> {
-  const res = await fetch(apiUrl("/users/"), {
+  const res = await tihldeFetch(apiUrl("/users/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
@@ -155,7 +208,7 @@ export async function tihldeCreateUser(
 
 /** Fetch the authenticated user's TIHLDE profile. */
 export async function tihldeGetMe(token: string): Promise<TihldeProfile> {
-  const res = await fetch(apiUrl("/users/me/"), {
+  const res = await tihldeFetch(apiUrl("/users/me/"), {
     headers: { [TOKEN_HEADER]: token },
     cache: "no-store",
   });
@@ -194,7 +247,7 @@ export async function tihldeGetMemberships(
   );
 
   for (let page = 0; url && page < MAX_MEMBERSHIP_PAGES; page++) {
-    const res: Response = await fetch(url, {
+    const res: Response = await tihldeFetch(url, {
       headers: { [TOKEN_HEADER]: token },
       cache: "no-store",
     });
@@ -247,7 +300,7 @@ export async function tihldeUpdateAllergy(
   userId: string,
   allergy: string,
 ): Promise<void> {
-  const res = await fetch(apiUrl(`/users/${encodeURIComponent(userId)}/`), {
+  const res = await tihldeFetch(apiUrl(`/users/${encodeURIComponent(userId)}/`), {
     method: "PATCH",
     headers: {
       [TOKEN_HEADER]: token,

--- a/src/server/auth/token-crypto.ts
+++ b/src/server/auth/token-crypto.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from "node:crypto";
+
+import { env } from "~/env";
+
+/**
+ * Encryption for the TIHLDE API tokens we hold on behalf of logged-in users.
+ *
+ * `Session.tihldeToken` is a live credential for someone's TIHLDE account — it
+ * can read their profile and write to it (that is how allergy sync works). It
+ * outlives our own session row and nothing on tihlde.org invalidates it when
+ * the user logs out here, so anyone who reads the sessions table gets durable
+ * access to real accounts. Storing it in clear text made a database dump a
+ * credential dump.
+ *
+ * AES-256-GCM, key from `SESSION_ENCRYPTION_KEY`. Ciphertexts are tagged with
+ * a version prefix so an unencrypted value written before this existed is still
+ * readable, and so the scheme can be rotated later without guesswork.
+ *
+ * With no key configured we simply do not store the token. That degrades one
+ * feature (allergy sync) and never writes a secret we cannot protect — which is
+ * the right way round for a value like this.
+ */
+
+const SCHEME = "v1";
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12; // 96-bit nonce, the GCM standard
+const AUTH_TAG_LENGTH = 16;
+
+/** The configured key, or null when encryption is not available. */
+function key(): Buffer | null {
+  const hex = env.SESSION_ENCRYPTION_KEY;
+  if (!hex) return null;
+  return Buffer.from(hex, "hex");
+}
+
+/** Whether tokens can be stored at all. */
+export function canStoreTihldeToken(): boolean {
+  return key() !== null;
+}
+
+/**
+ * Encrypt a TIHLDE token for storage. Returns null when no key is configured,
+ * which the caller stores as "no token" rather than as plaintext.
+ */
+export function encryptToken(plaintext: string | null): string | null {
+  if (!plaintext) return null;
+
+  const k = key();
+  if (!k) {
+    console.warn(
+      "[auth] SESSION_ENCRYPTION_KEY is not set — the TIHLDE token will not be stored, so allergy sync is disabled.",
+    );
+    return null;
+  }
+
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, k, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    SCHEME,
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    encrypted.toString("base64"),
+  ].join(".");
+}
+
+/**
+ * Decrypt a stored token.
+ *
+ * A value without our version prefix is one written before encryption existed,
+ * and is returned as-is so existing sessions keep working; it is replaced with
+ * a ciphertext the next time the user logs in. A value that is tagged but fails
+ * to authenticate returns null rather than throwing — a corrupt or
+ * wrong-key token should log the user out of TIHLDE-backed features, not crash
+ * every request that touches their session.
+ */
+export function decryptToken(stored: string | null): string | null {
+  if (!stored) return null;
+  if (!stored.startsWith(`${SCHEME}.`)) return stored;
+
+  const [, ivPart, tagPart, dataPart] = stored.split(".");
+  if (!ivPart || !tagPart || !dataPart) return null;
+
+  const k = key();
+  if (!k) return null;
+
+  try {
+    const authTag = Buffer.from(tagPart, "base64");
+    if (authTag.length !== AUTH_TAG_LENGTH) return null;
+
+    const decipher = createDecipheriv(
+      ALGORITHM,
+      k,
+      Buffer.from(ivPart, "base64"),
+    );
+    decipher.setAuthTag(authTag);
+
+    return Buffer.concat([
+      decipher.update(Buffer.from(dataPart, "base64")),
+      decipher.final(),
+    ]).toString("utf8");
+  } catch {
+    // Wrong key or tampered ciphertext.
+    return null;
+  }
+}

--- a/src/server/db-errors.ts
+++ b/src/server/db-errors.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { Prisma } from "@prisma/client";
+
+/**
+ * Recognising the database errors a user can actually cause.
+ *
+ * Without this every Prisma failure lands in a route's catch-all and comes out
+ * as "Noe gikk galt" — which is how a student who was simply already
+ * registered ended up stuck at a stand, retrying a form that could never
+ * succeed. A unique-constraint violation is not an internal error; it is the
+ * database telling us something specific and repeatable about the request.
+ */
+
+/** Prisma's code for "unique constraint failed". */
+const UNIQUE_CONSTRAINT = "P2002";
+
+/** Whether this error is a unique-constraint violation. */
+export function isUniqueConstraintError(err: unknown): boolean {
+  return (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    err.code === UNIQUE_CONSTRAINT
+  );
+}
+
+/**
+ * Which form field a unique-constraint violation belongs to, so the client can
+ * highlight it. Prisma reports the offending columns in `meta.target`; we map
+ * the ones that correspond to something the user typed.
+ */
+export function uniqueConstraintField(err: unknown): string | undefined {
+  if (!(err instanceof Prisma.PrismaClientKnownRequestError)) return undefined;
+
+  const target = err.meta?.target;
+  const columns = Array.isArray(target)
+    ? target.map(String)
+    : typeof target === "string"
+      ? [target]
+      : [];
+
+  if (columns.includes("email")) return "email";
+  if (columns.includes("tihldeUserId")) return "user_id";
+  return undefined;
+}

--- a/src/server/fadder.ts
+++ b/src/server/fadder.ts
@@ -1,0 +1,149 @@
+/**
+ * Who owes money for fadderuka — and, just as importantly, who never does.
+ *
+ * Only fadderbarn pay. Faddere are by definition students in their second year
+ * or later, so the study cohort on the TIHLDE profile is what separates the
+ * two groups. `User.klasse` holds Lepton's STUDYYEAR group name, which is the
+ * ADMISSION YEAR as a string ("2026") — not an ordinal like "1. klasse". A
+ * user admitted before the current fadderuke cohort is therefore in 2. klasse
+ * or higher and can never be a fadderbarn.
+ *
+ * Three signals feed the decision, in priority order:
+ *   1. `fadderOverride` — a manual admin decision, which always wins.
+ *   2. A FADDER role in a faddergruppe — explicit, and covers the rare fadder
+ *      whose cohort data is missing or wrong.
+ *   3. The study cohort — the automatic path, which is what makes a fadder
+ *      exempt from their very first login, before any admin has touched them.
+ *
+ * Deliberately fails towards "pays" when the cohort is unknown: a brand-new
+ * student self-registering has no year group yet (`class: null` in
+ * `tihldeCreateUser`), and that is exactly the fadderbarn case. A fadder who
+ * lands here anyway is one admin click away from being fixed, and can never be
+ * charged in the meantime — `payment.initiatePayment` refuses exempt users.
+ */
+
+import { env } from "~/env";
+
+/** Lowest admission year we'll believe; anything older is bad data, not a cohort. */
+const MIN_PLAUSIBLE_COHORT_YEAR = 2000;
+/** Highest admission year we'll believe, guarding against typos like "20265". */
+const MAX_PLAUSIBLE_COHORT_YEAR = 2100;
+
+/**
+ * Month (0-indexed) from which the new cohort is considered to have started.
+ * The academic year — and fadderuka itself — starts in August, so from July
+ * onwards "this year's" cohort is the new one. Before July, students admitted
+ * last year are still in their first year and still owe money.
+ */
+const NEW_COHORT_FROM_MONTH = 6; // July
+
+/**
+ * The admission year of the students fadderuka is being run for, i.e. this
+ * year's 1. klasse. Everyone admitted earlier is 2. klasse or higher.
+ *
+ * `FADDERUKE_COHORT_YEAR` pins it explicitly, which is what FadderKom should
+ * set each year: it removes any dependence on the server clock at the exact
+ * moment money is on the line. Without it we fall back to the calendar.
+ */
+export function currentCohortYear(
+  now: Date = new Date(),
+  override: string | undefined = env.FADDERUKE_COHORT_YEAR,
+): number {
+  const pinned = parseCohortYear(override ?? null);
+  if (pinned !== null) return pinned;
+  return cohortYearFromCalendar(now);
+}
+
+/**
+ * The cohort year implied by the calendar alone, ignoring any pinned value.
+ * Split out so the fallback stays directly testable — passing `undefined` to
+ * `currentCohortYear` re-triggers its default and reads the environment again.
+ */
+export function cohortYearFromCalendar(now: Date): number {
+  const year = now.getFullYear();
+  return now.getMonth() >= NEW_COHORT_FROM_MONTH ? year : year - 1;
+}
+
+/**
+ * Read an admission year out of a `klasse` value, or null when it isn't one.
+ *
+ * Lepton's STUDYYEAR groups are named by the plain year ("2026"), but the field
+ * is free-form text on our side, so anything that isn't a plausible four-digit
+ * year is treated as unknown rather than coerced.
+ */
+export function parseCohortYear(klasse: string | null | undefined): number | null {
+  if (typeof klasse !== "string") return null;
+
+  const match = /^\s*(\d{4})\s*$/.exec(klasse);
+  if (!match?.[1]) return null;
+
+  const year = Number(match[1]);
+  if (year < MIN_PLAUSIBLE_COHORT_YEAR || year > MAX_PLAUSIBLE_COHORT_YEAR) {
+    return null;
+  }
+  return year;
+}
+
+/**
+ * Whether the cohort puts this user in their second year or later — the
+ * baseline requirement for being a fadder. Unknown cohorts return false, which
+ * keeps a self-registering new student on the paying side.
+ */
+export function isSecondYearOrLater(
+  klasse: string | null | undefined,
+  cohortYear: number = currentCohortYear(),
+): boolean {
+  const year = parseCohortYear(klasse);
+  if (year === null) return false;
+  return year < cohortYear;
+}
+
+export interface DeriveFadderInput {
+  /** Manual admin decision; `null` means derive. */
+  fadderOverride?: boolean | null;
+  /** TIHLDE STUDYYEAR group name, i.e. the admission year. */
+  klasse?: string | null;
+  /** Whether the user holds a FADDER role in any faddergruppe. */
+  hasFadderMembership?: boolean;
+  cohortYear?: number;
+}
+
+/** Resolve the three signals into the single `isFadder` fact we persist. */
+export function deriveIsFadder({
+  fadderOverride = null,
+  klasse = null,
+  hasFadderMembership = false,
+  cohortYear = currentCohortYear(),
+}: DeriveFadderInput): boolean {
+  if (fadderOverride != null) return fadderOverride;
+  if (hasFadderMembership) return true;
+  return isSecondYearOrLater(klasse, cohortYear);
+}
+
+/**
+ * The single predicate every payment guard uses: does this user owe nothing?
+ *
+ * Admins run the app and have never paid; faddere are not customers at all.
+ * Keeping both behind one function is what stops the two rules drifting apart
+ * between the paywall, the tRPC procedures and the admin reporting.
+ */
+export function isPaymentExempt(user: {
+  isAdmin?: boolean | null;
+  isFadder?: boolean | null;
+}): boolean {
+  return user.isAdmin === true || user.isFadder === true;
+}
+
+/**
+ * Whether the user may see the app's content.
+ *
+ * Exempt users are in without paying; everyone else needs the verification a
+ * captured payment (or an admin) grants them.
+ */
+export function hasAppAccess(user: {
+  isAdmin?: boolean | null;
+  isFadder?: boolean | null;
+  isVerified?: boolean | null;
+}): boolean {
+  return isPaymentExempt(user) || user.isVerified === true;
+}

--- a/src/server/payment/vipps.ts
+++ b/src/server/payment/vipps.ts
@@ -26,7 +26,9 @@ export class VippsError extends Error {
 /** Raised when the server is missing the Vipps credentials it needs. */
 export class VippsNotConfiguredError extends VippsError {
   constructor() {
-    super("Vipps er ikke konfigurert på serveren");
+    super(
+      "Betaling er midlertidig utilgjengelig. Si fra til en fadder — det er ikke noe galt med Vipps-en din.",
+    );
     this.name = "VippsNotConfiguredError";
   }
 }
@@ -116,7 +118,9 @@ async function getAccessToken(cfg: VippsConfig): Promise<string> {
       response.status,
       await response.text(),
     );
-    throw new VippsError("Kunne ikke hente Vipps tilgangstoken");
+    throw new VippsError(
+            "Får ikke kontakt med Vipps akkurat nå. Vent litt og prøv igjen.",
+        );
   }
 
   const data = (await response.json()) as { access_token: string };
@@ -199,7 +203,9 @@ export async function createPayment(
       response.status,
       await response.text(),
     );
-    throw new VippsError("Kunne ikke opprette Vipps betaling");
+    throw new VippsError(
+            "Klarte ikke å starte betalingen i Vipps. Vent litt og prøv igjen.",
+        );
   }
 
   const data = (await response.json()) as { redirectUrl: string };

--- a/src/server/payment/webhook-signature.ts
+++ b/src/server/payment/webhook-signature.ts
@@ -1,0 +1,103 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Vipps webhook request authentication.
+ *
+ * Vipps signs every callback with HMAC-SHA256 over the request method, path,
+ * host, date and a hash of the raw body:
+ * https://developer.vippsmobilepay.com/docs/APIs/webhooks-api/request-authentication/
+ *
+ * Settling a payment already re-verifies everything against the Vipps API, so
+ * a forged webhook can never mark anyone paid. What it *could* do is name a
+ * real reference and make us capture a reservation early. Checking the
+ * signature closes that, and means we stop doing work on behalf of anyone who
+ * simply knows an order id.
+ *
+ * Ported from the equivalent implementation in Photon (`apps/api/src/lib/vipps.ts`).
+ */
+
+export interface VippsWebhookRequestParts {
+  /** HTTP method, e.g. "POST". */
+  method: string;
+  /** Path and query string, e.g. "/api/vipps/webhook". */
+  pathAndQuery: string;
+  /** The `Host` header the request was sent to. */
+  host: string;
+  /** The `x-ms-date` (or `date`) header. */
+  date: string;
+  /** The `x-ms-content-sha256` header: base64 SHA-256 of the body. */
+  contentSha256: string;
+  /** The `Authorization` header. */
+  authorization: string;
+  /** The raw, unparsed request body. */
+  rawBody: string;
+}
+
+/**
+ * Constant-time comparison of two UTF-8 strings that never throws on a length
+ * mismatch (which `timingSafeEqual` would).
+ */
+function safeStringEqual(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a, "utf-8");
+  const bufferB = Buffer.from(b, "utf-8");
+  if (bufferA.length !== bufferB.length) return false;
+  return timingSafeEqual(bufferA, bufferB);
+}
+
+/**
+ * Pull the `Signature` out of a Vipps `Authorization` header of the form
+ * `HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=<base64>`.
+ */
+function parseAuthorizationSignature(authorization: string): string | null {
+  if (!authorization.startsWith("HMAC-SHA256 ")) return null;
+  const match = /Signature=([^&\s]+)/.exec(authorization);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Verify a webhook request against the shared secret.
+ *
+ * @returns `true` when the request is authentically from Vipps.
+ */
+export function verifyVippsWebhookSignature(
+  parts: VippsWebhookRequestParts,
+  secret: string,
+): boolean {
+  const providedSignature = parseAuthorizationSignature(parts.authorization);
+  if (!providedSignature || !parts.contentSha256 || !parts.date) return false;
+
+  // The body must not have been tampered with: base64(sha256(rawBody)) has to
+  // match the x-ms-content-sha256 header.
+  const computedContentHash = createHash("sha256")
+    .update(parts.rawBody, "utf-8")
+    .digest("base64");
+
+  if (!safeStringEqual(computedContentHash, parts.contentSha256)) return false;
+
+  // Rebuild the string Vipps signed and recompute the signature.
+  const stringToSign = `${parts.method}\n${parts.pathAndQuery}\n${parts.date};${parts.host};${computedContentHash}`;
+  const expectedSignature = createHmac("sha256", secret)
+    .update(stringToSign, "utf-8")
+    .digest("base64");
+
+  return safeStringEqual(expectedSignature, providedSignature);
+}
+
+/** Read the parts we need to verify out of a Fetch API `Request`. */
+export function webhookPartsFromRequest(
+  request: Request,
+  rawBody: string,
+): VippsWebhookRequestParts {
+  const url = new URL(request.url);
+  const header = (name: string) => request.headers.get(name) ?? "";
+
+  return {
+    method: request.method,
+    pathAndQuery: url.pathname + url.search,
+    host: header("host") || url.host,
+    date: header("x-ms-date") || header("date"),
+    contentSha256: header("x-ms-content-sha256"),
+    authorization: header("authorization"),
+    rawBody,
+  };
+}

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -74,4 +74,14 @@ process.env.VIPPS_CLIENT_SECRET = "test-client-secret";
 process.env.VIPPS_MERCHANT_SERIAL_NUMBER = "123456";
 process.env.VIPPS_SUBSCRIPTION_KEY = "test-subscription-key";
 
+// Pin the fadderuke cohort so "who pays" never depends on the day the suite
+// runs. Without it the year is derived from the calendar, and every
+// cohort-based assertion would start failing on its own in January.
+process.env.FADDERUKE_COHORT_YEAR = "2026";
+
+// A throwaway key so the tests exercise the same encrypt-at-rest path
+// production uses. Without it, TIHLDE tokens are simply not stored, and the
+// session tests would be checking a code path no deployment runs.
+process.env.SESSION_ENCRYPTION_KEY = "0".repeat(64);
+
 export const TEST_DATABASE_URL = databaseUrl;

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -42,6 +42,8 @@ export async function createUser(
     klasse: string | null;
     passwordHash: string | null;
     passwordIsTemporary: boolean;
+    isFadder: boolean;
+    fadderOverride: boolean | null;
     createdAt: Date;
   }> = {},
 ) {
@@ -59,9 +61,23 @@ export async function createUser(
       klasse: overrides.klasse ?? null,
       passwordHash: overrides.passwordHash ?? null,
       passwordIsTemporary: overrides.passwordIsTemporary ?? false,
+      isFadder: overrides.isFadder ?? false,
+      fadderOverride: overrides.fadderOverride ?? null,
       ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
     },
   });
+}
+
+/**
+ * A user who has completed registration and therefore has access to the app —
+ * what almost every content test means by "a user". `createUser` deliberately
+ * defaults to unverified, because that models a fresh sign-up sitting behind
+ * the paywall, and the procedures serving fadderuka content reject those.
+ */
+export async function createMember(
+  overrides: Parameters<typeof createUser>[0] = {},
+) {
+  return createUser({ isVerified: true, ...overrides });
 }
 
 export async function createAdmin(

--- a/tests/integration/activity-router.test.ts
+++ b/tests/integration/activity-router.test.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 
 import { anonCaller, callerFor } from "../helpers/caller";
-import { createAdmin, createUser, db } from "../helpers/db";
+import { createAdmin, createMember, createUser, db } from "../helpers/db";
 import { fetchMock, json, text } from "../helpers/fetch-mock";
 
 async function expectCode(promise: Promise<unknown>, code: string) {
@@ -64,7 +64,7 @@ describe("activity.getUpcoming", () => {
       { id: 2, title: "Annet", start_date: "2026-08-08T18:00:00Z", category: "Bedpres" },
     ]);
 
-    const events = await anonCaller().activity.getUpcoming();
+    const events = await callerFor(await createMember()).activity.getUpcoming();
 
     // Kun Fadderuka-kategorien fra TIHLDE, og lokal aktivitet sist (senest dato).
     expect(events.map((e) => e.title)).toEqual(["Fadderuka-event", "Lokal"]);
@@ -77,7 +77,7 @@ describe("activity.getUpcoming", () => {
     await db.activity.create({ data: localActivity({ title: "Lokal" }) });
     fetchMock.on("GET", "/events/", text("service unavailable", 503));
 
-    const events = await anonCaller().activity.getUpcoming();
+    const events = await callerFor(await createMember()).activity.getUpcoming();
 
     expect(events.map((e) => e.title)).toEqual(["Lokal"]);
   });
@@ -105,7 +105,9 @@ describe("activity.getUpcoming", () => {
     );
     fetchMock.on("GET", "/events/1/", text("boom", 500));
 
-    await expect(anonCaller().activity.getUpcoming()).resolves.toEqual([]);
+    await expect(
+      callerFor(await createMember()).activity.getUpcoming(),
+    ).resolves.toEqual([]);
   });
 });
 
@@ -178,7 +180,8 @@ describe("activity: adminmutasjoner", () => {
     );
   });
 
-  it("getAll er åpen og sorterer på dato", async () => {
+  it("getAll sorterer på dato", async () => {
+    const member = await createMember();
     await db.activity.create({
       data: localActivity({ title: "Sen", date: new Date("2026-08-20T18:00:00Z") }),
     });
@@ -186,8 +189,35 @@ describe("activity: adminmutasjoner", () => {
       data: localActivity({ title: "Tidlig", date: new Date("2026-08-01T18:00:00Z") }),
     });
 
-    const activities = await anonCaller().activity.getAll();
+    const activities = await callerFor(member).activity.getAll();
 
     expect(activities.map((a) => a.title)).toEqual(["Tidlig", "Sen"]);
+  });
+});
+
+/**
+ * Betalingsmuren var tidligere bare et overlegg i klienten: innholdet lå
+ * server-rendret under, og disse endepunktene var åpne. Det holdt å fjerne
+ * ett element i devtools for å bruke appen uten å betale.
+ */
+describe("aktiviteter er bak betalingsmuren", () => {
+  it("avviser uinnloggede", async () => {
+    await expectCode(anonCaller().activity.getUpcoming(), "UNAUTHORIZED");
+    await expectCode(anonCaller().activity.getAll(), "UNAUTHORIZED");
+  });
+
+  it("avviser en innlogget bruker som ikke har betalt", async () => {
+    const unpaid = await createUser();
+
+    await expectCode(callerFor(unpaid).activity.getUpcoming(), "FORBIDDEN");
+    await expectCode(callerFor(unpaid).activity.getAll(), "FORBIDDEN");
+  });
+
+  it("slipper inn faddere, som aldri betaler", async () => {
+    const fadder = await createUser({ isFadder: true, isVerified: false });
+
+    await expect(
+      callerFor(fadder).activity.getAll(),
+    ).resolves.toEqual([]);
   });
 });

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -33,6 +33,7 @@ const ADMIN_PROCEDURE_INPUTS: Record<string, unknown> = {
   getUsers: undefined,
   setUserVerified: { userId: "x", isVerified: true },
   setUserAdmin: { userId: "x", isAdmin: true },
+  setUserFadder: { userId: "x", isFadder: true },
   resetUserPassword: { userId: "x" },
   getGrupper: undefined,
   createGruppe: { name: "Gruppe" },
@@ -225,11 +226,109 @@ describe("admin: brukere og grupper", () => {
   });
 });
 
+describe("fadder-fritak fra adminpanelet", () => {
+  it("fritar brukeren når de får FADDER-rollen i en gruppe", async () => {
+    const admin = await createAdmin();
+    const gruppe = await createGruppe();
+    const user = await createUser();
+
+    await callerFor(admin).admin.addMember({
+      userId: user.id,
+      gruppeId: gruppe.id,
+      role: "FADDER",
+    });
+
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.isFadder).toBe(true);
+    // Får tilgang med det samme — det kommer ingen betaling som verifiserer dem.
+    expect(after.isVerified).toBe(true);
+  });
+
+  it("setter brukeren tilbake til betalende når FADDER-rollen fjernes", async () => {
+    const admin = await createAdmin();
+    const gruppe = await createGruppe();
+    // 1. klasse, så kullet fritar dem ikke.
+    const user = await createUser({ klasse: "2026" });
+
+    const membership = await callerFor(admin).admin.addMember({
+      userId: user.id,
+      gruppeId: gruppe.id,
+      role: "FADDER",
+    });
+    await callerFor(admin).admin.updateMemberRole({
+      membershipId: membership.id,
+      role: "FADDERBARN",
+    });
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).isFadder,
+    ).toBe(false);
+  });
+
+  it("beholder fritaket når kullet sier 2. klasse, selv uten FADDER-rolle", async () => {
+    const admin = await createAdmin();
+    const gruppe = await createGruppe();
+    const user = await createUser({ klasse: "2024" });
+
+    const membership = await callerFor(admin).admin.addMember({
+      userId: user.id,
+      gruppeId: gruppe.id,
+      role: "FADDER",
+    });
+    await callerFor(admin).admin.removeMember({ membershipId: membership.id });
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).isFadder,
+    ).toBe(true);
+  });
+
+  it("varsler admin når en fadder allerede har betalt", async () => {
+    const admin = await createAdmin();
+    const user = await createUser({ name: "Kari", hasPaid: true });
+
+    const result = await callerFor(admin).admin.setUserFadder({
+      userId: user.id,
+      isFadder: true,
+    });
+
+    // Pengene skal tilbake, og admin er den eneste som kan starte det.
+    expect(result.needsRefund).toBe(true);
+    // hasPaid røres ikke: den beskriver at penger faktisk har skiftet hender.
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid,
+    ).toBe(true);
+  });
+
+  it("lar en manuell avgjørelse overleve en senere rolleendring", async () => {
+    const admin = await createAdmin();
+    const gruppe = await createGruppe();
+    const user = await createUser({ klasse: "2024" });
+
+    // En 2.-klassing som faktisk går som fadderbarn.
+    await callerFor(admin).admin.setUserFadder({
+      userId: user.id,
+      isFadder: false,
+    });
+    await callerFor(admin).admin.addMember({
+      userId: user.id,
+      gruppeId: gruppe.id,
+      role: "FADDERBARN",
+    });
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { id: user.id } })).isFadder,
+    ).toBe(false);
+  });
+});
+
 describe("admin.getRegistrations", () => {
   it("teller kun fadderbarn — admins og faddere holdes utenfor", async () => {
     const admin = await createAdmin();
     const gruppe = await createGruppe();
-    const fadder = await createUser({ name: "Fadder" });
+    // `isFadder` er fasiten på hvem som skylder penger, og er det oversikten
+    // filtrerer på. `addMember` her er en rå seeder som ikke går gjennom
+    // adminruteren, så flagget settes eksplisitt.
+    const fadder = await createUser({ name: "Fadder", isFadder: true });
     await addMember(fadder.id, gruppe.id, "FADDER");
     const fadderbarn = await createUser({ name: "Fadderbarn" });
     await addMember(fadderbarn.id, gruppe.id, "FADDERBARN");

--- a/tests/integration/auth-login.route.test.ts
+++ b/tests/integration/auth-login.route.test.ts
@@ -307,6 +307,36 @@ describe("POST /api/auth/login", () => {
     expect(await db.session.count()).toBe(0);
   });
 
+  it("sier at TIHLDE er nede når kallet ikke går gjennom", async () => {
+    fetchMock.on("POST", "/auth/login/", () => {
+      throw new TypeError("fetch failed");
+    });
+
+    const response = await post(CREDENTIALS);
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(503);
+    expect(body.error).toContain("ikke noe galt med det du fylte inn");
+  });
+
+  // Det lokale passordet finnes nettopp for å holde folk inne når TIHLDE ikke
+  // svarer — da skal det også brukes, ikke bare når Lepton sier 401.
+  it("slipper inn på lokalt passord når TIHLDE er utilgjengelig", async () => {
+    await createUser({
+      tihldeUserId: "olanor",
+      email: null,
+      passwordHash: await hashPassword(CREDENTIALS.password),
+    });
+    fetchMock.on("POST", "/auth/login/", () => {
+      throw new TypeError("fetch failed");
+    });
+
+    const response = await post(CREDENTIALS);
+
+    expect(response.status).toBe(200);
+    expect(lastSetCookie(SESSION_COOKIE)?.value).toBeTruthy();
+  });
+
   it("gir 502 når TIHLDE svarer med en serverfeil", async () => {
     fetchMock.on("POST", "/auth/login/", text("boom", 500));
 

--- a/tests/integration/auth-login.route.test.ts
+++ b/tests/integration/auth-login.route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { POST as login } from "~/app/api/auth/login/route";
 import { SESSION_COOKIE } from "~/server/auth/config";
 import { hashPassword } from "~/server/auth/password";
+import { decryptToken } from "~/server/auth/token-crypto";
 
 import { createUser, db } from "../helpers/db";
 import { fetchMock, json, text } from "../helpers/fetch-mock";
@@ -33,9 +34,11 @@ const PROFILE = {
 /** Stub the whole TIHLDE login chain: token, profile, memberships. */
 function stubTihldeLogin(opts: {
   memberships?: { group: { slug: string } }[];
+  /** Overrides merged into the default profile, e.g. a different `studyyear`. */
+  profile?: Partial<typeof PROFILE>;
 } = {}) {
   fetchMock.on("POST", "/auth/login/", json({ token: "tihlde-token" }));
-  fetchMock.on("GET", "/users/me/", json(PROFILE));
+  fetchMock.on("GET", "/users/me/", json({ ...PROFILE, ...opts.profile }));
   fetchMock.on(
     "GET",
     "/users/olanor/memberships/",
@@ -65,7 +68,10 @@ describe("POST /api/auth/login", () => {
     expect(user.isAdmin).toBe(false);
 
     const session = await db.session.findFirstOrThrow({ where: { userId: user.id } });
-    expect(session.tihldeToken).toBe("tihlde-token");
+    // TIHLDE-tokenet er en levende nøkkel til brukerens ekte konto, så det
+    // skal aldri ligge lesbart i databasen — men må komme uskadd tilbake.
+    expect(session.tihldeToken).not.toBe("tihlde-token");
+    expect(decryptToken(session.tihldeToken)).toBe("tihlde-token");
     // Kun første ledd av x-forwarded-for skal lagres.
     expect(session.ipAddress).toBe("10.0.0.1");
     expect(session.userAgent).toBe("vitest");
@@ -75,7 +81,7 @@ describe("POST /api/auth/login", () => {
     expect(cookie?.options).toMatchObject({ httpOnly: true, sameSite: "lax", path: "/" });
   });
 
-  it("gjør FadderKom-medlemmer til admin, verifisert og betalt", async () => {
+  it("gjør FadderKom-medlemmer til admin og gir dem tilgang uten å betale", async () => {
     stubTihldeLogin({ memberships: [{ group: { slug: "fadderkom" } }] });
 
     await post(CREDENTIALS);
@@ -85,7 +91,71 @@ describe("POST /api/auth/login", () => {
     });
     expect(user.isAdmin).toBe(true);
     expect(user.isVerified).toBe(true);
-    expect(user.hasPaid).toBe(true);
+    // `hasPaid` betyr at penger faktisk har skiftet hender. Å sette det her
+    // gjorde at en admin som senere ble degradert så betalt ut for alltid.
+    expect(user.hasPaid).toBe(false);
+  });
+
+  // Faddere går per definisjon i 2. klasse eller mer, så kullet på
+  // TIHLDE-profilen avgjør dette alene — før noen har lagt dem i en gruppe.
+  it("fritar en student i 2. klasse eller høyere fra betaling", async () => {
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2025" } } } });
+
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isFadder).toBe(true);
+    // Får tilgang med én gang: det kommer ingen betaling som ville verifisert dem.
+    expect(user.isVerified).toBe(true);
+    expect(user.hasPaid).toBe(false);
+  });
+
+  it("lar årets kull betale", async () => {
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2026" } } } });
+
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isFadder).toBe(false);
+    expect(user.isVerified).toBe(false);
+  });
+
+  it("lar en manuell fadder-fritakelse overleve innlogging", async () => {
+    await createUser({
+      tihldeUserId: "olanor",
+      email: null,
+      fadderOverride: true,
+    });
+    // Kullet sier 1. klasse, men admin har bestemt noe annet.
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2026" } } } });
+
+    await post(CREDENTIALS);
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } }))
+        .isFadder,
+    ).toBe(true);
+  });
+
+  it("lar en manuell betalingsplikt overleve innlogging", async () => {
+    // 2.-klassingen som faktisk går som fadderbarn.
+    await createUser({
+      tihldeUserId: "olanor",
+      email: null,
+      fadderOverride: false,
+    });
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2019" } } } });
+
+    await post(CREDENTIALS);
+
+    expect(
+      (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } }))
+        .isFadder,
+    ).toBe(false);
   });
 
   it("gjør Index-medlemmer til admin", async () => {

--- a/tests/integration/auth-register.route.test.ts
+++ b/tests/integration/auth-register.route.test.ts
@@ -131,15 +131,84 @@ describe("POST /api/auth/register", () => {
     expect(await db.user.count()).toBe(0);
   });
 
-  it("oppdaterer en eksisterende lokal bruker i stedet for å duplisere", async () => {
-    await createUser({ tihldeUserId: "olanor", name: "Gammelt Navn", email: null });
-    fetchMock.on("POST", "/users/", json({}, 201));
+  /**
+   * Den vanligste måten å feile på: en student som ikke fullførte Vipps kommer
+   * tilbake og registrerer seg på nytt. Før ga det «Noe gikk galt», som leses
+   * som «du gjorde noe feil» — og hun ble stående fast på stand.
+   */
+  describe("når brukeren allerede er registrert", () => {
+    it("sier hvem de er, i stedet for å duplisere", async () => {
+      await createUser({ tihldeUserId: "olanor", name: "Gammelt Navn", email: null });
 
-    await post(FORM);
+      const response = await post(FORM);
+      const body = (await response.json()) as {
+        error: string;
+        field?: string;
+        existingUserId?: string;
+      };
 
-    expect(await db.user.count()).toBe(1);
-    expect(
-      (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } })).name,
-    ).toBe("Ola Nordmann");
+      expect(response.status).toBe(409);
+      expect(body.error).toContain("olanor");
+      expect(body.existingUserId).toBe("olanor");
+      expect(body.field).toBe("user_id");
+      // Ingen ny TIHLDE-konto, og ingen ny lokal rad.
+      expect(fetchMock.calls).toHaveLength(0);
+      expect(await db.user.count()).toBe(1);
+    });
+
+    it("fanger e-postkollisjonen og peker på riktig bruker", async () => {
+      // Nøyaktig hendelsen fra 2. august: samme person, nytt brukernavn.
+      await createUser({ tihldeUserId: "ambea001", email: "ambea001@outlook.com" });
+
+      const response = await post({
+        ...FORM,
+        user_id: "Aminabh",
+        email: "Ambea001@outlook.com",
+      });
+      const body = (await response.json()) as {
+        error: string;
+        field?: string;
+        existingUserId?: string;
+      };
+
+      expect(response.status).toBe(409);
+      // Må matche uavhengig av store og små bokstaver.
+      expect(body.existingUserId).toBe("ambea001");
+      expect(body.field).toBe("email");
+      expect(body.error).toContain("ambea001");
+      // Og aller viktigst: ingen foreldreløs TIHLDE-konto ble opprettet.
+      expect(fetchMock.calls).toHaveLength(0);
+      expect(await db.user.count()).toBe(1);
+    });
+  });
+
+  it("ruller tilbake den lokale raden når TIHLDE avviser opprettelsen", async () => {
+    // Vår rad opprettes først nettopp fordi den er den vi kan angre.
+    fetchMock.on("POST", "/users/", json({ detail: "Nei" }, 400));
+
+    const response = await post(FORM);
+
+    expect(response.status).toBe(400);
+    expect(await db.user.count()).toBe(0);
+    expect(await db.session.count()).toBe(0);
+  });
+
+  it("sier at TIHLDE er nede når kallet ikke går gjennom", async () => {
+    // Nettverksfeil, ikke et HTTP-svar — 192 av disse traff 11 brukere den
+    // første uka, og alle fikk «Noe gikk galt».
+    fetchMock.on("POST", "/users/", () => {
+      throw new TypeError("fetch failed");
+    });
+
+    const response = await post(FORM);
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(body.error).toContain("TIHLDE");
+    // Meldingen må frita brukeren for skyld.
+    expect(body.error).toContain("ikke noe galt med det du fylte inn");
+    // Ingen halvferdig lokal bruker igjen.
+    expect(await db.user.count()).toBe(0);
   });
 });

--- a/tests/integration/gruppe-router.test.ts
+++ b/tests/integration/gruppe-router.test.ts
@@ -6,7 +6,7 @@ import {
   addMember,
   createAdmin,
   createGruppe,
-  createUser,
+  createMember,
   db,
 } from "../helpers/db";
 
@@ -20,8 +20,8 @@ async function expectCode(promise: Promise<unknown>, code: string) {
 describe("gruppe.getMyGruppe", () => {
   it("gir medlemskapet med alle gruppemedlemmene", async () => {
     const gruppe = await createGruppe("Gruppe 1");
-    const fadder = await createUser({ name: "Fadder" });
-    const barn = await createUser({ name: "Barn" });
+    const fadder = await createMember({ name: "Fadder" });
+    const barn = await createMember({ name: "Barn" });
     await addMember(fadder.id, gruppe.id, "FADDER");
     await addMember(barn.id, gruppe.id, "FADDERBARN");
 
@@ -36,7 +36,7 @@ describe("gruppe.getMyGruppe", () => {
   });
 
   it("gir null for en bruker uten gruppe", async () => {
-    const user = await createUser();
+    const user = await createMember();
     await expect(callerFor(user).gruppe.getMyGruppe()).resolves.toBeNull();
   });
 
@@ -48,7 +48,7 @@ describe("gruppe.getMyGruppe", () => {
 describe("gruppe.getMessages", () => {
   it("gir bare meldingene i den valgte kanalen", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser();
+    const fadder = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
     await db.groupMessage.createMany({
       data: [
@@ -67,7 +67,7 @@ describe("gruppe.getMessages", () => {
 
   it("stenger ute brukere som ikke er medlem", async () => {
     const gruppe = await createGruppe();
-    const outsider = await createUser();
+    const outsider = await createMember();
 
     await expectCode(
       callerFor(outsider).gruppe.getMessages({
@@ -94,7 +94,7 @@ describe("gruppe.getMessages", () => {
 describe("gruppe.postMessage", () => {
   it("lar en fadder poste kunngjøringer", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser();
+    const fadder = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
 
     const created = await callerFor(fadder).gruppe.postMessage({
@@ -109,7 +109,7 @@ describe("gruppe.postMessage", () => {
 
   it("lar et fadderbarn chatte, men ikke kunngjøre", async () => {
     const gruppe = await createGruppe();
-    const barn = await createUser();
+    const barn = await createMember();
     await addMember(barn.id, gruppe.id, "FADDERBARN");
     const caller = callerFor(barn);
 
@@ -133,7 +133,7 @@ describe("gruppe.postMessage", () => {
 
   it("stenger ute brukere som ikke er medlem", async () => {
     const gruppe = await createGruppe();
-    const outsider = await createUser();
+    const outsider = await createMember();
 
     await expectCode(
       callerFor(outsider).gruppe.postMessage({
@@ -148,9 +148,9 @@ describe("gruppe.postMessage", () => {
 
   it("varsler de andre medlemmene, men ikke avsenderen", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser({ name: "Kari" });
-    const barn1 = await createUser();
-    const barn2 = await createUser();
+    const fadder = await createMember({ name: "Kari" });
+    const barn1 = await createMember();
+    const barn2 = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
     await addMember(barn1.id, gruppe.id, "FADDERBARN");
     await addMember(barn2.id, gruppe.id, "FADDERBARN");
@@ -172,8 +172,8 @@ describe("gruppe.postMessage", () => {
 
   it("merker chat-varsler som melding", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser();
-    const barn = await createUser();
+    const fadder = await createMember();
+    const barn = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
     await addMember(barn.id, gruppe.id, "FADDERBARN");
 
@@ -189,7 +189,7 @@ describe("gruppe.postMessage", () => {
 
   it("avviser tomme og altfor lange meldinger", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser();
+    const fadder = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
     const caller = callerFor(fadder);
 
@@ -207,7 +207,7 @@ describe("gruppe.postMessage", () => {
 describe("gruppe.deleteMessage", () => {
   it("lar forfatteren slette sin egen melding", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser();
+    const fadder = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
     const message = await db.groupMessage.create({
       data: { content: "hei", authorId: fadder.id, gruppeId: gruppe.id },
@@ -220,7 +220,7 @@ describe("gruppe.deleteMessage", () => {
 
   it("lar admin slette andres meldinger", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser();
+    const fadder = await createMember();
     const admin = await createAdmin();
     await addMember(fadder.id, gruppe.id, "FADDER");
     const message = await db.groupMessage.create({
@@ -234,8 +234,8 @@ describe("gruppe.deleteMessage", () => {
 
   it("nekter andre medlemmer å slette", async () => {
     const gruppe = await createGruppe();
-    const fadder = await createUser();
-    const barn = await createUser();
+    const fadder = await createMember();
+    const barn = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
     await addMember(barn.id, gruppe.id, "FADDERBARN");
     const message = await db.groupMessage.create({
@@ -250,7 +250,7 @@ describe("gruppe.deleteMessage", () => {
   });
 
   it("gir NOT_FOUND for en melding som ikke finnes", async () => {
-    const user = await createUser();
+    const user = await createMember();
     await expectCode(
       callerFor(user).gruppe.deleteMessage({ messageId: "finnes-ikke" }),
       "NOT_FOUND",

--- a/tests/integration/notification-router.test.ts
+++ b/tests/integration/notification-router.test.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 
 import { anonCaller, callerFor } from "../helpers/caller";
-import { createGruppe, createUser, db } from "../helpers/db";
+import { createGruppe, createMember, db } from "../helpers/db";
 
 async function expectCode(promise: Promise<unknown>, code: string) {
   await expect(promise).rejects.toSatisfy(
@@ -18,8 +18,8 @@ async function notify(userId: string, gruppeId: string, message: string, read = 
 describe("notification", () => {
   it("lister bare brukerens egne varsler, nyeste først", async () => {
     const gruppe = await createGruppe();
-    const user = await createUser();
-    const other = await createUser();
+    const user = await createMember();
+    const other = await createMember();
     await notify(user.id, gruppe.id, "første");
     await notify(user.id, gruppe.id, "andre");
     await notify(other.id, gruppe.id, "andres");
@@ -31,7 +31,7 @@ describe("notification", () => {
 
   it("teller bare uleste varsler", async () => {
     const gruppe = await createGruppe();
-    const user = await createUser();
+    const user = await createMember();
     await notify(user.id, gruppe.id, "ulest");
     await notify(user.id, gruppe.id, "lest", true);
 
@@ -40,7 +40,7 @@ describe("notification", () => {
 
   it("markerer ett varsel som lest", async () => {
     const gruppe = await createGruppe();
-    const user = await createUser();
+    const user = await createMember();
     const notification = await notify(user.id, gruppe.id, "hei");
 
     await callerFor(user).notification.markRead({ id: notification.id });
@@ -52,8 +52,8 @@ describe("notification", () => {
 
   it("kan ikke markere en annens varsel som lest", async () => {
     const gruppe = await createGruppe();
-    const user = await createUser();
-    const other = await createUser();
+    const user = await createMember();
+    const other = await createMember();
     const notification = await notify(other.id, gruppe.id, "hei");
 
     // updateMany er scopet på userId, så kallet lykkes men treffer ingenting.
@@ -67,8 +67,8 @@ describe("notification", () => {
 
   it("markerer alle egne varsler som lest, og ingen andres", async () => {
     const gruppe = await createGruppe();
-    const user = await createUser();
-    const other = await createUser();
+    const user = await createMember();
+    const other = await createMember();
     await notify(user.id, gruppe.id, "a");
     await notify(user.id, gruppe.id, "b");
     await notify(other.id, gruppe.id, "c");

--- a/tests/integration/payment-router.test.ts
+++ b/tests/integration/payment-router.test.ts
@@ -22,6 +22,14 @@ describe("payment.getStatus", () => {
     await expect(callerFor(user).payment.getStatus()).resolves.toEqual({
       hasPaid: true,
       isVerified: true,
+      isExempt: false,
+    });
+  });
+
+  it("melder fra at faddere er fritatt, så klienten aldri viser betalingsvinduet", async () => {
+    const fadder = await createUser({ isFadder: true, isVerified: true });
+    await expect(callerFor(fadder).payment.getStatus()).resolves.toMatchObject({
+      isExempt: true,
     });
   });
 
@@ -60,6 +68,49 @@ describe("payment.initiatePayment", () => {
     const user = await createUser({ hasPaid: true });
     await expectCode(callerFor(user).payment.initiatePayment(), "BAD_REQUEST");
     expect(await db.payment.count()).toBe(0);
+  });
+
+  // Kjernen i "faddere skal ikke betale": å skjule knappen i UI-et holder ikke,
+  // for mutasjonen er fortsatt kallbar. Serveren må nekte å ta imot pengene.
+  it("nekter å ta betalt av en fadder", async () => {
+    const fadder = await createUser({ isFadder: true });
+
+    await expectCode(callerFor(fadder).payment.initiatePayment(), "FORBIDDEN");
+
+    // Ingen ordre opprettet, og Vipps ble aldri kontaktet i det hele tatt.
+    expect(await db.payment.count()).toBe(0);
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("nekter å ta betalt av en admin", async () => {
+    const admin = await createUser({ isAdmin: true });
+
+    await expectCode(callerFor(admin).payment.initiatePayment(), "FORBIDDEN");
+    expect(await db.payment.count()).toBe(0);
+  });
+
+  // To faner eller et utålmodig dobbeltklikk ga tidligere to live Vipps-ordrer,
+  // og begge kunne trekkes — brukeren betalte dobbelt.
+  it("gjenbruker en åpen ordre i stedet for å opprette en ny", async () => {
+    const user = await createUser();
+    stubVippsToken();
+    fetchMock.on(
+      "POST",
+      "/epayment/v1/payments",
+      json({ redirectUrl: "https://vipps.test/checkout/abc" }),
+    );
+
+    await callerFor(user).payment.initiatePayment();
+    await callerFor(user).payment.initiatePayment();
+
+    const orders = await db.payment.findMany({ where: { userId: user.id } });
+    expect(orders).toHaveLength(1);
+
+    // Begge forsøkene må peke på samme Vipps-referanse.
+    const references = fetchMock
+      .callsTo("/epayment/v1/payments")
+      .map((call) => (call.body as { reference: string }).reference);
+    expect(references).toEqual([orders[0]!.orderId, orders[0]!.orderId]);
   });
 
   it("gir BAD_GATEWAY når Vipps svarer med feil", async () => {

--- a/tests/integration/vipps-client.test.ts
+++ b/tests/integration/vipps-client.test.ts
@@ -368,8 +368,10 @@ describe("createPayment", () => {
   it("kaster VippsError når tilgangstokenet ikke kan hentes", async () => {
     fetchMock.on("POST", "/accesstoken/get", text("unauthorized", 401));
 
+    // Meldingen er studentens, ikke utviklerens: den nevner ikke
+    // «tilgangstoken», men sier hva de skal gjøre. Detaljene ligger i loggen.
     await expect(createPayment("fadderuka-bruker1-123")).rejects.toThrow(
-      /tilgangstoken/i,
+      /Får ikke kontakt med Vipps/i,
     );
   });
 });

--- a/tests/unit/fadder.test.ts
+++ b/tests/unit/fadder.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cohortYearFromCalendar,
+  currentCohortYear,
+  deriveIsFadder,
+  hasAppAccess,
+  isPaymentExempt,
+  isSecondYearOrLater,
+  parseCohortYear,
+} from "~/server/fadder";
+
+describe("parseCohortYear", () => {
+  it("leser årstallet Lepton lagrer som studieår", () => {
+    expect(parseCohortYear("2026")).toBe(2026);
+    expect(parseCohortYear("  2024  ")).toBe(2024);
+  });
+
+  it("returnerer null for alt som ikke er et troverdig årstall", () => {
+    // Nye studenter har ikke kull ennå, og feltet er fritekst hos oss.
+    expect(parseCohortYear(null)).toBeNull();
+    expect(parseCohortYear("")).toBeNull();
+    expect(parseCohortYear("1. klasse")).toBeNull();
+    expect(parseCohortYear("20265")).toBeNull();
+    expect(parseCohortYear("1899")).toBeNull();
+  });
+});
+
+describe("currentCohortYear", () => {
+  it("bruker det pinnede årstallet når det er satt", () => {
+    expect(currentCohortYear(new Date("2026-03-01"), "2031")).toBe(2031);
+  });
+
+  it("ignorerer et ugyldig pinnet årstall og faller tilbake på kalenderen", () => {
+    expect(currentCohortYear(new Date("2026-08-15"), "tull")).toBe(2026);
+  });
+});
+
+describe("cohortYearFromCalendar", () => {
+  it("regner nytt kull fra juli, siden fadderuka er i august", () => {
+    // I juni går 2025-kullet fortsatt i 1. klasse og skylder penger.
+    expect(cohortYearFromCalendar(new Date("2026-06-15"))).toBe(2025);
+    expect(cohortYearFromCalendar(new Date("2026-07-01"))).toBe(2026);
+    expect(cohortYearFromCalendar(new Date("2026-08-15"))).toBe(2026);
+  });
+});
+
+describe("isSecondYearOrLater", () => {
+  it("er sant for kull eldre enn årets", () => {
+    expect(isSecondYearOrLater("2025", 2026)).toBe(true);
+    expect(isSecondYearOrLater("2019", 2026)).toBe(true);
+  });
+
+  it("er usant for årets kull — de er fadderbarn", () => {
+    expect(isSecondYearOrLater("2026", 2026)).toBe(false);
+  });
+
+  it("er usant når kullet er ukjent", () => {
+    // Nyregistrerte har `class: null` hos TIHLDE, og det er nettopp
+    // fadderbarn-tilfellet. Feiler mot "betaler".
+    expect(isSecondYearOrLater(null, 2026)).toBe(false);
+  });
+});
+
+describe("deriveIsFadder", () => {
+  it("fritar studenter i 2. klasse eller høyere", () => {
+    expect(deriveIsFadder({ klasse: "2025", cohortYear: 2026 })).toBe(true);
+  });
+
+  it("lar 1. klasse betale", () => {
+    expect(deriveIsFadder({ klasse: "2026", cohortYear: 2026 })).toBe(false);
+  });
+
+  it("fritar den som har FADDER-rolle, uansett kull", () => {
+    // Dekker fadderen som mangler kulldata på TIHLDE-profilen.
+    expect(
+      deriveIsFadder({
+        klasse: null,
+        hasFadderMembership: true,
+        cohortYear: 2026,
+      }),
+    ).toBe(true);
+  });
+
+  it("lar en manuell avgjørelse overstyre alt annet", () => {
+    // En 2.-klassing som faktisk er fadderbarn skal kunne settes til å betale.
+    expect(
+      deriveIsFadder({
+        fadderOverride: false,
+        klasse: "2020",
+        hasFadderMembership: true,
+        cohortYear: 2026,
+      }),
+    ).toBe(false);
+
+    expect(
+      deriveIsFadder({
+        fadderOverride: true,
+        klasse: "2026",
+        cohortYear: 2026,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isPaymentExempt / hasAppAccess", () => {
+  it("fritar faddere og admins", () => {
+    expect(isPaymentExempt({ isFadder: true })).toBe(true);
+    expect(isPaymentExempt({ isAdmin: true })).toBe(true);
+    expect(isPaymentExempt({ isAdmin: false, isFadder: false })).toBe(false);
+  });
+
+  it("gir tilgang til både betalende og fritatte", () => {
+    expect(hasAppAccess({ isVerified: true })).toBe(true);
+    expect(hasAppAccess({ isFadder: true, isVerified: false })).toBe(true);
+    expect(hasAppAccess({ isAdmin: true, isVerified: false })).toBe(true);
+    expect(hasAppAccess({ isVerified: false })).toBe(false);
+  });
+});

--- a/tests/unit/token-crypto.test.ts
+++ b/tests/unit/token-crypto.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canStoreTihldeToken,
+  decryptToken,
+  encryptToken,
+} from "~/server/auth/token-crypto";
+
+describe("token-kryptering", () => {
+  it("krypterer og dekrypterer tokenet uskadd", () => {
+    const encrypted = encryptToken("tihlde-token");
+
+    expect(encrypted).not.toBeNull();
+    expect(encrypted).not.toBe("tihlde-token");
+    expect(decryptToken(encrypted)).toBe("tihlde-token");
+  });
+
+  it("gir ulik chiffertekst hver gang, så like tokens ikke kan kjennes igjen", () => {
+    // Ny tilfeldig nonce per kryptering.
+    expect(encryptToken("samme")).not.toBe(encryptToken("samme"));
+  });
+
+  it("håndterer tomt og manglende token", () => {
+    expect(encryptToken(null)).toBeNull();
+    expect(encryptToken("")).toBeNull();
+    expect(decryptToken(null)).toBeNull();
+  });
+
+  it("leser gamle, ukrypterte verdier som de er", () => {
+    // Rader skrevet før krypteringen fantes skal fortsatt virke, og byttes ut
+    // ved neste innlogging.
+    expect(decryptToken("gammelt-klartekst-token")).toBe("gammelt-klartekst-token");
+  });
+
+  it("returnerer null for tuklet chiffertekst i stedet for å kaste", () => {
+    const encrypted = encryptToken("tihlde-token")!;
+    const [scheme, iv, tag] = encrypted.split(".");
+
+    // Bytter ut selve dataene, men beholder autentiseringstaggen.
+    const tampered = [scheme, iv, tag, Buffer.from("tuklet").toString("base64")].join(".");
+    expect(decryptToken(tampered)).toBeNull();
+
+    // Og en helt ødelagt struktur.
+    expect(decryptToken("v1.bare-tull")).toBeNull();
+  });
+
+  it("melder at lagring er mulig når nøkkelen er satt", () => {
+    expect(canStoreTihldeToken()).toBe(true);
+  });
+});

--- a/tests/unit/webhook-signature.test.ts
+++ b/tests/unit/webhook-signature.test.ts
@@ -1,0 +1,146 @@
+import { createHash, createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  verifyVippsWebhookSignature,
+  webhookPartsFromRequest,
+  type VippsWebhookRequestParts,
+} from "~/server/payment/webhook-signature";
+
+const SECRET = "webhook-secret";
+
+/** Sign a request exactly the way Vipps does, so the happy path is real. */
+function signed(
+  overrides: Partial<VippsWebhookRequestParts> = {},
+  secret = SECRET,
+): VippsWebhookRequestParts {
+  const rawBody = overrides.rawBody ?? JSON.stringify({ reference: "abc" });
+  const method = overrides.method ?? "POST";
+  const pathAndQuery = overrides.pathAndQuery ?? "/api/vipps/webhook";
+  const host = overrides.host ?? "fadderuka.test";
+  const date = overrides.date ?? "Mon, 02 Aug 2026 12:00:00 GMT";
+
+  const contentSha256 = createHash("sha256")
+    .update(rawBody, "utf-8")
+    .digest("base64");
+
+  const signature = createHmac("sha256", secret)
+    .update(
+      `${method}\n${pathAndQuery}\n${date};${host};${contentSha256}`,
+      "utf-8",
+    )
+    .digest("base64");
+
+  return {
+    method,
+    pathAndQuery,
+    host,
+    date,
+    contentSha256,
+    authorization: `HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=${signature}`,
+    rawBody,
+    ...overrides,
+  };
+}
+
+describe("verifyVippsWebhookSignature", () => {
+  it("godtar en ekte signatur fra Vipps", () => {
+    expect(verifyVippsWebhookSignature(signed(), SECRET)).toBe(true);
+  });
+
+  it("avviser en signatur laget med feil hemmelighet", () => {
+    expect(verifyVippsWebhookSignature(signed({}, "feil-hemmelighet"), SECRET)).toBe(
+      false,
+    );
+  });
+
+  it("avviser en endret body", () => {
+    // Signaturen dekker innholdshashen, så en byttet body må falle.
+    const parts = signed();
+    expect(
+      verifyVippsWebhookSignature(
+        { ...parts, rawBody: JSON.stringify({ reference: "en-annen-ordre" }) },
+        SECRET,
+      ),
+    ).toBe(false);
+  });
+
+  it("avviser når innholdshashen ikke stemmer med bodyen", () => {
+    const parts = signed();
+    expect(
+      verifyVippsWebhookSignature(
+        { ...parts, contentSha256: createHash("sha256").update("noe annet").digest("base64") },
+        SECRET,
+      ),
+    ).toBe(false);
+  });
+
+  it("avviser når sti, host eller dato er byttet ut", () => {
+    for (const override of [
+      { pathAndQuery: "/api/vipps/annet" },
+      { host: "angriper.test" },
+      { date: "Tue, 03 Aug 2026 12:00:00 GMT" },
+    ]) {
+      const parts = { ...signed(), ...override };
+      expect(verifyVippsWebhookSignature(parts, SECRET)).toBe(false);
+    }
+  });
+
+  it("avviser en manglende eller ukjent Authorization-header", () => {
+    expect(
+      verifyVippsWebhookSignature({ ...signed(), authorization: "" }, SECRET),
+    ).toBe(false);
+    expect(
+      verifyVippsWebhookSignature(
+        { ...signed(), authorization: "Bearer noe" },
+        SECRET,
+      ),
+    ).toBe(false);
+  });
+
+  it("avviser når dato eller innholdshash mangler helt", () => {
+    expect(verifyVippsWebhookSignature({ ...signed(), date: "" }, SECRET)).toBe(
+      false,
+    );
+    expect(
+      verifyVippsWebhookSignature({ ...signed(), contentSha256: "" }, SECRET),
+    ).toBe(false);
+  });
+});
+
+describe("webhookPartsFromRequest", () => {
+  it("plukker ut delene signaturen dekker", () => {
+    const rawBody = JSON.stringify({ reference: "abc" });
+    const request = new Request("https://fadderuka.test/api/vipps/webhook?x=1", {
+      method: "POST",
+      headers: {
+        host: "fadderuka.test",
+        "x-ms-date": "Mon, 02 Aug 2026 12:00:00 GMT",
+        "x-ms-content-sha256": "hash",
+        authorization: "HMAC-SHA256 Signature=sig",
+      },
+      body: rawBody,
+    });
+
+    expect(webhookPartsFromRequest(request, rawBody)).toMatchObject({
+      method: "POST",
+      pathAndQuery: "/api/vipps/webhook?x=1",
+      host: "fadderuka.test",
+      date: "Mon, 02 Aug 2026 12:00:00 GMT",
+      contentSha256: "hash",
+      rawBody,
+    });
+  });
+
+  it("faller tilbake på date-headeren når x-ms-date mangler", () => {
+    const request = new Request("https://fadderuka.test/api/vipps/webhook", {
+      method: "POST",
+      headers: { date: "Mon, 02 Aug 2026 12:00:00 GMT" },
+      body: "{}",
+    });
+
+    expect(webhookPartsFromRequest(request, "{}").date).toBe(
+      "Mon, 02 Aug 2026 12:00:00 GMT",
+    );
+  });
+});


### PR DESCRIPTION
## Hvorfor

Faddere skal ikke betale for fadderuka, men ingenting håndhevet det. `FADDER`-rollen fantes bare som gruppemedlemskap, og ble brukt ett eneste sted i betalingssammenheng — som et filter i adminrapporten. Selve håndhevingen kjente ikke rollen:

- Betalingsmuren sjekket bare `isVerified`
- `initiatePayment` hadde ingen fadder-sperre — en fadder **kunne** betale, og API-et tok imot pengene
- Rollen tildeles først *etter* registrering, av en admin

En fadder som logget inn møtte altså en blokkerende «Betal 380 kr»-modal. Registrerte de seg via `/registrering`, ble de sendt rett til Vipps-checkout.

## Hvordan

Faddere går per definisjon i 2. klasse eller mer, og `User.klasse` er **opptaksåret** fra Lepton (`"2026"`, ikke et ordenstall). Kullet avgjør derfor alene, før noen har lagt dem i en gruppe — det er det som gjør at en fadder aldri ser et betalingsvindu, heller ikke ved første innlogging.

`isFadder` utledes ved innlogging fra tre signaler i prioritert rekkefølge:

1. `fadderOverride` — manuell adminavgjørelse, vinner alltid
2. FADDER-rolle i en faddergruppe
3. Studiekullet

Sperren ligger i `initiatePayment`, ikke i UI-et. Å skjule knappen hjelper ikke når mutasjonen er kallbar.

`hasPaid` betyr igjen at penger faktisk har skiftet hender. Innlogging ga admins `hasPaid: true` for å hoppe over muren, noe som gjorde at enhver som senere ble degradert så betalt ut for alltid. Tilgang kommer nå fra fritaket, og en backfill rydder de eksisterende radene.

## Auth-herding

| Funn | Fiks |
|---|---|
| Betalingsmuren var kosmetisk — layouten server-rendret hele appen under overlegget, og innholdsprosedyrene var åpne | Ny `verifiedProcedure`; layouten rendrer betalingsvinduet *i stedet for* innholdet |
| `tihldeToken` lå i klartekst — en levende nøkkel til brukerens ekte TIHLDE-konto | AES-256-GCM. Uten nøkkel lagres det ikke i det hele tatt |
| Vipps-webhooken hadde ingen signaturvalidering | HMAC-SHA256, portert fra Photon |
| To faner ga to trekkbare ordrer → dobbeltbetaling | `initiatePayment` gjenbruker åpne ordrer |
| Registrering var en ustrupet kontoopprettings-proxy mot Lepton | Rate limiting per IP |
| Sesjoner utløp hardt etter 7 dager og ble aldri ryddet | Fornyes ved bruk; utløpte sveipes bort |
| `adminOverride` kunne ikke nullstilles — en feilaktig degradering låste ute for alltid | `setUserAdmin` kan slippe pinningen |

## Verifisering

`bun run check`: 0 feil, **236 tester grønne** (opp fra 190). `next build` går gjennom.

Verifisert mot kjørende app med ekte sesjoner, ikke bare tester:

- **Fadder som kaller betalings-API-et direkte, utenom UI-et:** `403 — "Faddere betaler ikke for fadderuka."` Null ordrer opprettet, Vipps aldri kontaktet
- **Ubetalt fadderbarn:** 62 KB sidesvar, null treff på appinnholdet
- **Fadder:** 105 KB, rett inn i appen

De 43 KB er innholdet som før lå server-rendret under overlegget.

## Før produksjon

To variabler må settes (se `.env.example`):

- **`FADDERUKE_COHORT_YEAR`** (f.eks. `2026`) — uten den utledes året fra kalenderen, og en pengebeslutning bør ikke ri på serverklokka
- **`SESSION_ENCRYPTION_KEY`** (`openssl rand -hex 32`) — ellers slås allergisynk av

`VIPPS_WEBHOOK_SECRET` er valgfri; webhooken re-verifiserer uansett mot Vipps-API-et.

## Verdt å vite

En 2.-klassing som *ikke* er fadder blir også fritatt. Det er riktig — de er ikke fadderbarn og skal ikke betale — men det gir dem appen gratis. Fadder-privilegier (kunngjøringer) krever fortsatt ekte gruppemedlemskap, så det gjelder bare innholdet.

`docs/auth-photon-oauth.md` utreder å bytte fra dagens Lepton-passordproxy til OAuth mot Photon. Anbefalingen er å **ikke** gjøre det før fadderuka: nyregistrering er det egentlige problemet, og den flyten må testes på stand først.

🤖 Generated with [Claude Code](https://claude.com/claude-code)