### PR TITLE
Bytt engangspassord mot selvbetjent glemt-passord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,18 @@ FADDERUKE_COHORT_YEAR="2026"
 # Without it the tokens are not stored at all, which disables allergy sync.
 SESSION_ENCRYPTION_KEY=""
 
+# E-post via Photon
+# Fadderuka sender ikke e-post selv — «glemt passord»-lenka går gjennom Photons
+# e-post-API, som sender fra no-reply@tihlde.org. Nøkkelen må være den samme
+# som EMAIL_API_KEY på Photon-serveren. Uten den er glemt-passord avslått.
+PHOTON_API_URL="https://photon.tihlde.org"
+PHOTON_EMAIL_API_KEY=""
+
+# Offentlig URL til denne appen, brukt til å bygge lenka i reset-e-posten.
+# Settes eksplisitt fordi Host-headeren kan forfalskes. Faller tilbake til
+# VIPPS_CALLBACK_URL når den er satt.
+APP_URL="http://localhost:3000"
+
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
 DATABASE_URL="postgresql://postgres:password@localhost:5432/fadderuke"

--- a/docs/auth-photon-oauth.md
+++ b/docs/auth-photon-oauth.md
@@ -24,10 +24,10 @@ seg fikse innenfor modellen:
    endepunktet er per definisjon en maskin som svarer på «er dette passordet
    riktig for denne TIHLDE-brukeren?».
 
-I tillegg har appen måttet bygge sitt eget engangspassord-system for studenter
-som venter på godkjenning på tihlde.org — `passwordHash`, `passwordIsTemporary`,
-`/velg-passord`, `admin.resetUserPassword`. Det er reell kompleksitet som finnes
-kun fordi innloggingen er koblet til Leptons godkjenningsløp.
+I tillegg har appen måttet bygge sin egen lokale passordbro for studenter som
+venter på godkjenning på tihlde.org — `passwordHash`, `/velg-passord`. Det er
+reell kompleksitet som finnes kun fordi innloggingen er koblet til Leptons
+godkjenningsløp. (Engangspassordene admin kunne utstede er fjernet.)
 
 ## Hva Photon allerede kan
 
@@ -56,7 +56,7 @@ Photon-siden for selve innloggingen.
 | `Session.tihldeToken` + kryptering | Vi får et scoped access token, ikke en kontonøkkel |
 | `src/server/auth/token-crypto.ts` | Har ikke lenger noe å beskytte |
 | Rate limiting på innlogging | Ikke lenger vår innlogging å beskytte |
-| Engangspassord-systemet | `passwordHash`, `passwordIsTemporary`, `/velg-passord`, `resetUserPassword` |
+| Den lokale passordbroen | `passwordHash`, `/velg-passord` |
 | `POST /users/` som registreringsvei | Kontoopprettelse skjer hos Photon/Feide |
 
 Grovt anslag: rundt 600 linjer produksjonskode og fire databasekolonner utgår.

--- a/prisma/migrations/20260805120000_drop_password_is_temporary/migration.sql
+++ b/prisma/migrations/20260805120000_drop_password_is_temporary/migration.sql
@@ -1,0 +1,4 @@
+-- Engangspassord-ordningen er fjernet: admin utsteder ikke lenger midlertidige
+-- passord, så flagget som ba brukeren bytte det ut har ingen lesere igjen.
+-- Brukere som allerede har et admin-utstedt passord beholder det som sitt eget.
+ALTER TABLE "User" DROP COLUMN "passwordIsTemporary";

--- a/prisma/migrations/20260805130000_password_reset_token/migration.sql
+++ b/prisma/migrations/20260805130000_password_reset_token/migration.sql
@@ -1,0 +1,19 @@
+-- Selvbetjent «glemt passord» for kontoer som logger inn med det lokale
+-- passordet. Kun hashen av lenkas token lagres; klarteksten finnes bare i
+-- e-posten som ble sendt.
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,9 +73,6 @@ model User {
     // awaits approval, so they can log back in before tihlde.org activates
     // them. Cleared on the first successful TIHLDE login.
     passwordHash  String?
-    // True when passwordHash is an admin-issued one-time password. The user is
-    // asked to replace it with one of their own on the next page load.
-    passwordIsTemporary Boolean @default(false)
     // Whether this user is a fadder — i.e. someone who never owes money for
     // fadderuka. Derived on every login from the study cohort and any FADDER
     // group membership (see `src/server/fadder.ts`), and persisted so every
@@ -92,6 +89,7 @@ model User {
     groupMessages GroupMessage[]
     notifications Notification[]
     payments      Payment[]
+    passwordResets PasswordResetToken[]
 }
 
 model FadderGruppe {
@@ -187,6 +185,24 @@ model Session {
     userAgent   String?
     userId      String
     user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model PasswordResetToken {
+    // A "glemt passord"-link, for accounts that log in with the local password
+    // chosen at registration (tihlde.org owns the password for everyone else).
+    //
+    // Only the SHA-256 of the token is stored: the plaintext lives in the email
+    // and nowhere else, so a leaked database does not hand over live reset
+    // links. Single-use (`usedAt`) and short-lived (`expiresAt`).
+    id        String    @id @default(cuid())
+    tokenHash String    @unique
+    userId    String
+    user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+    expiresAt DateTime
+    usedAt    DateTime?
+    createdAt DateTime  @default(now())
+
+    @@index([userId])
 }
 
 model LoginAttempt {

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, KeyRound, Shield, ShieldOff, Trash2, UserCheck } from "lucide-react";
+import { ChevronDown, Shield, ShieldOff, Trash2, UserCheck } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 import { api } from "~/trpc/react";
@@ -58,12 +58,6 @@ export function UsersTab() {
   const [verifyingUserId, setVerifyingUserId] = useState<string | null>(null);
   const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
   const [expandedMajor, setExpandedMajor] = useState<string | null>(null);
-  // Engangspassordet vises kun i denne økten – det kan ikke hentes fram igjen.
-  const [tempPassword, setTempPassword] = useState<{
-    userId: string;
-    tihldeUserId: string;
-    password: string;
-  } | null>(null);
   const utils = api.useUtils();
 
   const { data: users, isLoading } = api.admin.getUsers.useQuery();
@@ -83,15 +77,6 @@ export function UsersTab() {
       void utils.admin.getUsers.invalidate();
       setDeletingUserId(null);
       toast("Bruker slettet");
-    },
-    onError: (error) => {
-      toast.error("Feil", { description: error.message });
-    },
-  });
-
-  const resetPasswordMutation = api.admin.resetUserPassword.useMutation({
-    onSuccess: (data, variables) => {
-      setTempPassword({ userId: variables.userId, ...data });
     },
     onError: (error) => {
       toast.error("Feil", { description: error.message });
@@ -246,26 +231,7 @@ export function UsersTab() {
                   </p>
                 </div>
 
-                {tempPassword?.userId === user.id ? (
-                  <div className="flex flex-col !gap-2 sm:items-end">
-                    <p className="text-xs font-medium text-foreground">
-                      Gi disse til brukeren – passordet vises kun nå:
-                    </p>
-                    <code className="rounded-lg border border-border bg-background !px-3 !py-2 text-sm font-semibold break-all text-foreground">
-                      {tempPassword.tihldeUserId} / {tempPassword.password}
-                    </code>
-                    <p className="max-w-xs text-xs text-muted-foreground sm:text-right">
-                      Gjelder kun her, fram til kontoen godkjennes på tihlde.org.
-                    </p>
-                    <button
-                      type="button"
-                      onClick={() => setTempPassword(null)}
-                      className="rounded-lg !px-3 !py-1.5 text-xs text-muted-foreground transition hover:text-foreground"
-                    >
-                      Lukk
-                    </button>
-                  </div>
-                ) : verifyingUserId === user.id ? (
+                {verifyingUserId === user.id ? (
                   <div className="flex flex-col !gap-2 sm:items-end">
                     <p className="text-xs font-medium text-muted-foreground">
                       Velg faddergruppe:
@@ -335,18 +301,6 @@ export function UsersTab() {
                     >
                       <UserCheck className="h-4 w-4" />
                       Verifiser
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        resetPasswordMutation.mutate({ userId: user.id })
-                      }
-                      disabled={resetPasswordMutation.isPending}
-                      title="Lag et engangspassord for innlogging her, i påvente av godkjenning på tihlde.org"
-                      className="inline-flex items-center !gap-2 rounded-xl border border-border bg-secondary !px-4 !py-2 text-sm font-semibold text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
-                    >
-                      <KeyRound className="h-4 w-4" />
-                      Engangspassord
                     </button>
                     <button
                       type="button"
@@ -446,7 +400,6 @@ export function UsersTab() {
                           <th className="!px-4 !py-3 font-medium">Rolle</th>
                           <th className="!px-4 !py-3 font-medium">Betaling</th>
                           <th className="!px-4 !py-3 font-medium text-center">Admin</th>
-                          <th className="!px-4 !py-3 font-medium">Passord</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -575,50 +528,13 @@ export function UsersTab() {
                                   )}
                                 </button>
                               </td>
-                              {/* Betaling setter isVerified, så brukere som er
-                                  låst ute i påvente av godkjenning på
-                                  tihlde.org havner her og ikke i lista over
-                                  uverifiserte. Knappen må derfor finnes begge
-                                  steder. */}
-                              <td className="!px-4 !py-3">
-                                {tempPassword?.userId === user.id ? (
-                                  <div className="flex flex-col !gap-1">
-                                    <code className="rounded-lg border border-border bg-background !px-2 !py-1 text-xs font-semibold break-all text-foreground">
-                                      {tempPassword.tihldeUserId} /{" "}
-                                      {tempPassword.password}
-                                    </code>
-                                    <button
-                                      type="button"
-                                      onClick={() => setTempPassword(null)}
-                                      className="self-start text-xs text-muted-foreground transition hover:text-foreground"
-                                    >
-                                      Lukk
-                                    </button>
-                                  </div>
-                                ) : (
-                                  <button
-                                    type="button"
-                                    onClick={() =>
-                                      resetPasswordMutation.mutate({
-                                        userId: user.id,
-                                      })
-                                    }
-                                    disabled={resetPasswordMutation.isPending}
-                                    title="Lag et engangspassord for innlogging her, i påvente av godkjenning på tihlde.org"
-                                    className="inline-flex items-center !gap-1.5 rounded-lg border border-border bg-secondary !px-2.5 !py-1 text-xs font-medium text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
-                                  >
-                                    <KeyRound className="h-3.5 w-3.5" />
-                                    Engangspassord
-                                  </button>
-                                )}
-                              </td>
                             </tr>
                           );
                         })}
                         {usersInGroup.length === 0 && (
                           <tr>
                             <td
-                              colSpan={9}
+                              colSpan={8}
                               className="!px-4 !py-6 text-center text-muted-foreground"
                             >
                               Ingen brukere funnet

--- a/src/app/api/auth/glemt-passord/route.ts
+++ b/src/app/api/auth/glemt-passord/route.ts
@@ -1,0 +1,104 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  createResetToken,
+  sendResetEmail,
+} from "~/server/auth/password-reset";
+import { checkResetRateLimit, recordResetAttempt } from "~/server/auth/rate-limit";
+import { db } from "~/server/db";
+import { isEmailConfigured } from "~/server/email/photon";
+
+/**
+ * Ask for a password reset link.
+ *
+ * Only accounts that actually have a local password get one. For everyone else
+ * tihlde.org owns the password, and minting a local one from an email link
+ * would be a second door into an approved TIHLDE account — see
+ * `src/server/auth/password-reset.ts`.
+ *
+ * The answer is the same either way: whether an account exists, whether it has
+ * a local password, and whether the mail went out are all invisible from the
+ * outside. Otherwise this endpoint would answer "does this person have an
+ * account here?" for anyone who asks.
+ */
+
+const bodySchema = z.object({
+  user_id: z.string().min(1, "Fyll inn brukernavnet ditt."),
+});
+
+/** Same answer for every outcome. */
+const GENERIC_OK = {
+  ok: true,
+  message:
+    "Hvis brukernavnet finnes og kan tilbakestilles her, har vi sendt en e-post med lenke. Sjekk også søppelposten.",
+};
+
+async function clientIp(): Promise<string | null> {
+  const hdrs = await headers();
+  return hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
+}
+
+export async function POST(request: Request) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ugyldig forespørsel." },
+      { status: 400 },
+    );
+  }
+
+  // Without a mail key nothing can be sent, and claiming otherwise would leave
+  // people waiting for an email that never comes.
+  if (!isEmailConfigured()) {
+    return NextResponse.json(
+      {
+        error:
+          "Tilbakestilling av passord er ikke tilgjengelig akkurat nå. Ta kontakt med fadderkomiteen.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const userId = parsed.data.user_id.trim().toLowerCase();
+  const ip = await clientIp();
+
+  const limit = await checkResetRateLimit(userId, ip);
+  if (limit.blocked) {
+    return NextResponse.json(
+      {
+        error: `For mange forespørsler. Prøv igjen om ${limit.retryAfterMinutes} minutter.`,
+      },
+      { status: 429 },
+    );
+  }
+
+  const user = await db.user.findUnique({
+    where: { tihldeUserId: userId },
+    select: { id: true, email: true, passwordHash: true, tihldeUserId: true },
+  });
+
+  // No account, no local password, or no address to send to: answer as if it
+  // worked. `passwordHash` is null for everyone TIHLDE authenticates.
+  if (!user?.passwordHash || !user.email) {
+    return NextResponse.json(GENERIC_OK);
+  }
+
+  await recordResetAttempt(userId, ip);
+
+  try {
+    const token = await createResetToken(user.id);
+    await sendResetEmail({
+      to: user.email,
+      tihldeUserId: user.tihldeUserId,
+      token,
+    });
+  } catch (error) {
+    // Logged for us, invisible to the caller: a failing mail provider must not
+    // become a way to probe which usernames exist.
+    console.error("Klarte ikke sende reset-e-post:", error);
+  }
+
+  return NextResponse.json(GENERIC_OK);
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -243,7 +243,6 @@ export async function POST(request: Request) {
         studieretning,
         klasse: mapped.klasse,
         passwordHash: null,
-        passwordIsTemporary: false,
         isFadder,
         ...studyGrant,
         ...adminGrant,

--- a/src/app/api/auth/nytt-passord/route.ts
+++ b/src/app/api/auth/nytt-passord/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { consumableToken, consumeToken } from "~/server/auth/password-reset";
+import { hashPassword } from "~/server/auth/password";
+
+/**
+ * Spend a reset link: set the new password and burn the token.
+ *
+ * The token in the URL is the only thing proving who this is, which is why it
+ * is single-use, short-lived, and why every session on the account is dropped
+ * when it is spent.
+ */
+
+const bodySchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8, "Passordet må være minst 8 tegn."),
+});
+
+const INVALID = {
+  error:
+    "Lenka er ugyldig eller utløpt. Be om en ny på «Glemt passord»-sida.",
+};
+
+export async function POST(request: Request) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ugyldig forespørsel." },
+      { status: 400 },
+    );
+  }
+
+  const stored = await consumableToken(parsed.data.token);
+  if (!stored) return NextResponse.json(INVALID, { status: 400 });
+
+  const spent = await consumeToken(
+    stored.id,
+    stored.userId,
+    await hashPassword(parsed.data.password),
+  );
+  // Lost a race against another request using the same link.
+  if (!spent) return NextResponse.json(INVALID, { status: 400 });
+
+  return NextResponse.json({ ok: true, tihldeUserId: stored.user.tihldeUserId });
+}

--- a/src/app/api/auth/set-password/route.ts
+++ b/src/app/api/auth/set-password/route.ts
@@ -50,7 +50,6 @@ export async function POST(request: Request) {
     where: { id: session.user.id },
     data: {
       passwordHash: await hashPassword(parsed.data.password),
-      passwordIsTemporary: false,
     },
   });
 

--- a/src/app/glemt-passord/page.tsx
+++ b/src/app/glemt-passord/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Card, CardDescription, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+/**
+ * Ask for a reset link. Only useful for accounts with a local password — those
+ * whose TIHLDE account is still pending — so the copy points everyone else at
+ * tihlde.org rather than leaving them to guess why no mail arrives.
+ */
+export default function GlemtPassordPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+    const userId = (formData.get("user_id") as string)?.trim();
+
+    const res = await fetch("/api/auth/glemt-passord", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId }),
+    });
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+      message?: string;
+    } | null;
+
+    setLoading(false);
+    if (!res.ok) {
+      setError(body?.error ?? "Noe gikk galt. Prøv igjen.");
+      return;
+    }
+    setSent(body?.message ?? "Sjekk e-posten din.");
+  };
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 py-8">
+      <div className="w-full max-w-xl">
+        <Card>
+          <div className="flex flex-col gap-6 p-8 sm:p-12">
+            <div className="flex flex-col gap-2">
+              <CardTitle className="text-3xl font-bold">Glemt passord</CardTitle>
+              <CardDescription>
+                Skriv inn brukernavnet ditt, så sender vi en lenke til
+                e-postadressen som står på kontoen din.
+              </CardDescription>
+            </div>
+
+            {sent ? (
+              <>
+                <p className="rounded-lg border border-border bg-secondary px-4 py-3 text-sm">
+                  {sent}
+                </p>
+                <Link href="/logg-inn" className="text-sm underline">
+                  Tilbake til innlogging
+                </Link>
+              </>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="user_id">Brukernavn</Label>
+                  <Input
+                    id="user_id"
+                    name="user_id"
+                    type="text"
+                    autoComplete="username"
+                    placeholder="ditt TIHLDE-brukernavn"
+                    required
+                    className="h-12"
+                  />
+                </div>
+
+                {error && <p className="text-destructive text-sm">{error}</p>}
+
+                <Button type="submit" disabled={loading} className="h-12 w-full">
+                  {loading ? "Sender..." : "Send lenke"}
+                </Button>
+
+                <CardDescription>
+                  Er TIHLDE-brukeren din godkjent på tihlde.org, logger du inn
+                  med TIHLDE-passordet ditt — det tilbakestiller du på{" "}
+                  <a
+                    href="https://tihlde.org/glemt-passord"
+                    className="underline"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    tihlde.org
+                  </a>
+                  , ikke her.
+                </CardDescription>
+              </form>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/logg-inn/page.tsx
+++ b/src/app/logg-inn/page.tsx
@@ -96,9 +96,17 @@ function LoggInnSkjema() {
                   />
                 </div>
                 <div className="grid gap-2">
-                  <Label htmlFor="login-password">
-                    Passord <span className="text-destructive">*</span>
-                  </Label>
+                  <div className="flex items-baseline justify-between gap-2">
+                    <Label htmlFor="login-password">
+                      Passord <span className="text-destructive">*</span>
+                    </Label>
+                    <Link
+                      href="/glemt-passord"
+                      className="text-muted-foreground text-sm underline"
+                    >
+                      Glemt passord?
+                    </Link>
+                  </div>
                   <Input
                     id="login-password"
                     name="password"

--- a/src/app/nytt-passord/[token]/nytt-passord-form.tsx
+++ b/src/app/nytt-passord/[token]/nytt-passord-form.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+export function NyttPassordForm({ token }: { token: string }) {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    const formData = new FormData(e.currentTarget);
+    const password = formData.get("password") as string;
+    const repeat = formData.get("password_repeat") as string;
+
+    if (password !== repeat) {
+      setError("Passordene er ikke like.");
+      return;
+    }
+
+    setLoading(true);
+    const res = await fetch("/api/auth/nytt-passord", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, password }),
+    });
+
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      setError(body?.error ?? "Noe gikk galt. Prøv igjen.");
+      setLoading(false);
+      return;
+    }
+
+    // Setting the password logs every session out, so the way back in is the
+    // login page — with the new password.
+    const body = (await res.json().catch(() => null)) as {
+      tihldeUserId?: string;
+    } | null;
+    const query = body?.tihldeUserId
+      ? `?user_id=${encodeURIComponent(body.tihldeUserId)}`
+      : "";
+    router.push(`/logg-inn${query}`);
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="password">Nytt passord</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="minst 8 tegn"
+          required
+          minLength={8}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="password_repeat">Gjenta passordet</Label>
+        <Input
+          id="password_repeat"
+          name="password_repeat"
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={8}
+        />
+      </div>
+
+      {error && <p className="text-destructive text-sm">{error}</p>}
+
+      <Button type="submit" disabled={loading} className="h-12 w-full">
+        {loading ? "Lagrer..." : "Lagre passord"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/nytt-passord/[token]/page.tsx
+++ b/src/app/nytt-passord/[token]/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { Card, CardDescription, CardTitle } from "~/components/ui/card";
+import { consumableToken } from "~/server/auth/password-reset";
+
+import { NyttPassordForm } from "./nytt-passord-form";
+
+/**
+ * The page a reset link lands on. The token is checked here so a dead link says
+ * so immediately instead of after the user has typed a password twice — it is
+ * checked again on submit, since anything can happen in between.
+ */
+export default async function NyttPassordPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const stored = await consumableToken(token);
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 py-8">
+      <div className="w-full max-w-xl">
+        <Card>
+          <div className="flex flex-col gap-6 p-8 sm:p-12">
+            {stored ? (
+              <>
+                <div className="flex flex-col gap-2">
+                  <CardTitle className="text-3xl font-bold">
+                    Velg nytt passord
+                  </CardTitle>
+                  <CardDescription>
+                    Du setter nytt passord for{" "}
+                    <span className="text-foreground font-semibold">
+                      {stored.user.tihldeUserId}
+                    </span>
+                    . Passordet gjelder bare denne siden — passordet ditt på
+                    tihlde.org endres ikke.
+                  </CardDescription>
+                </div>
+                <NyttPassordForm token={token} />
+              </>
+            ) : (
+              <>
+                <div className="flex flex-col gap-2">
+                  <CardTitle className="text-3xl font-bold">
+                    Lenka virker ikke
+                  </CardTitle>
+                  <CardDescription>
+                    Lenker varer i én time og kan bare brukes én gang. Denne er
+                    enten brukt opp, utløpt eller erstattet av en nyere.
+                  </CardDescription>
+                </div>
+                <Link href="/glemt-passord" className="text-sm underline">
+                  Be om en ny lenke
+                </Link>
+              </>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/velg-passord/page.tsx
+++ b/src/app/velg-passord/page.tsx
@@ -19,10 +19,6 @@ export default async function VelgPassordPage() {
   // Nothing to do for anyone else — don't strand them on a dead-end page.
   if (!needsLocalPassword(session)) redirect("/");
 
-  // Two ways to land here, and the wording has to match: either an admin just
-  // handed them a one-time password, or they have none at all.
-  const hasTempPassword = session.user.passwordIsTemporary;
-
   return (
     <div className="flex flex-1 items-center justify-center px-4 py-8">
         <div className="w-full max-w-xl">
@@ -30,17 +26,13 @@ export default async function VelgPassordPage() {
             <div className="flex flex-col gap-6 p-8 sm:p-12">
               <div className="flex flex-col gap-2">
                 <CardTitle className="text-3xl font-bold">
-                  {hasTempPassword ? "Velg ditt eget passord" : "Velg et passord"}
+                  Velg et passord
                 </CardTitle>
                 <CardDescription>
-                  {hasTempPassword
-                    ? `Du logget inn med et engangspassord du fikk av
-                       fadderkomiteen. Velg nå et passord du selv husker — det
-                       erstatter engangspassordet.`
-                    : `Brukeren din på tihlde.org venter fortsatt på godkjenning,
-                       og fram til den er godkjent kan du ikke logge inn her med
-                       TIHLDE-passordet ditt. Velg et passord du bruker her, så
-                       kommer du inn igjen neste gang.`}
+                  Brukeren din på tihlde.org venter fortsatt på godkjenning, og
+                  fram til den er godkjent kan du ikke logge inn her med
+                  TIHLDE-passordet ditt. Velg et passord du bruker her, så
+                  kommer du inn igjen neste gang.
                 </CardDescription>
                 <CardDescription>
                   Du logger inn med brukernavnet ditt,{" "}

--- a/src/env.js
+++ b/src/env.js
@@ -40,6 +40,25 @@ export const env = createEnv({
       .string()
       .regex(/^[0-9a-fA-F]{64}$/, "SESSION_ENCRYPTION_KEY må være 64 hex-tegn")
       .optional(),
+    /**
+     * Photon's API, which sends our email for us (`POST /api/email/send`).
+     * Fadderuka has no mail setup of its own — see `src/server/email/photon.ts`.
+     */
+    PHOTON_API_URL: z.string().url().default("https://photon.tihlde.org"),
+    /**
+     * Shared secret for that endpoint, matching `EMAIL_API_KEY` on the Photon
+     * server. Unset, no mail is sent and "glemt passord" answers that the
+     * feature is unavailable rather than pretending a mail went out.
+     */
+    PHOTON_EMAIL_API_KEY: z.string().optional(),
+    /**
+     * Public origin of this app, used to build the password reset link. Set
+     * explicitly rather than read off the request's Host header, which an
+     * attacker controls — that is how reset links get poisoned. Falls back to
+     * `VIPPS_CALLBACK_URL`, which is already the public URL in every
+     * environment that has it.
+     */
+    APP_URL: z.string().url().optional(),
   },
 
   client: {},
@@ -57,6 +76,9 @@ export const env = createEnv({
     VIPPS_WEBHOOK_SECRET: process.env.VIPPS_WEBHOOK_SECRET,
     FADDERUKE_COHORT_YEAR: process.env.FADDERUKE_COHORT_YEAR,
     SESSION_ENCRYPTION_KEY: process.env.SESSION_ENCRYPTION_KEY,
+    PHOTON_API_URL: process.env.PHOTON_API_URL,
+    PHOTON_EMAIL_API_KEY: process.env.PHOTON_EMAIL_API_KEY,
+    APP_URL: process.env.APP_URL,
   },
 
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -7,7 +7,6 @@ import {
   adminProcedure,
   createTRPCRouter,
 } from "~/server/api/trpc";
-import { generateTempPassword, hashPassword } from "~/server/auth/password";
 import {
   PAYMENT_AMOUNT_ORE,
   VippsError,
@@ -109,31 +108,6 @@ export const adminRouter = createTRPCRouter({
         where: { id: input.userId },
         data: { isVerified: input.isVerified },
       });
-    }),
-
-  /**
-   * Issue a one-time local password for a user whose TIHLDE account is still
-   * pending approval, so they can log in here in the meantime. Needed for
-   * everyone who registered before we started storing a local hash — their
-   * password only ever went to TIHLDE, so it cannot be recovered.
-   *
-   * The plaintext is returned once, for the admin to pass on; only the hash is
-   * stored, and a successful TIHLDE login clears it again.
-   */
-  resetUserPassword: adminProcedure
-    .input(z.object({ userId: z.string() }))
-    .mutation(async ({ ctx, input }) => {
-      const password = generateTempPassword();
-      const user = await ctx.db.user.update({
-        where: { id: input.userId },
-        data: {
-          passwordHash: await hashPassword(password),
-          // Brukeren blir bedt om å bytte det ut ved neste sidelast.
-          passwordIsTemporary: true,
-        },
-        select: { tihldeUserId: true },
-      });
-      return { tihldeUserId: user.tihldeUserId, password };
     }),
 
   /**

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -140,13 +140,10 @@ export async function deleteSession(token: string) {
 /**
  * True when the signed-in user should choose a local password for this app.
  *
- * Two cases, both limited to accounts TIHLDE does not authenticate yet (no
- * token on the session, because tihlde.org has not approved them):
- *
- *  - No password at all: they registered here before we stored a hash, so
- *    nothing would let them back in once this session expires.
- *  - An admin-issued one-time password: it got them in, but it is a random
- *    string nobody wants to keep, so they are asked to replace it.
+ * Limited to accounts TIHLDE does not authenticate yet (no token on the
+ * session, because tihlde.org has not approved them) and that have no password
+ * hash: they registered here before we stored one, so nothing would let them
+ * back in once this session expires.
  *
  * Derived rather than a hardcoded list of usernames, so it stays correct as
  * accounts get approved and as new ones appear.
@@ -155,7 +152,7 @@ export function needsLocalPassword(
   session: NonNullable<Awaited<ReturnType<typeof getSession>>>,
 ): boolean {
   if (session.session.tihldeToken) return false;
-  return !session.user.passwordHash || session.user.passwordIsTemporary;
+  return !session.user.passwordHash;
 }
 
 /**

--- a/src/server/auth/password-reset.ts
+++ b/src/server/auth/password-reset.ts
@@ -1,0 +1,146 @@
+import "server-only";
+
+import { createHash, randomBytes } from "node:crypto";
+
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { sendEmail } from "~/server/email/photon";
+
+/**
+ * Self-service password reset for the local login bridge.
+ *
+ * Who this is for: students who registered here while their TIHLDE account
+ * waits for approval on tihlde.org. They log in with a password they chose
+ * during registration, we hold the only hash of it, and until now a forgotten
+ * one meant an admin had to hand out a replacement by hand.
+ *
+ * Who it is deliberately NOT for: accounts TIHLDE authenticates. Their
+ * `passwordHash` is null — tihlde.org owns their password, and letting an
+ * email link mint a local one would build a second way into an approved
+ * account that bypasses TIHLDE entirely.
+ */
+
+/** How long a link works. Long enough to find the mail, short enough to matter. */
+const TOKEN_TTL_MS = 60 * 60 * 1000;
+
+/** Bytes of entropy in the token. 32 is far beyond guessable. */
+const TOKEN_BYTES = 32;
+
+/**
+ * Only the hash is stored, so a database leak yields no working links. SHA-256
+ * without a salt is right here (unlike for passwords): the input is 256 bits of
+ * randomness, so there is nothing to brute-force or rainbow-table.
+ */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+/** The public origin, for building the link. See `APP_URL` in `src/env.js`. */
+function appUrl(): string {
+  const url = env.APP_URL ?? env.VIPPS_CALLBACK_URL ?? "http://localhost:3000";
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Create a reset token for `userId`, invalidating any earlier unused ones so a
+ * second request cannot leave two live links behind. Returns the plaintext,
+ * which exists only in the returned value and the email built from it.
+ */
+export async function createResetToken(userId: string): Promise<string> {
+  const token = randomBytes(TOKEN_BYTES).toString("base64url");
+
+  await db.$transaction([
+    db.passwordResetToken.deleteMany({ where: { userId, usedAt: null } }),
+    db.passwordResetToken.create({
+      data: {
+        tokenHash: hashToken(token),
+        userId,
+        expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
+      },
+    }),
+  ]);
+
+  return token;
+}
+
+/**
+ * Look up a token and return the user it belongs to, or null when it is
+ * unknown, already used or expired. The lookup is by hash, so the plaintext is
+ * never compared against anything stored.
+ */
+export async function consumableToken(token: string) {
+  if (!token) return null;
+
+  const stored = await db.passwordResetToken.findUnique({
+    where: { tokenHash: hashToken(token) },
+    include: { user: { select: { id: true, tihldeUserId: true } } },
+  });
+
+  if (!stored) return null;
+  if (stored.usedAt) return null;
+  if (stored.expiresAt.getTime() <= Date.now()) return null;
+
+  return stored;
+}
+
+/**
+ * Spend a token: set the new password hash, mark the token used, and drop every
+ * session the account has. Logging the sessions out matters — whoever asked for
+ * the reset may be locking out someone who is signed in on their account right
+ * now, and that is the whole point of a password reset.
+ *
+ * Guarded on `usedAt: null` inside the transaction so two requests racing on
+ * the same link cannot both succeed.
+ */
+export async function consumeToken(
+  tokenId: string,
+  userId: string,
+  passwordHash: string,
+): Promise<boolean> {
+  return db.$transaction(async (tx) => {
+    // Claim the token first. Losing this race has to mean writing nothing at
+    // all — a batched transaction would have set the password anyway and then
+    // reported failure.
+    const marked = await tx.passwordResetToken.updateMany({
+      where: { id: tokenId, usedAt: null },
+      data: { usedAt: new Date() },
+    });
+    if (marked.count !== 1) return false;
+
+    await tx.user.update({ where: { id: userId }, data: { passwordHash } });
+    await tx.session.deleteMany({ where: { userId } });
+    return true;
+  });
+}
+
+/** Build and send the reset mail through Photon. */
+export async function sendResetEmail(input: {
+  to: string;
+  tihldeUserId: string;
+  token: string;
+}): Promise<void> {
+  const link = `${appUrl()}/nytt-passord/${input.token}`;
+
+  await sendEmail({
+    to: input.to,
+    subject: "Tilbakestill passordet ditt på Fadderuka",
+    content: [
+      { type: "title", content: "Glemt passord" },
+      {
+        type: "text",
+        content: `Noen har bedt om å tilbakestille passordet for «${input.tihldeUserId}» på Fadderuka-sida. Trykk på knappen for å velge et nytt passord.`,
+      },
+      { type: "button", text: "Velg nytt passord", url: link },
+      {
+        type: "text",
+        content:
+          "Lenka virker i én time og kan bare brukes én gang. Har du ikke bedt om dette, kan du se bort fra e-posten — passordet ditt er uendret.",
+      },
+      {
+        type: "text",
+        content:
+          "Passordet gjelder kun Fadderuka-sida. Passordet ditt på tihlde.org endres ikke.",
+      },
+    ],
+  });
+}

--- a/src/server/auth/password.ts
+++ b/src/server/auth/password.ts
@@ -25,32 +25,6 @@ function derive(password: string, salt: Buffer): Promise<Buffer> {
   });
 }
 
-/**
- * Alphabet without the characters that get misread when a password is passed on
- * verbally or on paper (0/O, 1/l/I).
- */
-const TEMP_ALPHABET = "abcdefghijkmnpqrstuvwxyz23456789";
-const TEMP_LENGTH = 12;
-
-/**
- * A single-use password an admin hands to a student whose TIHLDE account is
- * still pending. Rejection sampling keeps the distribution uniform (256 is not
- * a multiple of the alphabet length, so plain modulo would bias the first
- * characters).
- */
-export function generateTempPassword(): string {
-  const limit = 256 - (256 % TEMP_ALPHABET.length);
-  let out = "";
-  while (out.length < TEMP_LENGTH) {
-    for (const byte of randomBytes(TEMP_LENGTH)) {
-      if (byte >= limit) continue;
-      out += TEMP_ALPHABET[byte % TEMP_ALPHABET.length];
-      if (out.length === TEMP_LENGTH) break;
-    }
-  }
-  return out;
-}
-
 /** Hash a plaintext password into a self-describing `scrypt:salt:hash` string. */
 export async function hashPassword(password: string): Promise<string> {
   const salt = randomBytes(16);

--- a/src/server/auth/rate-limit.ts
+++ b/src/server/auth/rate-limit.ts
@@ -132,6 +132,74 @@ export async function checkRegisterRateLimit(
   };
 }
 
+/**
+ * Password reset throttling.
+ *
+ * Every request sends an email to an address we did not choose, so an
+ * unthrottled endpoint is a way to mailbomb a student through TIHLDE's mail
+ * relay — and a way to burn Photon's sending quota. Successes are what need
+ * bounding here, same as registration, so every accepted request is counted.
+ *
+ * Counted per username as well as per IP: the per-IP cap alone would let a
+ * distributed caller keep hitting the same inbox.
+ */
+const RESET_WINDOW_MS = 60 * 60 * 1000;
+
+/** Reset mails one account may trigger per hour. */
+const MAX_RESETS_PER_USER = 5;
+/** Reset mails one IP may trigger per hour, across accounts. */
+const MAX_RESETS_PER_IP = 15;
+
+const resetUserKey = (userId: string) =>
+  `reset-user:${userId.trim().toLowerCase()}`;
+const resetIpKey = (ip: string) => `reset-ip:${ip}`;
+
+/** Whether this username/IP has used up its reset budget. */
+export async function checkResetRateLimit(
+  userId: string,
+  ip: string | null,
+): Promise<RateLimitVerdict> {
+  const since = new Date(Date.now() - RESET_WINDOW_MS);
+  const keys = ip ? [resetUserKey(userId), resetIpKey(ip)] : [resetUserKey(userId)];
+
+  const attempts = await db.loginAttempt.findMany({
+    where: { key: { in: keys }, createdAt: { gte: since } },
+    select: { key: true, createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const forUser = attempts.filter((a) => a.key === keys[0]);
+  const forIp = ip ? attempts.filter((a) => a.key === resetIpKey(ip)) : [];
+
+  const overUser = forUser.length >= MAX_RESETS_PER_USER;
+  const overIp = forIp.length >= MAX_RESETS_PER_IP;
+  if (!overUser && !overIp) return { blocked: false, retryAfterMinutes: 0 };
+
+  const oldest = (overUser ? forUser : forIp)[0]!.createdAt;
+  const msLeft = oldest.getTime() + RESET_WINDOW_MS - Date.now();
+  return {
+    blocked: true,
+    retryAfterMinutes: Math.max(1, Math.ceil(msLeft / 60_000)),
+  };
+}
+
+/** Record a sent reset mail and drop rows that have aged out. */
+export async function recordResetAttempt(
+  userId: string,
+  ip: string | null,
+): Promise<void> {
+  const rows = [{ key: resetUserKey(userId) }];
+  if (ip) rows.push({ key: resetIpKey(ip) });
+
+  await db.loginAttempt.createMany({ data: rows });
+  await db.loginAttempt.deleteMany({
+    where: {
+      key: { startsWith: "reset-" },
+      createdAt: { lt: new Date(Date.now() - RESET_WINDOW_MS) },
+    },
+  });
+}
+
 /** Record a registration attempt and drop rows that have aged out. */
 export async function recordRegisterAttempt(ip: string | null): Promise<void> {
   if (!ip) return;

--- a/src/server/email/photon.ts
+++ b/src/server/email/photon.ts
@@ -1,0 +1,81 @@
+import "server-only";
+
+import { env } from "~/env";
+
+/**
+ * Outgoing email, sent through Photon's email API.
+ *
+ * Fadderuka has no mail infrastructure of its own, and getting some would mean
+ * a new provider account plus DKIM/SPF records on tihlde.org — DNS we do not
+ * control. Photon already sends from `no-reply@tihlde.org` over TIHLDE's own
+ * SMTP relay, and exposes `POST /api/email/send` for exactly this: an external
+ * service handing it a subject and a few content blocks.
+ *
+ * Auth is a shared secret (`PHOTON_EMAIL_API_KEY`), not a user token, so this
+ * must only ever be called from the server.
+ */
+
+/** The block types Photon's `CustomEmail` template renders. */
+export type EmailBlock =
+  | { type: "title"; content: string }
+  | { type: "text"; content: string }
+  | { type: "button"; text: string; url: string };
+
+export class EmailNotConfiguredError extends Error {
+  constructor() {
+    super("PHOTON_EMAIL_API_KEY er ikke satt — e-post kan ikke sendes.");
+    this.name = "EmailNotConfiguredError";
+  }
+}
+
+export class EmailSendError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EmailSendError";
+  }
+}
+
+/** Whether email is switched on at all. Lets callers degrade instead of throw. */
+export function isEmailConfigured(): boolean {
+  return Boolean(env.PHOTON_EMAIL_API_KEY);
+}
+
+/**
+ * Send one email. Throws `EmailNotConfiguredError` when the key is missing and
+ * `EmailSendError` when Photon rejects it, so the caller decides what the user
+ * gets told — for password resets that is deliberately nothing specific.
+ */
+export async function sendEmail(input: {
+  to: string;
+  subject: string;
+  content: EmailBlock[];
+}): Promise<void> {
+  const apiKey = env.PHOTON_EMAIL_API_KEY;
+  if (!apiKey) throw new EmailNotConfiguredError();
+
+  let response: Response;
+  try {
+    response = await fetch(`${env.PHOTON_API_URL}/api/email/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(input),
+      // Photon queues the mail and answers immediately; if it cannot, we would
+      // rather fail than hold the request open.
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (cause) {
+    throw new EmailSendError(
+      `Fikk ikke kontakt med Photon: ${cause instanceof Error ? cause.message : "ukjent feil"}`,
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new EmailSendError(
+      `Photon svarte ${response.status} på e-postsending. ${body.slice(0, 200)}`,
+    );
+  }
+}

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -84,4 +84,10 @@ process.env.FADDERUKE_COHORT_YEAR = "2026";
 // session tests would be checking a code path no deployment runs.
 process.env.SESSION_ENCRYPTION_KEY = "0".repeat(64);
 
+// Photon's email API, which "glemt passord" sends through. The host is fake and
+// `fetch` is stubbed — the key only has to be set for the feature to be on.
+process.env.PHOTON_API_URL = "https://photon.test";
+process.env.PHOTON_EMAIL_API_KEY = "test-email-api-key";
+process.env.APP_URL = "https://fadderuka.test";
+
 export const TEST_DATABASE_URL = databaseUrl;

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -7,6 +7,7 @@ import { db } from "~/server/db";
  */
 const TABLES = [
   "LoginAttempt",
+  "PasswordResetToken",
   "Payment",
   "Notification",
   "GroupMessage",
@@ -42,7 +43,6 @@ export async function createUser(
     studieretningOverride: string | null;
     klasse: string | null;
     passwordHash: string | null;
-    passwordIsTemporary: boolean;
     isFadder: boolean;
     fadderOverride: boolean | null;
     createdAt: Date;
@@ -62,7 +62,6 @@ export async function createUser(
       studieretningOverride: overrides.studieretningOverride ?? null,
       klasse: overrides.klasse ?? null,
       passwordHash: overrides.passwordHash ?? null,
-      passwordIsTemporary: overrides.passwordIsTemporary ?? false,
       isFadder: overrides.isFadder ?? false,
       fadderOverride: overrides.fadderOverride ?? null,
       ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -2,7 +2,6 @@ import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 
 import { appRouter } from "~/server/api/root";
-import { verifyPassword } from "~/server/auth/password";
 import { PAYMENT_AMOUNT_ORE } from "~/server/payment/vipps";
 
 import { anonCaller, callerFor } from "../helpers/caller";
@@ -35,7 +34,6 @@ const ADMIN_PROCEDURE_INPUTS: Record<string, unknown> = {
   setUserAdmin: { userId: "x", isAdmin: true },
   setUserFadder: { userId: "x", isFadder: true },
   setUserStudieretning: { userId: "x", studieretning: "Dataingeniør" },
-  resetUserPassword: { userId: "x" },
   getGrupper: undefined,
   createGruppe: { name: "Gruppe" },
   updateGruppe: { gruppeId: "x", name: "Gruppe" },
@@ -97,43 +95,6 @@ describe("admin: brukere og grupper", () => {
     expect(
       (await db.user.findUniqueOrThrow({ where: { id: user.id } })).isVerified,
     ).toBe(true);
-  });
-
-  it("lager et engangspassord brukeren kan logge inn med", async () => {
-    const admin = await createAdmin();
-    const user = await createUser({ tihldeUserId: "olanor" });
-
-    const result = await callerFor(admin).admin.resetUserPassword({
-      userId: user.id,
-    });
-
-    expect(result.tihldeUserId).toBe("olanor");
-    expect(result.password).toHaveLength(12);
-
-    // Kun hashen lagres, og den skal matche passordet admin fikk utlevert.
-    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
-    expect(stored.passwordHash).not.toContain(result.password);
-    await expect(verifyPassword(result.password, stored.passwordHash)).resolves.toBe(
-      true,
-    );
-    // Merket som midlertidig, så brukeren blir bedt om å velge sitt eget.
-    expect(stored.passwordIsTemporary).toBe(true);
-  });
-
-  it("lager et nytt engangspassord hver gang", async () => {
-    const admin = await createAdmin();
-    const user = await createUser();
-    const caller = callerFor(admin);
-
-    const first = await caller.admin.resetUserPassword({ userId: user.id });
-    const second = await caller.admin.resetUserPassword({ userId: user.id });
-
-    expect(second.password).not.toBe(first.password);
-    // Det forrige passordet skal ikke lenger gjelde.
-    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
-    await expect(verifyPassword(first.password, stored.passwordHash)).resolves.toBe(
-      false,
-    );
   });
 
   it("nekter å slette verifiserte brukere", async () => {

--- a/tests/integration/auth-password-reset.route.test.ts
+++ b/tests/integration/auth-password-reset.route.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { POST as glemtPassord } from "~/app/api/auth/glemt-passord/route";
+import { POST as nyttPassord } from "~/app/api/auth/nytt-passord/route";
+import { createSession } from "~/server/auth/config";
+import { hashPassword, verifyPassword } from "~/server/auth/password";
+
+import { createUser, db } from "../helpers/db";
+import { fetchMock, json } from "../helpers/fetch-mock";
+import { resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+const ask = (body: unknown, ip = "10.0.0.1") => {
+  resetNextHeaders({ "user-agent": "vitest", "x-forwarded-for": ip });
+  return glemtPassord(
+    new Request("https://fadderuka.test/api/auth/glemt-passord", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+};
+
+const submit = (body: unknown) =>
+  nyttPassord(
+    new Request("https://fadderuka.test/api/auth/nytt-passord", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+
+/** Accept the mail Photon would have sent, and hand back the link it contained. */
+function stubPhotonEmail() {
+  fetchMock.on("POST", "/api/email/send", json({ success: true }));
+}
+
+/** The reset URL out of the mail body we sent to Photon. */
+function sentLink(): string {
+  const call = fetchMock.callsTo("/api/email/send").at(-1);
+  const body = call?.body as
+    | { content?: Array<{ type: string; url?: string }> }
+    | undefined;
+  const button = body?.content?.find((block) => block.type === "button");
+  return button?.url ?? "";
+}
+
+const tokenFrom = (link: string) => link.split("/nytt-passord/")[1] ?? "";
+
+/** A user of the local login bridge: registered here, TIHLDE not done yet. */
+async function pendingUser(password = "gammelt-passord") {
+  return createUser({
+    tihldeUserId: "ventende",
+    email: "ventende@stud.ntnu.no",
+    passwordHash: await hashPassword(password),
+  });
+}
+
+describe("POST /api/auth/glemt-passord", () => {
+  it("sender en lenke til brukerens e-post", async () => {
+    stubPhotonEmail();
+    const user = await pendingUser();
+
+    const response = await ask({ user_id: "ventende" });
+
+    expect(response.status).toBe(200);
+    const call = fetchMock.callsTo("/api/email/send").at(-1);
+    expect(call?.headers.authorization).toBe("Bearer test-email-api-key");
+    expect((call?.body as { to: string }).to).toBe("ventende@stud.ntnu.no");
+
+    // Lenka peker på appen, ikke på verdien i Host-headeren.
+    expect(sentLink()).toMatch(/^https:\/\/fadderuka\.test\/nytt-passord\//);
+
+    // Kun hashen lagres — klarteksten finnes bare i e-posten.
+    const stored = await db.passwordResetToken.findFirstOrThrow({
+      where: { userId: user.id },
+    });
+    expect(stored.tokenHash).not.toContain(tokenFrom(sentLink()));
+    expect(stored.usedAt).toBeNull();
+  });
+
+  it("tåler brukernavn i feil kasus", async () => {
+    stubPhotonEmail();
+    const user = await pendingUser();
+
+    await ask({ user_id: "  VENTENDE " });
+
+    expect(await db.passwordResetToken.count({ where: { userId: user.id } })).toBe(1);
+  });
+
+  it("sender ingenting til kontoer TIHLDE autentiserer", async () => {
+    // Uten lokal hash eier tihlde.org passordet. En lenke herfra ville vært en
+    // ekstra vei inn i en godkjent TIHLDE-konto.
+    await createUser({ tihldeUserId: "godkjent", email: "godkjent@stud.ntnu.no" });
+
+    const response = await ask({ user_id: "godkjent" });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.callsTo("/api/email/send")).toHaveLength(0);
+    expect(await db.passwordResetToken.count()).toBe(0);
+  });
+
+  it("røper ikke om brukernavnet finnes", async () => {
+    stubPhotonEmail();
+    await pendingUser();
+
+    const finnes = await ask({ user_id: "ventende" });
+    const finnesIkke = await ask({ user_id: "finnes-ikke" });
+
+    expect(finnesIkke.status).toBe(finnes.status);
+    expect(await finnesIkke.json()).toEqual(await finnes.json());
+  });
+
+  it("røper ikke at e-postsending feilet", async () => {
+    fetchMock.on("POST", "/api/email/send", json({ message: "nei" }, 500));
+    await pendingUser();
+
+    const response = await ask({ user_id: "ventende" });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("stopper mailbombing av én konto", async () => {
+    stubPhotonEmail();
+    await pendingUser();
+
+    for (let i = 0; i < 5; i++) {
+      expect((await ask({ user_id: "ventende" })).status).toBe(200);
+    }
+    const blocked = await ask({ user_id: "ventende" });
+
+    expect(blocked.status).toBe(429);
+    expect(fetchMock.callsTo("/api/email/send")).toHaveLength(5);
+  });
+
+  it("erstatter en tidligere ubrukt lenke", async () => {
+    stubPhotonEmail();
+    const user = await pendingUser();
+
+    await ask({ user_id: "ventende" });
+    const first = tokenFrom(sentLink());
+    await ask({ user_id: "ventende" });
+    const second = tokenFrom(sentLink());
+
+    expect(second).not.toBe(first);
+    expect(await db.passwordResetToken.count({ where: { userId: user.id } })).toBe(1);
+
+    // Den gamle lenka skal være død.
+    const response = await submit({ token: first, password: "nytt-passord" });
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("POST /api/auth/nytt-passord", () => {
+  it("setter nytt passord og brenner lenka", async () => {
+    stubPhotonEmail();
+    const user = await pendingUser("gammelt-passord");
+    await ask({ user_id: "ventende" });
+    const token = tokenFrom(sentLink());
+
+    const response = await submit({ token, password: "mitt-nye-passord" });
+
+    expect(response.status).toBe(200);
+    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    await expect(
+      verifyPassword("mitt-nye-passord", stored.passwordHash),
+    ).resolves.toBe(true);
+    await expect(
+      verifyPassword("gammelt-passord", stored.passwordHash),
+    ).resolves.toBe(false);
+
+    // Engangsbruk: samme lenke en gang til gir ingenting.
+    const reuse = await submit({ token, password: "enda-et-passord" });
+    expect(reuse.status).toBe(400);
+    await expect(
+      verifyPassword("mitt-nye-passord", stored.passwordHash),
+    ).resolves.toBe(true);
+  });
+
+  it("logger ut alle økter på kontoen", async () => {
+    // Den som ba om tilbakestilling kan være i ferd med å kaste ut noen som
+    // sitter innlogget på kontoen akkurat nå.
+    stubPhotonEmail();
+    const user = await pendingUser();
+    await createSession({ userId: user.id, tihldeToken: null });
+    expect(await db.session.count({ where: { userId: user.id } })).toBe(1);
+
+    await ask({ user_id: "ventende" });
+    await submit({ token: tokenFrom(sentLink()), password: "mitt-nye-passord" });
+
+    expect(await db.session.count({ where: { userId: user.id } })).toBe(0);
+  });
+
+  it("avviser en utløpt lenke", async () => {
+    stubPhotonEmail();
+    const user = await pendingUser("gammelt-passord");
+    await ask({ user_id: "ventende" });
+    const token = tokenFrom(sentLink());
+
+    await db.passwordResetToken.updateMany({
+      where: { userId: user.id },
+      data: { expiresAt: new Date(Date.now() - 1000) },
+    });
+
+    const response = await submit({ token, password: "mitt-nye-passord" });
+
+    expect(response.status).toBe(400);
+    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    await expect(
+      verifyPassword("gammelt-passord", stored.passwordHash),
+    ).resolves.toBe(true);
+  });
+
+  it("avviser et token som ikke finnes", async () => {
+    const response = await submit({ token: "finnes-ikke", password: "et-passord-nok" });
+    expect(response.status).toBe(400);
+  });
+
+  it("krever minst 8 tegn", async () => {
+    stubPhotonEmail();
+    const user = await pendingUser("gammelt-passord");
+    await ask({ user_id: "ventende" });
+
+    const response = await submit({ token: tokenFrom(sentLink()), password: "kort" });
+
+    expect(response.status).toBe(400);
+    // Lenka skal fortsatt virke — de skrev bare et for kort passord.
+    const stored = await db.passwordResetToken.findFirstOrThrow({
+      where: { userId: user.id },
+    });
+    expect(stored.usedAt).toBeNull();
+  });
+});

--- a/tests/integration/auth-set-password.route.test.ts
+++ b/tests/integration/auth-set-password.route.test.ts
@@ -68,25 +68,6 @@ describe("POST /api/auth/set-password", () => {
     ).toBeNull();
   });
 
-  it("lar en bruker bytte ut et admin-utstedt engangspassord", async () => {
-    // Poenget med engangspassordet: det skal ikke bli det de sitter med.
-    const user = await createUser({
-      passwordHash: await hashPassword("engangspassord"),
-      passwordIsTemporary: true,
-    });
-    await signIn(user.id, null);
-
-    const response = await post({ password: "mitt-egne-passord" });
-
-    expect(response.status).toBe(200);
-    const stored = await db.user.findUniqueOrThrow({ where: { id: user.id } });
-    await expect(verifyPassword("mitt-egne-passord", stored.passwordHash)).resolves.toBe(true);
-    // Det gamle engangspassordet skal ikke lenger gjelde ...
-    await expect(verifyPassword("engangspassord", stored.passwordHash)).resolves.toBe(false);
-    // ... og passordet er ikke midlertidig lenger, så de slipper å velge igjen.
-    expect(stored.passwordIsTemporary).toBe(false);
-  });
-
   it("avviser en bruker som allerede har et lokalt passord", async () => {
     // Ellers ville ruta vært en vei til å overskrive passordet uten å kunne det
     // gamle, for den som skulle få tak i en sesjon.


### PR DESCRIPTION
## Hva

Fjerner engangspassordene admin kunne utstede, og erstatter dem med en selvbetjent glemt-passord-flyt som sender e-post gjennom Photons e-post-API.

## Hvorfor

Engangspassordene var det eneste sikkerhetsnettet for en student som glemte det lokale passordet sitt, men de krevde at en admin gjorde jobben manuelt. Ingen i prod hadde et aktivt engangspassord (0 av 193 brukere), så selve fjerningen påvirker ingen — men hullet det etterlot måtte tettes.

Photon sender allerede fra `no-reply@tihlde.org` over TIHLDEs egen SMTP-relay og eksponerer `POST /api/email/send`. Det sparer oss for både en ny e-postleverandør og DKIM/SPF-records på `tihlde.org`, som vi uansett ikke styrer DNS for.

## Flyten

`/logg-inn` → «Glemt passord?» → `/glemt-passord` → e-post med lenke → `/nytt-passord/[token]` → tilbake til innlogging med brukernavnet forhåndsutfylt.

## Sikkerhetsvalg

- **Kun kontoer med lokal `passwordHash` får lenke.** Uten hash eier tihlde.org passordet, og en lenke herfra ville vært en ekstra vei inn i en godkjent TIHLDE-konto som omgår TIHLDE. De pekes til `tihlde.org/glemt-passord`.
- **Samme svar uansett utfall** — om brukernavnet finnes, om det kan tilbakestilles, og om e-posten gikk ut er usynlig utenfra.
- **Kun SHA-256 av tokenet lagres.** Klarteksten finnes i e-posten og ingen andre steder. Én time, én gangs bruk, ny forespørsel dreper den forrige lenka.
- **Lenka bygges fra `APP_URL`, ikke Host-headeren** — det er slik reset-lenker forgiftes.
- **Alle økter logges ut** ved passordbytte. Rate limiting: 5 per konto og 15 per IP i timen, mot mailbombing gjennom TIHLDEs relay.

## Testet

- 262 tester grønne, hvorav 12 nye for denne flyten (engangsbruk, utløp, kappløp på samme lenke, ingen lekkasje av hvem som har konto, rate limiting).
- Ekte kall fra dev-server til `photon.tihlde.org/api/email/send`: kom fram, avvist med `403 Invalid API key` fordi den lokale nøkkelen var en dummy — URL, path og Bearer-format stemmer.
- Gjennomgang i nettleser: nytt passord virker, gammelt virker ikke, token merket brukt, 0 økter igjen. Innlogging med nytt passord `200`, gammelt `401`, brukt lenke `400`.
- `tsc --noEmit` rent, eslint 0 errors, `next build` OK.

## Før merge til prod

To nye env-variabler må settes i Vercel:

- `PHOTON_EMAIL_API_KEY` — må matche `EMAIL_API_KEY` på Photon-serveren. Uten den svarer flyten ærlig at den er utilgjengelig i stedet for å late som en e-post gikk ut.
- `APP_URL` — `https://fadderuka.tihlde.org` i produksjon. Sett den for Preview også, ellers arver preview-deploys `VIPPS_CALLBACK_URL` og lager reset-lenker som peker til prod.

Og to migrasjoner, som Vercel ikke kjører selv:

```bash
npx prisma migrate deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)