### PR TITLE
fix(fadderuka): identifiser DT-startere som fadderbarn, og la admin rette studieretning

### DIFF
--- a/prisma/migrations/20260803090000_studieretning_override/migration.sql
+++ b/prisma/migrations/20260803090000_studieretning_override/migration.sql
@@ -1,0 +1,4 @@
+-- Lets a user pin the programme they are starting when TIHLDE's profile still
+-- shows the one they came from (Digital transformasjon: a 2-year continuation
+-- whose new students keep their bachelor STUDY group and cohort on tihlde.org).
+ALTER TABLE "User" ADD COLUMN "studieretningOverride" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,13 @@ model User {
     phone         String?
     klasse        String?
     studieretning String?
+    // The programme the user told us they are STARTING, when TIHLDE's profile
+    // still shows the one they came from. Digital transformasjon is the case
+    // this exists for: it is a 2-year continuation of a bachelor, so its new
+    // students keep their old STUDY group (and old cohort) on tihlde.org.
+    // `null` means "trust TIHLDE"; a value pins `studieretning` and survives
+    // every later login instead of being overwritten by the profile.
+    studieretningOverride String?
     isVerified    Boolean   @default(false)
     hasPaid       Boolean   @default(false)
     isAdmin       Boolean   @default(false)

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -7,10 +7,51 @@ import { api } from "~/trpc/react";
 import { toast } from "~/components/ui/use-toast";
 import {
   MAJORS,
+  type Major,
   UKJENT_STUDIERETNING,
   compareMajorLabels,
   findMajor,
 } from "~/lib/majors";
+
+/**
+ * Correct the programme TIHLDE reports for a user.
+ *
+ * Shows the pinned choice when there is one, and otherwise "Følg TIHLDE" with
+ * whatever the profile currently says — so it is visible at a glance whether a
+ * row is being overridden, and clearing it is one option away.
+ */
+function StudieVelger({
+  studieretning,
+  studieretningOverride,
+  disabled,
+  onChange,
+}: {
+  studieretning: string | null;
+  studieretningOverride: string | null;
+  disabled: boolean;
+  onChange: (studieretning: Major | null) => void;
+}) {
+  return (
+    <select
+      value={studieretningOverride ?? ""}
+      disabled={disabled}
+      onChange={(e) =>
+        onChange(e.target.value === "" ? null : (e.target.value as Major))
+      }
+      title="Overstyr studieretningen TIHLDE oppgir, f.eks. for en som begynner på Digital transformasjon"
+      className="max-w-[13rem] rounded-lg border border-border bg-background !px-2 !py-1 text-xs text-foreground transition focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+    >
+      <option value="">
+        Følg TIHLDE{studieretning ? ` (${studieretning})` : ""}
+      </option>
+      {MAJORS.map((major) => (
+        <option key={major} value={major}>
+          {major}
+        </option>
+      ))}
+    </select>
+  );
+}
 
 export function UsersTab() {
   const [search, setSearch] = useState("");
@@ -79,6 +120,24 @@ export function UsersTab() {
           ? "Refunder betalingen fra Betalinger-fanen."
           : undefined,
         variant: result.needsRefund ? "destructive" : undefined,
+      });
+    },
+    onError: (error) => {
+      toast({ title: "Feil", description: error.message, variant: "destructive" });
+    },
+  });
+
+  const studieMutation = api.admin.setUserStudieretning.useMutation({
+    onSuccess: (result, variables) => {
+      void utils.admin.getUsers.invalidate();
+      void utils.admin.getRegistrations.invalidate();
+      toast({
+        title: variables.studieretning
+          ? `${result.name} står nå på ${variables.studieretning}`
+          : `${result.name} følger TIHLDE igjen`,
+        description: variables.studieretning
+          ? "Valget overlever innlogging. Betalingsstatus er ikke endret."
+          : "Studieretningen hentes fra TIHLDE-profilen ved neste innlogging.",
       });
     },
     onError: (error) => {
@@ -163,7 +222,17 @@ export function UsersTab() {
                       <span className="text-xs text-muted-foreground">Ingen klasse/retning oppgitt</span>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground">
+                  <div className="!mt-2">
+                    <StudieVelger
+                      studieretning={user.studieretning}
+                      studieretningOverride={user.studieretningOverride}
+                      disabled={studieMutation.isPending}
+                      onChange={(studieretning) =>
+                        studieMutation.mutate({ userId: user.id, studieretning })
+                      }
+                    />
+                  </div>
+                  <p className="!mt-2 text-xs text-muted-foreground">
                     Registrert{" "}
                     {new Date(user.createdAt).toLocaleDateString("no-NO", {
                       day: "numeric",
@@ -364,6 +433,7 @@ export function UsersTab() {
                           <th className="!px-4 !py-3 font-medium">Navn</th>
                           <th className="!px-4 !py-3 font-medium">E-post</th>
                           <th className="!px-4 !py-3 font-medium">Klasse</th>
+                          <th className="!px-4 !py-3 font-medium">Studie</th>
                           <th className="!px-4 !py-3 font-medium">Gruppe</th>
                           <th className="!px-4 !py-3 font-medium">Rolle</th>
                           <th className="!px-4 !py-3 font-medium">Betaling</th>
@@ -393,6 +463,22 @@ export function UsersTab() {
                                 ) : (
                                   <span className="text-muted-foreground">—</span>
                                 )}
+                              </td>
+                              {/* TIHLDE eier studieretningen, men henger etter
+                                  for den som begynner på et påbygg som Digital
+                                  transformasjon. Da er dette veien inn. */}
+                              <td className="!px-4 !py-3">
+                                <StudieVelger
+                                  studieretning={user.studieretning}
+                                  studieretningOverride={user.studieretningOverride}
+                                  disabled={studieMutation.isPending}
+                                  onChange={(studieretning) =>
+                                    studieMutation.mutate({
+                                      userId: user.id,
+                                      studieretning,
+                                    })
+                                  }
+                                />
                               </td>
                               <td className="!px-4 !py-3 text-muted-foreground">
                                 {membership ? membership.gruppe.name : "—"}
@@ -524,7 +610,7 @@ export function UsersTab() {
                         {usersInGroup.length === 0 && (
                           <tr>
                             <td
-                              colSpan={7}
+                              colSpan={9}
                               className="!px-4 !py-6 text-center text-muted-foreground"
                             >
                               Ingen brukere funnet

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { cookies, headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { REGISTRATION_STUDY_SLUGS, studyLabelForSlug } from "~/lib/majors";
 import {
   SESSION_COOKIE,
   SESSION_MAX_AGE,
@@ -34,6 +35,12 @@ const ADMIN_GROUP_SLUGS = ["fadderkom", "index"];
 const bodySchema = z.object({
   user_id: z.string().min(1, "Brukernavn er påkrevd."),
   password: z.string().min(1, "Passord er påkrevd."),
+  /**
+   * Optional: the programme the user is STARTING this autumn, when it isn't the
+   * one their TIHLDE profile shows. Sent from the "nytt studium i år" option on
+   * the login page — see the handling in step 3.
+   */
+  study: z.enum(REGISTRATION_STUDY_SLUGS).optional(),
 });
 
 /** The caller's IP, taken from the first hop in x-forwarded-for. */
@@ -129,6 +136,9 @@ export async function POST(request: Request) {
       select: {
         adminOverride: true,
         fadderOverride: true,
+        studieretningOverride: true,
+        isFadder: true,
+        hasPaid: true,
         memberships: { where: { role: "FADDER" }, select: { id: true } },
       },
     });
@@ -147,44 +157,100 @@ export async function POST(request: Request) {
       }
     }
 
-    // 3. Decide whether this user owes anything at all. Only fadderbarn pay,
+    const hasFadderMembership = (existing?.memberships.length ?? 0) > 0;
+
+    // 3. Handle a user who is starting a NEW programme this autumn.
+    //
+    //    Digital transformasjon is the reason this exists: it is a 2-year
+    //    continuation of a 3-year bachelor, so nearly everyone starting it
+    //    already has a TIHLDE account from their bachelor — and tihlde.org
+    //    keeps them in the OLD study group and the OLD cohort. Read literally,
+    //    that profile says "admitted in 2023", which the cohort rule below
+    //    correctly reads as "2. klasse or later" and therefore a fadder. They
+    //    are in fact in their 4th year of study but their 1st year on DT: a
+    //    fadderbarn, who should pay and be placed in a faddergruppe.
+    //
+    //    Nothing in the profile distinguishes DT year 1 from DT year 2, so the
+    //    user tells us, and we pin both facts the way the admin panel pins its
+    //    decisions — they must survive every later login, or the next one would
+    //    silently restore the bachelor and the exemption.
+    //
+    //    A declaration only ever moves someone onto the PAYING side, so it is
+    //    not worth abusing. It is still refused for anyone holding a FADDER
+    //    role in a faddergruppe: they demonstrably are a fadder, and a
+    //    mis-click should not hand them a payment prompt.
+    const declaredStudy =
+      parsed.data.study && !hasFadderMembership
+        ? studyLabelForSlug(parsed.data.study)
+        : null;
+
+    // 4. Decide whether this user owes anything at all. Only fadderbarn pay,
     //    and a fadder is by definition in 2. klasse or higher — so the study
     //    cohort we just read from TIHLDE settles it without anyone having to
     //    be assigned to a group first. That is what keeps a fadder from ever
     //    seeing a payment prompt, including on their very first login.
     const isFadder = deriveIsFadder({
-      fadderOverride: existing?.fadderOverride,
+      fadderOverride: declaredStudy ? false : existing?.fadderOverride,
       klasse: mapped.klasse,
-      hasFadderMembership: (existing?.memberships.length ?? 0) > 0,
+      hasFadderMembership,
     });
 
-    // Exempt users get access outright; everyone else keeps whatever
-    // verification they have earned by paying.
-    const isExempt = isFadder || adminGrant.isAdmin === true;
-    const accessGrant = isExempt ? { isVerified: true } : {};
+    // The programme we show and group by: a declaration wins, then any earlier
+    // declaration, and otherwise TIHLDE owns the field as before.
+    const studieretning =
+      declaredStudy ?? existing?.studieretningOverride ?? mapped.studieretning;
 
-    // 4. Upsert the local user, keyed by TIHLDE user_id. Payment flags for
+    // Exempt users get access outright; everyone else keeps whatever
+    // verification they have earned by paying. The one case where access is
+    // taken away is a user who was auto-exempted as a fadder and has now told
+    // us they are a fadderbarn — that access came from the exemption, so it
+    // leaves with it, unless real money has already changed hands.
+    const isExempt = isFadder || adminGrant.isAdmin === true;
+    const losesStaleExemption =
+      declaredStudy !== null &&
+      existing?.isFadder === true &&
+      existing.hasPaid !== true;
+
+    const accessGrant = isExempt
+      ? { isVerified: true }
+      : losesStaleExemption
+        ? { isVerified: false }
+        : {};
+
+    const studyGrant = declaredStudy
+      ? { studieretningOverride: declaredStudy, fadderOverride: false }
+      : {};
+
+    // 5. Upsert the local user, keyed by TIHLDE user_id. Payment flags for
     //    non-exempt users are owned by us (earned via Vipps) and left
     //    untouched. TIHLDE now authenticates this account, so the local
     //    registration password hash has served its purpose and is dropped.
     const user = await db.user.upsert({
       where: { tihldeUserId: mapped.tihldeUserId },
-      create: { ...mapped, ...adminGrant, ...accessGrant, isFadder },
+      create: {
+        ...mapped,
+        studieretning,
+        ...studyGrant,
+        ...adminGrant,
+        ...accessGrant,
+        isFadder,
+      },
       update: {
         name: mapped.name,
         email: mapped.email,
         image: mapped.image,
-        studieretning: mapped.studieretning,
+        studieretning,
         klasse: mapped.klasse,
         passwordHash: null,
         passwordIsTemporary: false,
         isFadder,
+        ...studyGrant,
         ...adminGrant,
         ...accessGrant,
       },
     });
 
-    // 5. Mint our own session and set the httpOnly cookie. Proving they know
+    // 6. Mint our own session and set the httpOnly cookie. Proving they know
     //    the password also clears whatever failures came before.
     await issueSession(user.id, token);
     await clearLoginFailures(parsed.data.user_id, ip);

--- a/src/app/logg-inn/page.tsx
+++ b/src/app/logg-inn/page.tsx
@@ -9,10 +9,16 @@ import { Card, CardDescription, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { authClient } from "~/lib/auth-client";
+import { REGISTRATION_STUDIES } from "~/lib/majors";
 
 function LoggInnSkjema() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  // Den som begynner på et nytt studium i høst må si fra selv: TIHLDE-profilen
+  // deres viser fortsatt bachelorlinja og bachelorkullet, så uten dette valget
+  // leses de som 2. klassing — altså fadder — og slipper å betale.
+  const [nyttStudium, setNyttStudium] = useState(false);
+  const [study, setStudy] = useState("");
   const router = useRouter();
   // Registreringssiden sender hit med brukernavnet når noen prøvde å
   // registrere seg på nytt — da slipper de å huske hva de valgte.
@@ -21,13 +27,23 @@ function LoggInnSkjema() {
   const handleLogin = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
+
+    if (nyttStudium && !study) {
+      setError("Velg hvilken linje du begynner på.");
+      return;
+    }
+
     setLoading(true);
 
     const formData = new FormData(e.currentTarget);
     const userId = (formData.get("user_id") as string)?.trim();
     const password = formData.get("password") as string;
 
-    const { error } = await authClient.signIn(userId, password);
+    const { error } = await authClient.signIn(
+      userId,
+      password,
+      nyttStudium ? study : undefined,
+    );
 
     if (error) {
       setError(error);
@@ -110,6 +126,59 @@ function LoggInnSkjema() {
                     placeholder="••••••••"
                     className="h-12"
                   />
+                </div>
+
+                <div className="grid gap-3 rounded-md border border-input px-4 py-3">
+                  <label className="flex cursor-pointer items-start gap-3 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={nyttStudium}
+                      onChange={(e) => {
+                        setNyttStudium(e.target.checked);
+                        setError(null);
+                      }}
+                      className="mt-0.5 h-4 w-4"
+                    />
+                    <span>
+                      <span className="font-medium">
+                        Jeg begynner på et nytt studium i høst
+                      </span>
+                      <span className="text-muted-foreground block">
+                        For eksempel Digital transformasjon etter fullført
+                        bachelor. TIHLDE-profilen din viser fortsatt den gamle
+                        linja, så uten dette blir du registrert som fadder i
+                        stedet for fadderbarn.
+                      </span>
+                    </span>
+                  </label>
+
+                  {nyttStudium && (
+                    <div
+                      className="grid gap-2"
+                      role="radiogroup"
+                      aria-label="Ny linje"
+                    >
+                      {REGISTRATION_STUDIES.map((option) => (
+                        <label
+                          key={option.slug}
+                          className="flex cursor-pointer items-center gap-3 rounded-md border border-input px-4 py-3 text-sm has-[:checked]:border-primary has-[:checked]:bg-primary/5"
+                        >
+                          <input
+                            type="radio"
+                            name="study"
+                            value={option.slug}
+                            checked={study === option.slug}
+                            onChange={(e) => {
+                              setStudy(e.target.value);
+                              setError(null);
+                            }}
+                            className="h-4 w-4"
+                          />
+                          {option.label}
+                        </label>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -42,12 +42,22 @@ async function readError(res: Response, fallback: string): Promise<string> {
 }
 
 export const authClient = {
-  /** Log in with a TIHLDE username + password. */
-  async signIn(userId: string, password: string): Promise<SignInResult> {
+  /**
+   * Log in with a TIHLDE username + password.
+   *
+   * `study` is the slug of a programme the user is STARTING this autumn, for
+   * the case where TIHLDE's profile still shows the one they came from (see
+   * /api/auth/login). Omitted for everyone else, which is almost everyone.
+   */
+  async signIn(
+    userId: string,
+    password: string,
+    study?: string,
+  ): Promise<SignInResult> {
     const res = await fetch("/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: userId, password }),
+      body: JSON.stringify({ user_id: userId, password, study }),
     });
 
     if (!res.ok) {

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import type { PaymentStatus, PrismaClient } from "@prisma/client";
 import { z } from "zod";
+import { MAJORS } from "~/lib/majors";
 import { deriveIsFadder } from "~/server/fadder";
 import {
   adminProcedure,
@@ -79,6 +80,7 @@ export const adminRouter = createTRPCRouter({
         email: true,
         klasse: true,
         studieretning: true,
+        studieretningOverride: true,
         isVerified: true,
         isAdmin: true,
         hasPaid: true,
@@ -191,6 +193,42 @@ export const adminRouter = createTRPCRouter({
       // Surfaced by the client so a fadder who paid before being marked is
       // never quietly left out of pocket.
       return { ...user, needsRefund: input.isFadder && user.hasPaid };
+    }),
+
+  /**
+   * Correct which programme a user is on.
+   *
+   * TIHLDE owns this field by default, and for almost everyone that is right.
+   * The exception is anyone whose profile has fallen behind reality — Digital
+   * transformasjon being the standing case, since its students keep the
+   * bachelor STUDY group they came from. Users can say so themselves at login,
+   * and this is the same decision from the admin side: for the ones who never
+   * did, and for undoing a mis-click.
+   *
+   * Passing `null` hands the field back to TIHLDE. The stored value is left
+   * alone rather than blanked, so the user stays grouped where they are until
+   * their next login refreshes it from the profile.
+   *
+   * Deliberately does NOT touch payment status. Being on DT does not by itself
+   * make someone a fadderbarn — a second-year DT student is a fadder — so that
+   * stays the separate, explicit decision `setUserFadder` makes.
+   */
+  setUserStudieretning: adminProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+        studieretning: z.enum(MAJORS).nullable(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.db.user.update({
+        where: { id: input.userId },
+        data: {
+          studieretningOverride: input.studieretning,
+          ...(input.studieretning ? { studieretning: input.studieretning } : {}),
+        },
+        select: { id: true, name: true, studieretning: true },
+      });
     }),
 
   /** List all faddergrupper with member counts */

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -39,6 +39,7 @@ export async function createUser(
     isVerified: boolean;
     hasPaid: boolean;
     studieretning: string | null;
+    studieretningOverride: string | null;
     klasse: string | null;
     passwordHash: string | null;
     passwordIsTemporary: boolean;
@@ -58,6 +59,7 @@ export async function createUser(
       isVerified: overrides.isVerified ?? false,
       hasPaid: overrides.hasPaid ?? false,
       studieretning: overrides.studieretning ?? null,
+      studieretningOverride: overrides.studieretningOverride ?? null,
       klasse: overrides.klasse ?? null,
       passwordHash: overrides.passwordHash ?? null,
       passwordIsTemporary: overrides.passwordIsTemporary ?? false,

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -34,6 +34,7 @@ const ADMIN_PROCEDURE_INPUTS: Record<string, unknown> = {
   setUserVerified: { userId: "x", isVerified: true },
   setUserAdmin: { userId: "x", isAdmin: true },
   setUserFadder: { userId: "x", isFadder: true },
+  setUserStudieretning: { userId: "x", studieretning: "Dataingeniør" },
   resetUserPassword: { userId: "x" },
   getGrupper: undefined,
   createGruppe: { name: "Gruppe" },
@@ -297,6 +298,60 @@ describe("fadder-fritak fra adminpanelet", () => {
     expect(
       (await db.user.findUniqueOrThrow({ where: { id: user.id } })).hasPaid,
     ).toBe(true);
+  });
+
+  it("lar admin sette studieretningen, og pinner valget", async () => {
+    const admin = await createAdmin();
+    const user = await createUser({
+      name: "Kari",
+      studieretning: "Dataingeniør",
+      isFadder: true,
+    });
+
+    await callerFor(admin).admin.setUserStudieretning({
+      userId: user.id,
+      studieretning: "Digital transformasjon",
+    });
+
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.studieretning).toBe("Digital transformasjon");
+    // Pinnet, ellers ville neste innlogging hentet bachelorlinja tilbake.
+    expect(after.studieretningOverride).toBe("Digital transformasjon");
+    // Studieretning og betalingsplikt er to avgjørelser: en DT-student på 2.
+    // året er fortsatt fadder.
+    expect(after.isFadder).toBe(true);
+  });
+
+  it("gir studieretningen tilbake til TIHLDE uten å tømme feltet", async () => {
+    const admin = await createAdmin();
+    const user = await createUser({
+      studieretning: "Digital transformasjon",
+      studieretningOverride: "Digital transformasjon",
+    });
+
+    await callerFor(admin).admin.setUserStudieretning({
+      userId: user.id,
+      studieretning: null,
+    });
+
+    const after = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.studieretningOverride).toBeNull();
+    // Verdien blir stående til neste innlogging henter profilen på nytt —
+    // ellers ville brukeren falt ut av gruppperingen sin med en gang.
+    expect(after.studieretning).toBe("Digital transformasjon");
+  });
+
+  it("avviser en studieretning som ikke finnes", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+
+    await expectCode(
+      callerFor(admin).admin.setUserStudieretning({
+        userId: user.id,
+        studieretning: "Kokkelinja" as never,
+      }),
+      "BAD_REQUEST",
+    );
   });
 
   it("lar en manuell avgjørelse overleve en senere rolleendring", async () => {

--- a/tests/integration/auth-login.route.test.ts
+++ b/tests/integration/auth-login.route.test.ts
@@ -5,7 +5,7 @@ import { SESSION_COOKIE } from "~/server/auth/config";
 import { hashPassword } from "~/server/auth/password";
 import { decryptToken } from "~/server/auth/token-crypto";
 
-import { createUser, db } from "../helpers/db";
+import { addMember, createGruppe, createUser, db } from "../helpers/db";
 import { fetchMock, json, text } from "../helpers/fetch-mock";
 import { lastSetCookie, resetNextHeaders } from "../helpers/next-headers";
 
@@ -156,6 +156,102 @@ describe("POST /api/auth/login", () => {
       (await db.user.findUniqueOrThrow({ where: { tihldeUserId: "olanor" } }))
         .isFadder,
     ).toBe(false);
+  });
+
+  // Digital transformasjon er et 2-årig påbygg: de som begynner har allerede
+  // en TIHLDE-bruker fra bacheloren, og profilen der viser fortsatt gammel
+  // linje og gammelt kull. Uten at de sier fra leses de som 2. klassing.
+  it("gjør en som begynner på nytt studium til fadderbarn, tross gammelt kull", async () => {
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2023" } } } });
+
+    await post({ ...CREDENTIALS, study: "digital-samhandling" });
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isFadder).toBe(false);
+    expect(user.fadderOverride).toBe(false);
+    expect(user.isVerified).toBe(false);
+    expect(user.studieretning).toBe("Digital transformasjon");
+    // Kullet fra TIHLDE lagres uendret — det er tolkningen vi overstyrer.
+    expect(user.klasse).toBe("2023");
+  });
+
+  it("lar det nye studiet overleve neste innlogging", async () => {
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2023" } } } });
+    await post({ ...CREDENTIALS, study: "digital-samhandling" });
+
+    // Neste innlogging sender ingen linje, og TIHLDE svarer fortsatt med
+    // bacheloren. Uten at valget er pinnet ville de blitt fadder igjen her.
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2023" } } } });
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.studieretning).toBe("Digital transformasjon");
+    expect(user.isFadder).toBe(false);
+  });
+
+  it("tar fritaket fra en som allerede var auto-fritatt som fadder", async () => {
+    await createUser({
+      tihldeUserId: "olanor",
+      email: null,
+      isFadder: true,
+      isVerified: true,
+    });
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2023" } } } });
+
+    await post({ ...CREDENTIALS, study: "digital-samhandling" });
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isFadder).toBe(false);
+    // Tilgangen kom fra fritaket, så den følger med når fritaket faller bort.
+    expect(user.isVerified).toBe(false);
+  });
+
+  it("beholder tilgangen til en som faktisk har betalt", async () => {
+    await createUser({
+      tihldeUserId: "olanor",
+      email: null,
+      isFadder: true,
+      isVerified: true,
+      hasPaid: true,
+    });
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2023" } } } });
+
+    await post({ ...CREDENTIALS, study: "digital-samhandling" });
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isFadder).toBe(false);
+    expect(user.isVerified).toBe(true);
+  });
+
+  it("lar ikke en med fadderverv melde seg som fadderbarn", async () => {
+    const user = await createUser({ tihldeUserId: "olanor", email: null });
+    await addMember(user.id, (await createGruppe()).id, "FADDER");
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2023" } } } });
+
+    await post({ ...CREDENTIALS, study: "digital-samhandling" });
+
+    const after = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(after.isFadder).toBe(true);
+    expect(after.studieretning).toBe("Dataingeniør");
+  });
+
+  it("avviser en ukjent linje i stedet for å logge inn", async () => {
+    stubTihldeLogin();
+
+    const response = await post({ ...CREDENTIALS, study: "finnes-ikke" });
+
+    expect(response.status).toBe(400);
+    expect(await db.user.count()).toBe(0);
   });
 
   it("gjør Index-medlemmer til admin", async () => {


### PR DESCRIPTION
## Problemet

Digital transformasjon er et 2-årig påbygg. Nesten alle som begynner har allerede en TIHLDE-bruker fra bacheloren sin, og tihlde.org beholder dem i den **gamle** studiegruppa og det **gamle** kullet.

Lest bokstavelig sier profilen deres «tatt opp i 2023», som kull-regelen i `src/server/fadder.ts` korrekt leser som 2. klasse eller mer — altså fadder. I realiteten er de på sitt 4. studieår, men sitt 1. år på DT: fadderbarn, som skal betale og plasseres i en faddergruppe.

Konsekvensen i dag: de blir stille fritatt for betaling ved innlogging (`isFadder = true` + auto-`isVerified`), og de dukker opp under bachelorlinja i adminpanelet — så de er heller ikke lette å finne igjen manuelt. Registrere seg som nye kan de ikke: Lepton avviser duplikat brukernavn og sender dem til innlogging.

Jeg bekreftet mot live-API-et at gruppa faktisk heter «Digital transformasjon» (slug-en er fortsatt det gamle `digital-samhandling`), og at TIHLDE **ikke har noen 2026-kullgruppe ennå** — bare 2017–2025. Ingen kan altså komme inn med riktig kull via profilen sin.

## Løsningen

Ingenting i profilen skiller DT 1. år fra DT 2. år, så informasjonen må komme et annet sted fra. To veier inn, samme avgjørelse:

**Brukeren sier fra selv ved innlogging.** Et avkryssingsfelt — «Jeg begynner på et nytt studium i høst» — folder ut linjevalget, med en forklaring på hvorfor det finnes.

**Admin kan rette det i adminpanelet.** Ny `Studie`-kolonne i tabellen over verifiserte, og samme nedtrekksmeny i kortene for uverifiserte, der DT-startere som ikke har betalt havner.

Begge skriver den nye kolonnen `User.studieretningOverride`, som følger samme kontrakt som `adminOverride` og `fadderOverride`: `null` utleder fra TIHLDE, en verdi pinnes og overlever hver innlogging. Uten pinning ville neste innlogging gjenopprettet bacheloren.

## Verdt å vite for review

- **Erklæringen avvises for den som har FADDER-verv** i en faddergruppe. De er beviselig faddere, og et feilklikk skal ikke gi dem en betalingsprompt.
- **Auto-fritatte mister tilgangen sin** når fritaket faller bort — men bare hvis de ikke faktisk har betalt. `hasPaid` røres aldri. Sjekken er bevisst smal (`existing.isFadder === true`), så en admin-gitt verifisering ikke trekkes tilbake.
- **Selverklæringen kan bare flytte folk til den betalende siden**, så det er ingenting å misbruke.
- **Studieretning og betalingsplikt er to avgjørelser.** Å sette DT gjør ikke noen til fadderbarn — en DT-student på 2. året er fadder — så det forblir `setUserFadder` sin jobb.
- **`null` i adminvalget tømmer ikke feltet**, bare overstyringen. Ellers ville brukeren forsvunnet ut av grupperingen sin i samme øyeblikk.

## Verifisering

`typecheck`, `lint` (0 errors) og `build` går grønt. **251 tester passerer, 10 nye** — 6 på login-ruten (gammelt kull + erklært DT gir fadderbarn, overstyringen overlever neste innlogging, fritaket trekkes tilbake, betalt tilgang beholdes, fadderverv blokkerer, ugyldig slug gir 400 uten å opprette bruker) og 4 på adminruteren.

Ikke verifisert visuelt: forhåndsvisningspanelet rendret ikke i sesjonen (viewport 0x0), og adminpanelet ligger uansett bak innlogging. Serversiden er dekket av testene; UI-en er lest gjennom, ikke klikk-testet.

## Før merge til prod

Prod (`main`) ligger **to migrasjoner bak** — `fadder_exemption` og `fadder_backfill` fra #97 er ikke kjørt ennå, og den siste gjør UPDATE på ekte brukerdata. Migrasjonen i denne PR-en er additiv og nullbar (`ADD COLUMN ... TEXT`), så den er trygg når som helst, men kjør dem i riktig rekkefølge og bruk Neons direkte endepunkt (ikke `-pooler`) til `prisma migrate deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)