### PR TITLE
fix(auth): kort ned forklaringen på nytt studium ved innlogging

### DIFF
--- a/src/app/logg-inn/page.tsx
+++ b/src/app/logg-inn/page.tsx
@@ -145,9 +145,7 @@ function LoggInnSkjema() {
                       </span>
                       <span className="text-muted-foreground block">
                         For eksempel Digital transformasjon etter fullført
-                        bachelor. TIHLDE-profilen din viser fortsatt den gamle
-                        linja, så uten dette blir du registrert som fadder i
-                        stedet for fadderbarn.
+                        bachelor.
                       </span>
                     </span>
                   </label>


### PR DESCRIPTION
Fjerner denne setningen fra avkryssingsfeltet på `/logg-inn`:

> TIHLDE-profilen din viser fortsatt den gamle linja, så uten dette blir du registrert som fadder i stedet for fadderbarn.

Den forklarte vår interne mekanikk, ikke noe brukeren kan gjøre noe med. Eksempelet står igjen og er det som faktisk hjelper folk å kjenne seg igjen.

**Før:**
> Jeg begynner på et nytt studium i høst
> For eksempel Digital transformasjon etter fullført bachelor. TIHLDE-profilen din viser fortsatt den gamle linja, så uten dette blir du registrert som fadder i stedet for fadderbarn.

**Etter:**
> Jeg begynner på et nytt studium i høst
> For eksempel Digital transformasjon etter fullført bachelor.

Ren tekstendring — ingen logikk, ingen migrasjon.

## Verifisering

`typecheck`, `lint` (0 errors), `build` og 251 tester grønt. Bekreftet mot den kjørende dev-serveren at setningen er borte fra rendret HTML og at resten av feltet står som før.

Branchet fra `dev`, så denne er uavhengig av #100 som fortsatt er åpen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)