### PR TITLE
fix(auth): be om et JWT-access-token, ikke et ugjennomsiktig

### DIFF
--- a/src/server/auth/photon.ts
+++ b/src/server/auth/photon.ts
@@ -23,6 +23,12 @@ import { env } from "~/env";
 
 const SCOPES = "openid profile email";
 
+/**
+ * The audience we request tokens for — Photon's auth base URL, which is the
+ * only value its provider accepts. See the note in `exchangeCode`.
+ */
+const PHOTON_AUDIENCE = `${env.PHOTON_API_URL.replace(/\/$/, "")}/api/auth`;
+
 /** How long we wait for Photon before giving up on a request. */
 const TIMEOUT_MS = 10_000;
 
@@ -198,6 +204,20 @@ export async function exchangeCode(
     redirect_uri: redirectUri(),
     client_id: requireClientId(),
     code_verifier: codeVerifier,
+    /**
+     * Asks for an access token we can actually use against Photon's API.
+     *
+     * Without `resource` the provider mints an OPAQUE token (`tihlde_oat_…`),
+     * and Photon's own `requireAuth` only understands JWTs — it bails on
+     * `token.split(".").length !== 3` and answers 401. Every profile lookup
+     * then failed with "Kunne ikke hente profilen din fra TIHLDE", which is
+     * what took the login down on the night of the cutover.
+     *
+     * The value has to be Photon's auth base URL: `validAudiences` is not
+     * configured on the provider, so it defaults to exactly that one origin and
+     * rejects anything else with `requested resource invalid`.
+     */
+    resource: PHOTON_AUDIENCE,
   });
 
   const secret = env.PHOTON_OAUTH_CLIENT_SECRET;


### PR DESCRIPTION
Hotfix. Innloggingen feiler nå med «Kunne ikke hente profilen din fra TIHLDE».

## Årsak

`exchangeCode` ba ikke om noen `resource`. I `@better-auth/oauth-provider` avgjøres tokenformatet av

```js
const isJwtAccessToken = audience && !opts.disableJwtPlugin;
const audience = await checkResource(ctx, opts, scopes); // kun satt når resource sendes
```

Uten `resource` blir det altså et **ugjennomsiktig** token. Photons `requireAuth` forstår bare JWT — `verifyJWTAccessToken` returnerer `null` allerede på `token.split(".").length !== 3`, faller tilbake til sesjonscookie, finner ingen, og svarer 401. Callbacken vår leser det som at profilen ikke kunne hentes.

## Bevis, målt mot prod

Samme klient, `client_credentials` (midlertidig påskrudd og fjernet igjen):

| | token |
|---|---|
| uten `resource` | `tihlde_oat_mCTMOSFRlEtlISjFB…` — én del |
| med `resource` | `eyJhbGciOiJFZERTQSIsImtpZCI6…` — tre deler, EdDSA |

## Verdien

Må være Photons auth-base-URL (`https://photon.tihlde.org/api/auth`). `validAudiences` er ikke satt på provideren, så den defaulter til `ctx.context.baseURL` og avviser alt annet med `requested resource invalid`. Utledes fra `PHOTON_API_URL` i stedet for å hardkodes.

`tsc --noEmit` grønt, `bun run test` 182/182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)