### PR TITLE
Fiks overflow i adminpanelet på mobil

### DIFF
--- a/src/app/(authenticated)/admin/aktiviteter-tab.tsx
+++ b/src/app/(authenticated)/admin/aktiviteter-tab.tsx
@@ -230,7 +230,7 @@ export function AktiviteterTab() {
               key={activity.id}
               className="flex flex-col !gap-3 rounded-xl border border-border bg-card !p-4 sm:flex-row sm:items-start sm:justify-between"
             >
-              <div className="flex !gap-4">
+              <div className="flex min-w-0 !gap-4">
                 {activity.imageUrl ? (
                   <img
                     src={activity.imageUrl}
@@ -244,8 +244,10 @@ export function AktiviteterTab() {
                     </span>
                   </div>
                 )}
-                <div className="!space-y-1">
-                  <p className="font-semibold text-foreground">{activity.title}</p>
+                <div className="min-w-0 !space-y-1">
+                  <p className="font-semibold break-words text-foreground">
+                    {activity.title}
+                  </p>
                   <p className="text-xs text-muted-foreground">
                     {new Date(activity.date).toLocaleDateString("no-NO", {
                       weekday: "short",
@@ -264,7 +266,7 @@ export function AktiviteterTab() {
                 </div>
               </div>
 
-              <div className="flex items-center !gap-2 sm:flex-shrink-0">
+              <div className="flex flex-wrap items-center !gap-2 sm:flex-shrink-0">
                 <button
                   type="button"
                   onClick={() => openEdit(activity)}

--- a/src/app/(authenticated)/admin/grupper-tab.tsx
+++ b/src/app/(authenticated)/admin/grupper-tab.tsx
@@ -119,7 +119,7 @@ export function GrupperTab() {
   return (
     <div className="!space-y-6">
       {/* Create new gruppe */}
-      <form onSubmit={handleCreateGruppe} className="flex !gap-3">
+      <form onSubmit={handleCreateGruppe} className="flex flex-wrap !gap-3">
         <input
           type="text"
           placeholder="Ny faddergruppe navn..."
@@ -168,13 +168,13 @@ export function GrupperTab() {
                     {/* Gruppe header */}
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between !px-5 !py-4 text-left transition hover:bg-muted/50"
+                      className="flex w-full items-center justify-between !gap-3 !px-5 !py-4 text-left transition hover:bg-muted/50"
                       onClick={() =>
                         setExpandedGruppe(isExpanded ? null : gruppe.id)
                       }
                     >
-                      <div className="flex items-center !gap-3">
-                        <h3 className="text-lg font-semibold text-foreground">
+                      <div className="flex min-w-0 flex-wrap items-center !gap-x-3">
+                        <h3 className="text-lg font-semibold break-words text-foreground">
                           {gruppe.name}
                         </h3>
                         <span className="text-sm text-muted-foreground">
@@ -182,9 +182,9 @@ export function GrupperTab() {
                         </span>
                       </div>
                       {isExpanded ? (
-                        <ChevronUp className="h-5 w-5 text-muted-foreground" />
+                        <ChevronUp className="h-5 w-5 shrink-0 text-muted-foreground" />
                       ) : (
-                        <ChevronDown className="h-5 w-5 text-muted-foreground" />
+                        <ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground" />
                       )}
                     </button>
 
@@ -200,17 +200,20 @@ export function GrupperTab() {
                               {faddere.map((member) => (
                                 <li
                                   key={member.id}
-                                  className="flex items-center justify-between rounded-lg !px-3 !py-2 hover:bg-muted/50"
+                                  className="flex items-center justify-between !gap-3 rounded-lg !px-3 !py-2 hover:bg-muted/50"
                                 >
-                                  <div>
+                                  {/* E-postene er lange nok til å skyve
+                                      knappene ut av kortet på mobil, så navn og
+                                      e-post legger seg under hverandre der. */}
+                                  <div className="flex min-w-0 flex-col sm:flex-row sm:items-baseline sm:!gap-2">
                                     <span className="text-sm text-foreground">
                                       {member.user.name}
                                     </span>
-                                    <span className="!ml-2 text-xs text-muted-foreground">
+                                    <span className="text-xs break-all text-muted-foreground">
                                       {member.user.email}
                                     </span>
                                   </div>
-                                  <div className="flex items-center !gap-2">
+                                  <div className="flex shrink-0 items-center !gap-2">
                                     <button
                                       type="button"
                                       onClick={() =>
@@ -257,17 +260,20 @@ export function GrupperTab() {
                               {fadderbarn.map((member) => (
                                 <li
                                   key={member.id}
-                                  className="flex items-center justify-between rounded-lg !px-3 !py-2 hover:bg-muted/50"
+                                  className="flex items-center justify-between !gap-3 rounded-lg !px-3 !py-2 hover:bg-muted/50"
                                 >
-                                  <div>
+                                  {/* E-postene er lange nok til å skyve
+                                      knappene ut av kortet på mobil, så navn og
+                                      e-post legger seg under hverandre der. */}
+                                  <div className="flex min-w-0 flex-col sm:flex-row sm:items-baseline sm:!gap-2">
                                     <span className="text-sm text-foreground">
                                       {member.user.name}
                                     </span>
-                                    <span className="!ml-2 text-xs text-muted-foreground">
+                                    <span className="text-xs break-all text-muted-foreground">
                                       {member.user.email}
                                     </span>
                                   </div>
-                                  <div className="flex items-center !gap-2">
+                                  <div className="flex shrink-0 items-center !gap-2">
                                     <button
                                       type="button"
                                       onClick={() =>

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -204,9 +204,13 @@ export function UsersTab() {
                 key={user.id}
                 className="flex flex-col !gap-3 rounded-xl border border-border bg-card !p-4 sm:flex-row sm:items-center sm:justify-between"
               >
-                <div>
-                  <p className="font-medium text-foreground">{user.name}</p>
-                  <p className="text-sm text-muted-foreground">{user.email}</p>
+                <div className="min-w-0">
+                  <p className="font-medium break-words text-foreground">
+                    {user.name}
+                  </p>
+                  <p className="text-sm break-all text-muted-foreground">
+                    {user.email}
+                  </p>
                   <div className="mt-1 flex flex-wrap !gap-1.5">
                     {user.klasse && (
                       <span className="rounded-full bg-primary/10 !px-2 !py-0.5 text-xs font-medium text-primary">
@@ -247,7 +251,7 @@ export function UsersTab() {
                     <p className="text-xs font-medium text-foreground">
                       Gi disse til brukeren – passordet vises kun nå:
                     </p>
-                    <code className="rounded-lg border border-border bg-background !px-3 !py-2 text-sm font-semibold text-foreground">
+                    <code className="rounded-lg border border-border bg-background !px-3 !py-2 text-sm font-semibold break-all text-foreground">
                       {tempPassword.tihldeUserId} / {tempPassword.password}
                     </code>
                     <p className="max-w-xs text-xs text-muted-foreground sm:text-right">
@@ -302,7 +306,7 @@ export function UsersTab() {
                     <p className="text-xs font-medium text-destructive">
                       Sikker på at du vil slette denne brukeren?
                     </p>
-                    <div className="flex !gap-2">
+                    <div className="flex flex-wrap !gap-2">
                       <button
                         type="button"
                         onClick={() => deleteMutation.mutate({ userId: user.id })}
@@ -321,7 +325,9 @@ export function UsersTab() {
                     </div>
                   </div>
                 ) : (
-                  <div className="flex !gap-2">
+                  /* Tre knapper får ikke plass på en mobilbredde, så de brekker
+                     til neste linje framfor å stikke ut av kortet. */
+                  <div className="flex flex-wrap !gap-2 sm:shrink-0">
                     <button
                       type="button"
                       onClick={() => setVerifyingUserId(user.id)}
@@ -577,7 +583,7 @@ export function UsersTab() {
                               <td className="!px-4 !py-3">
                                 {tempPassword?.userId === user.id ? (
                                   <div className="flex flex-col !gap-1">
-                                    <code className="rounded-lg border border-border bg-background !px-2 !py-1 text-xs font-semibold text-foreground">
+                                    <code className="rounded-lg border border-border bg-background !px-2 !py-1 text-xs font-semibold break-all text-foreground">
                                       {tempPassword.tihldeUserId} /{" "}
                                       {tempPassword.password}
                                     </code>

--- a/src/components/ui/slide-tabs.tsx
+++ b/src/components/ui/slide-tabs.tsx
@@ -38,12 +38,22 @@ export function SlideTabsBar<V extends string>({
 }: SlideTabsBarProps<V>) {
   // Unik per instans så flere linjer på samme side ikke deler pille.
   const layoutId = React.useId();
+  const activeTabRef = React.useRef<HTMLButtonElement>(null);
+
+  // Faner som ikke får plass scroller heller enn å bli klippet. Da må den
+  // valgte fanen dras inn i synet selv, ellers kan pilla havne utenfor kanten.
+  React.useEffect(() => {
+    activeTabRef.current?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [value]);
 
   return (
     <div
       className={cn(
-        "relative flex items-center rounded-xl border border-border bg-secondary !p-1",
-        stretch ? "w-full" : "w-fit max-w-full overflow-x-auto",
+        "no-scrollbar relative flex items-center overflow-x-auto rounded-xl border border-border bg-secondary !p-1",
+        stretch ? "w-full" : "w-fit max-w-full",
         className,
       )}
       role="tablist"
@@ -54,6 +64,7 @@ export function SlideTabsBar<V extends string>({
         return (
           <button
             key={t.value}
+            ref={active ? activeTabRef : undefined}
             type="button"
             role="tab"
             aria-selected={active}


### PR DESCRIPTION
Fanelinja i adminpanelet fikk ikke plass til fire faner på en
mobilbredde, og "Betalinger" ble klippet av kanten. Linja scroller nå
horisontalt (uten synlig scrollbar) i stedet for å bli klippet, og valgt
fane dras inn i synet slik at pilla aldri havner utenfor.

I kortene var det knapperadene og de lange e-postene som stakk ut:
knappene brekker nå til neste linje, tekstkolonnene har min-w-0 slik at
de faktisk kan krympe, og e-poster/engangspassord brytes framfor å
skyve innholdet ut.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X43KhzZ4KLYXWJsfm2uE5P