### PR TITLE
fix(betaling): la ikke kullet omgjøre en som faktisk har betalt

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -192,6 +192,7 @@ export async function POST(request: Request) {
     const isFadder = deriveIsFadder({
       fadderOverride: declaredStudy ? false : existing?.fadderOverride,
       klasse: mapped.klasse,
+      hasPaid: existing?.hasPaid === true,
       hasFadderMembership,
     });
 

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -52,6 +52,7 @@ async function resyncFadderStatus(
     select: {
       fadderOverride: true,
       klasse: true,
+      hasPaid: true,
       memberships: { where: { role: "FADDER" }, select: { id: true } },
     },
   });
@@ -60,6 +61,7 @@ async function resyncFadderStatus(
   const isFadder = deriveIsFadder({
     fadderOverride: user.fadderOverride,
     klasse: user.klasse,
+    hasPaid: user.hasPaid,
     hasFadderMembership: user.memberships.length > 0,
   });
 

--- a/src/server/fadder.ts
+++ b/src/server/fadder.ts
@@ -8,11 +8,15 @@
  * user admitted before the current fadderuke cohort is therefore in 2. klasse
  * or higher and can never be a fadderbarn.
  *
- * Three signals feed the decision, in priority order:
+ * Four signals feed the decision, in priority order:
  *   1. `fadderOverride` — a manual admin decision, which always wins.
  *   2. A FADDER role in a faddergruppe — explicit, and covers the rare fadder
  *      whose cohort data is missing or wrong.
- *   3. The study cohort — the automatic path, which is what makes a fadder
+ *   3. A captured payment — proof, not a guess. `payment.initiatePayment`
+ *      refuses exempt users outright, so money having changed hands means this
+ *      user was on the paying side when it did. That outranks the cohort,
+ *      which is only ever an inference from an admission year.
+ *   4. The study cohort — the automatic path, which is what makes a fadder
  *      exempt from their very first login, before any admin has touched them.
  *
  * Deliberately fails towards "pays" when the cohort is unknown: a brand-new
@@ -105,18 +109,28 @@ export interface DeriveFadderInput {
   klasse?: string | null;
   /** Whether the user holds a FADDER role in any faddergruppe. */
   hasFadderMembership?: boolean;
+  /** Whether money has actually changed hands for this user. */
+  hasPaid?: boolean;
   cohortYear?: number;
 }
 
-/** Resolve the three signals into the single `isFadder` fact we persist. */
+/** Resolve the four signals into the single `isFadder` fact we persist. */
 export function deriveIsFadder({
   fadderOverride = null,
   klasse = null,
   hasFadderMembership = false,
+  hasPaid = false,
   cohortYear = currentCohortYear(),
 }: DeriveFadderInput): boolean {
   if (fadderOverride != null) return fadderOverride;
   if (hasFadderMembership) return true;
+  // Someone who paid was demonstrably a fadderbarn. Letting the cohort
+  // override that is how a paying student gets silently reclassified as
+  // exempt — and then looks, to an admin reading the payment overview, like a
+  // fadder owed a refund. This is the concrete case: a student starting a
+  // 2-year continuation like Digital transformasjon keeps their bachelor
+  // admission year, so the cohort insists they are in 2. klasse or later.
+  if (hasPaid) return false;
   return isSecondYearOrLater(klasse, cohortYear);
 }
 

--- a/tests/integration/auth-login.route.test.ts
+++ b/tests/integration/auth-login.route.test.ts
@@ -124,6 +124,28 @@ describe("POST /api/auth/login", () => {
     expect(user.isVerified).toBe(false);
   });
 
+  // De som begynte på Digital transformasjon rakk å betale før fadder-fritaket
+  // gikk live. Uten dette ville neste innlogging gjort dem om til faddere som
+  // "har betalt" — og noen kunne refundert dem i god tro.
+  it("gjør ikke om en som har betalt til fadder, uansett kull", async () => {
+    await createUser({
+      tihldeUserId: "olanor",
+      email: null,
+      hasPaid: true,
+      isVerified: true,
+    });
+    stubTihldeLogin({ profile: { studyyear: { group: { name: "2023" } } } });
+
+    await post(CREDENTIALS);
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "olanor" },
+    });
+    expect(user.isFadder).toBe(false);
+    expect(user.hasPaid).toBe(true);
+    expect(user.isVerified).toBe(true);
+  });
+
   it("lar en manuell fadder-fritakelse overleve innlogging", async () => {
     await createUser({
       tihldeUserId: "olanor",

--- a/tests/unit/fadder.test.ts
+++ b/tests/unit/fadder.test.ts
@@ -82,6 +82,28 @@ describe("deriveIsFadder", () => {
     ).toBe(true);
   });
 
+  // Den som begynner på et 2-årig påbygg som Digital transformasjon beholder
+  // opptaksåret fra bacheloren, så kullet insisterer på at hen er 2. klassing.
+  // Betalingen er bevis på det motsatte: fritatte får ikke betale i det hele
+  // tatt, så pengene kunne ikke ha gått gjennom om hen var fadder.
+  it("lar ikke kullet omgjøre en som faktisk har betalt", () => {
+    expect(
+      deriveIsFadder({ klasse: "2023", hasPaid: true, cohortYear: 2026 }),
+    ).toBe(false);
+  });
+
+  it("lar fadderverv veie tyngre enn en betaling gjort ved en feil", () => {
+    // Da skal admin få refusjonsvarselet, ikke en stille omklassifisering.
+    expect(
+      deriveIsFadder({
+        klasse: "2023",
+        hasPaid: true,
+        hasFadderMembership: true,
+        cohortYear: 2026,
+      }),
+    ).toBe(true);
+  });
+
   it("lar en manuell avgjørelse overstyre alt annet", () => {
     // En 2.-klassing som faktisk er fadderbarn skal kunne settes til å betale.
     expect(


### PR DESCRIPTION
Oppfølging til #98, funnet ved å se på prod-dataene etter at migrasjonene var kjørt.

## Problemet

De som begynner på Digital transformasjon i år rakk å betale fadderuke-avgiften før fadder-fritaket gikk live. De har `klasse = "2023"` på TIHLDE-profilen, fordi et 2-årig påbygg beholder opptaksåret fra bacheloren — så neste gang de logger inn ville kull-regelen gjort dem om til faddere.

**I prod gjelder det 7 personer med fanget betaling** (8 brukere har kull 2023; 7 av dem har betalt).

Verre enn feilklassifiseringen: de ville sett ut som *faddere som har betalt*, og det er akkurat signalet adminpanelet bruker for å foreslå refusjon. Noen i FadderKom kunne refundert dem i god tro.

## Løsningen

En fanget betaling er ikke en gjetning, den er bevis. `payment.initiatePayment` nekter fritatte å betale i det hele tatt, så at pengene har gått gjennom betyr at brukeren sto på den betalende siden da det skjedde. Det veier tyngre enn kullet, som bare er en slutning fra et opptaksår.

Ny rekkefølge i `deriveIsFadder`:

```
fadderOverride  →  FADDER-verv  →  hasPaid ⇒ ikke fadder  →  kull-regelen
```

Fadderverv veier fortsatt tyngre enn betalingen, så en fadder som betalte ved en feil gir refusjonsvarselet som før i stedet for en stille omklassifisering. Manuell overstyring vinner over alt, uendret.

Begge kallstedene er oppdatert: innloggingsruten og `resyncFadderStatus` i adminruteren.

## Verdt å vite

Dette løser de 7 automatisk ved neste innlogging, uten manuell opprydding. **Den åttende (`marilhof`, kull 2023, ikke betalt, ingen tilgang) dekkes ikke** — uten betaling finnes det ikke noe bevis å gå på, så hen treffer fortsatt kull-regelen og blir fritatt ved innlogging. Hen må enten huke av «Jeg begynner på et nytt studium i høst» selv, eller settes manuelt av admin.

## Verifisering

`typecheck`, `lint` (0 errors) og `build` grønt. **254 tester passerer, 3 nye**: at kullet ikke omgjør en som har betalt, at fadderverv fortsatt veier tyngre, og en integrasjonstest på innloggingsruten som kjører nøyaktig scenariet de 7 vil treffe.

En enkelt kjøring viste én feilende test underveis, som jeg ikke klarte å reprodusere — tre påfølgende fulle kjøringer er 254/254 grønne. Jeg vet ikke hvilken det var, så jeg kan ikke utelukke en flaky test i suiten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)