### PR TITLE
fix(register): ikke gjenta Photons «Internal server error» til studenten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       # at module load. Dummy values only — nothing here reaches a real service.
       DATABASE_URL: postgresql://postgres:password@localhost:5432/fadderuke_test
       TIHLDE_API_URL: https://api.tihlde.org
+      # Both API URLs are spelled out because SKIP_ENV_VALIDATION hands the code
+      # raw process.env — the defaults in ~/env never run here.
+      PHOTON_API_URL: https://photon.tihlde.org
       SKIP_ENV_VALIDATION: "1"
 
     steps:

--- a/docs/photon-issue-register-500.md
+++ b/docs/photon-issue-register-500.md
@@ -1,0 +1,93 @@
+# Photon-issue: `POST /api/user/register` svarer 500 når brukernavnet er tatt
+
+Klar til å limes inn som issue i TIHLDE/Photon. Skrevet 2026-08-07 av Fadderuka-teamet.
+
+---
+
+**Tittel:** `POST /api/user/register` svarer 500 «Internal server error» når brukernavnet allerede finnes
+
+**Labels:** bug, api, auth
+
+## Sammendrag
+
+`POST /api/user/register` krasjer med 500 i stedet for å svare 409/400 når e-posten er ny, men det utledede brukernavnet allerede er i bruk. Better Auth sin unikhetssjekk på brukernavn kjører aldri for dette endepunktet, så innsettingen går rett på unik-indeksen `user.username`.
+
+Dette rammer alle som allerede har en Photon-konto laget med Feide og deretter registrerer seg via en tjeneste som bruker `users:create`.
+
+## Effekt
+
+Fadderuka viser Photons melding til studenten. En ny masterstudent på Digital transformasjon møtte derfor teksten «Internal server error» på registreringsskjemaet 2026-08-07, uten noe hint om at det de skulle gjort var å logge inn. Vi har lappet over det på vår side ved å aldri gjenta en 5xx fra Photon, men selve feilen bør fikses her — den gjelder alle konsumenter av API-nøkkelen.
+
+## Reproduksjon
+
+1. Lag en konto med Feide på tihlde.org. Kontoen får `username` = NTNU-brukernavn (backfilles i `syncFeideHook` → `backfillUsername`), og `email` = adressen Feide oppgir, som ofte **ikke** er `<ntnu-brukernavn>@stud.ntnu.no`.
+2. Kall `POST /api/user/register` med en API-nøkkel som har `users:create`:
+   ```json
+   {
+     "name": "Ola Nordmann",
+     "email": "olanord@stud.ntnu.no",
+     "password": "<minst 8 tegn>",
+     "studyProgramSlug": "digital-samhandling"
+   }
+   ```
+   der `olanord` er brukernavnet fra steg 1, men adressen er en annen enn den kontoen har.
+3. Forventet: 409 (eller 400) med en melding som sier at brukeren finnes.
+   Faktisk: `500 {"status":500,"message":"Internal server error"}`.
+
+Merk: hvis adressen er **identisk** med den eksisterende, svarer Better Auth pent med «User already exists». Det er bare brukernavn-kollisjonen som krasjer.
+
+## Årsak
+
+`apps/api/src/routes/user/register.ts` kaller `auth.api.signUpEmail`. Brukernavnet settes av den globale før-hooken i `packages/auth/src/index.ts`:
+
+```ts
+hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+        if (ctx.path !== "/sign-up/email") return;
+        // ...
+        return { context: { body: { ...ctx.body, email, username: match[1] } } };
+    }),
+```
+
+I `better-auth@1.6.x` (`dist/api/dispatch.mjs`):
+
+- `getHooks()` legger brukerens hook **først**, deretter plugin-hookene — så username-pluginens hooks kjører etter vår.
+- `runBeforeHooks()` samler returnert kontekst i `modifiedContext`, men kaller hver hook med den **opprinnelige** konteksten: `hook.handler({ ...context, returnHeaders: true })`. Den sammenslåtte konteksten treffer først selve endepunktet.
+
+Følgen er at username-pluginens sjekk
+
+```ts
+const username = ctx.body.username;
+if (username !== void 0 && typeof username === "string") {
+  /* USERNAME_IS_ALREADY_TAKEN */
+}
+```
+
+ser `undefined` og hopper over hele valideringen. Database-hooken fanger det heller ikke opp, fordi den hopper over validering nettopp for `/sign-up/email`:
+
+```ts
+const pathsWithHttpHookValidation = ["/sign-up/email", "/update-user"];
+// ...
+if (!skipValidation)
+  await validateUsername(username, displayUsername, ctx.adapter);
+```
+
+Da står bare unik-indeksen igjen (`packages/db/src/schema/auth.ts`: `username: text("username").unique()`), og drivertfeilen bobler ufanget opp til `globalErrorHandler`, som i produksjon svarer «Internal server error».
+
+Det samme gjelder websidens egen registrering — den går gjennom nøyaktig samme hook.
+
+## Forslag til fiks
+
+Enten, eller helst begge:
+
+1. **I `registerUserRoute`:** slå opp brukernavnet før `signUpEmail`, på linje med slug-sjekken som allerede gjøres der, og svar 409 hvis det er tatt. Da får kalleren noe å vise brukeren.
+2. **I den globale før-hooken:** sett `username` slik at pluginens validering faktisk ser det — eller gjør unikhetssjekken selv i hooken. Dette er det som også dekker websidens sign-up.
+
+Et sikkerhetsnett i `globalErrorHandler` for unik-brudd fra databasen (→ 409) ville dessuten hindre at neste tilsvarende sak lekker «Internal server error» ut til en student.
+
+## Berørte filer
+
+- `apps/api/src/routes/user/register.ts`
+- `packages/auth/src/index.ts` (`hooks.before` for `/sign-up/email`)
+- `packages/db/src/schema/auth.ts` (unik-indeksen)
+- `apps/api/src/lib/errors.ts` (`globalErrorHandler`)

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -8,7 +8,11 @@ import {
   SESSION_MAX_AGE,
   createSession,
 } from "~/server/auth/config";
-import { PhotonAuthError, photonCreateUser } from "~/server/auth/photon";
+import {
+  PhotonAuthError,
+  PhotonUnavailableError,
+  photonCreateUser,
+} from "~/server/auth/photon";
 import {
   checkRegisterRateLimit,
   recordRegisterAttempt,
@@ -172,16 +176,65 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true });
   } catch (err) {
+    // Photon could not be reached at all. Its own message says so, and the
+    // advice is "wait", not "check the form" — so it keeps a 503 and a
+    // Retry-After rather than being folded into the case below.
+    if (err instanceof PhotonUnavailableError) {
+      console.error("[auth/register] photon unreachable", err.cause);
+      return NextResponse.json(
+        { error: err.message },
+        { status: 503, headers: { "Retry-After": "30" } },
+      );
+    }
+
     if (err instanceof PhotonAuthError) {
-      // 5xx is ours to own; anything else is something the student can act on,
-      // and Photon's message already says what.
-      const status = err.status >= 500 ? 502 : 400;
+      /**
+       * A 5xx from Photon is never something to repeat to the student.
+       *
+       * Photon answers an unhandled error with the literal string "Internal
+       * server error", and this route used to forward it verbatim — which is
+       * what a new student on Digital transformasjon met on 2026-08-07: an
+       * English server message on a Norwegian form, with no idea what to do
+       * next.
+       *
+       * The overwhelmingly likely cause is that they already have a TIHLDE
+       * account. Photon derives the username from the e-mail, and creating an
+       * account whose username is taken but whose address is not hits the
+       * unique index on `user.username` unguarded — Photon's own duplicate
+       * check only ever sees the address. That is exactly the shape of an
+       * account made with Feide on tihlde.org, where the address Feide reports
+       * is usually not `<ntnu-brukernavn>@stud.ntnu.no`. Logging in is the only
+       * thing that helps them, so we offer that instead of a raw 500, and hedge
+       * it as a question because the same status also covers a genuine Photon
+       * fault.
+       */
+      if (err.status >= 500) {
+        console.error(
+          "[auth/register] photon 5xx",
+          err.status,
+          err.message,
+          userId,
+        );
+        return NextResponse.json(
+          {
+            error:
+              "Vi fikk ikke opprettet TIHLDE-brukeren din. Har du allerede en bruker på tihlde.org — for eksempel laget med Feide? Da må du logge inn i stedet for å registrere deg. Hjelper ikke det, si fra til en fadder.",
+            // Lights up the "Logg inn med TIHLDE"-link on the form; the
+            // username is the one Photon would have given them anyway.
+            existingUserId: userId,
+          },
+          { status: 502 },
+        );
+      }
+
+      // Anything else is something the student can act on, and Photon's message
+      // already says what.
       const field = /e-?post|adresse/i.test(err.message)
         ? "email"
         : /passord/i.test(err.message)
           ? "password"
           : undefined;
-      return NextResponse.json({ error: err.message, field }, { status });
+      return NextResponse.json({ error: err.message, field }, { status: 400 });
     }
 
     if (isUniqueConstraintError(err)) {

--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -113,7 +113,12 @@ export default function RegistreringPage() {
               </CardTitle>
               <CardDescription>
                 Opprett en TIHLDE-bruker og betal med Vipps. Brukeren kan du
-                senere bruke på tihlde.org.
+                senere bruke på tihlde.org. Har du allerede laget bruker på
+                tihlde.org — for eksempel med Feide — skal du{" "}
+                <Link href="/logg-inn" className="underline">
+                  logge inn
+                </Link>{" "}
+                i stedet.
               </CardDescription>
             </div>
 

--- a/src/server/auth/photon.ts
+++ b/src/server/auth/photon.ts
@@ -26,8 +26,15 @@ const SCOPES = "openid profile email";
 /**
  * The audience we request tokens for — Photon's auth base URL, which is the
  * only value its provider accepts. See the note in `exchangeCode`.
+ *
+ * A function, not a constant: with `SKIP_ENV_VALIDATION` set — which is how CI
+ * runs `next build` — `env` is raw `process.env`, so the zod default for
+ * `PHOTON_API_URL` never applies. Reading it while the module loaded therefore
+ * threw `Cannot read properties of undefined` and failed the build on every
+ * machine without that variable set. Nothing else here touches `env` before it
+ * is called.
  */
-const PHOTON_AUDIENCE = `${env.PHOTON_API_URL.replace(/\/$/, "")}/api/auth`;
+const photonAudience = () => endpoint("/api/auth");
 
 /** How long we wait for Photon before giving up on a request. */
 const TIMEOUT_MS = 10_000;
@@ -217,7 +224,7 @@ export async function exchangeCode(
      * configured on the provider, so it defaults to exactly that one origin and
      * rejects anything else with `requested resource invalid`.
      */
-    resource: PHOTON_AUDIENCE,
+    resource: photonAudience(),
   });
 
   const secret = env.PHOTON_OAUTH_CLIENT_SECRET;

--- a/tests/integration/auth-register.route.test.ts
+++ b/tests/integration/auth-register.route.test.ts
@@ -128,4 +128,46 @@ describe("POST /api/auth/register", () => {
       db.user.findUnique({ where: { tihldeUserId: "ola" } }),
     ).resolves.toBeNull();
   });
+
+  // Photon svarer «Internal server error» når brukernavnet er tatt, men
+  // e-posten er ny — altså den som allerede har laget bruker med Feide. Den
+  // meldingen ble tidligere vist ordrett i skjemaet, og etterlot studenten uten
+  // noe å gjøre.
+  it("tilbyr innlogging i stedet for å gjenta Photons «Internal server error»", async () => {
+    fetchMock.on(
+      "POST",
+      "/api/user/register",
+      json({ status: 500, message: "Internal server error" }, 500),
+    );
+
+    const response = await post(FORM);
+    const body = (await response.json()) as {
+      error: string;
+      existingUserId?: string;
+    };
+
+    expect(response.status).toBe(502);
+    expect(body.error).not.toContain("Internal server error");
+    expect(body.error).toContain("logge inn");
+    // Lyser opp innloggingslenken i skjemaet.
+    expect(body.existingUserId).toBe("ola");
+
+    await expect(
+      db.user.findUnique({ where: { tihldeUserId: "ola" } }),
+    ).resolves.toBeNull();
+  });
+
+  it("ber studenten vente når Photon ikke er å få tak i", async () => {
+    fetchMock.on("POST", "/api/user/register", () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    const response = await post(FORM);
+
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(body.error).toContain("Får ikke kontakt med TIHLDE");
+  });
 });


### PR DESCRIPTION
## Bakgrunn

En ny masterstudent på Digital transformasjon meldte at registreringen på fadderuka.tihlde.org alltid feiler med «internal server error». De hadde allerede laget TIHLDE-bruker med Feide.

Årsakskjeden:

1. Studenten bruker «Registrer deg» selv om de allerede har konto.
2. Vi kaller `POST /api/user/register` på Photon med `<ntnu-brukernavn>@stud.ntnu.no`.
3. Photon lar `auth.api.signUpEmail` gå videre uten unikhetssjekk på brukernavn — better-auth kaller hver før-hook med den *opprinnelige* konteksten, så username-pluginen ser aldri brukernavnet Photons egen hook injiserer, og database-hooken hopper over valideringen for `/sign-up/email`. Innsettingen treffer unik-indeksen `user.username` og bobler ufanget opp: `{"status":500,"message":"Internal server error"}`.
4. Vår rute sendte den meldingen rett til skjemaet.

E-post som matcher eksakt gir en pen «User already exists»; det er bare brukernavn-kollisjonen som krasjer — altså akkurat Feide-tilfellet, der adressen Feide oppgir sjelden er `<brukernavn>@stud.ntnu.no`.

## Hva denne PR-en gjør

- **En 5xx fra Photon vises aldri ordrett.** Studenten får i stedet spørsmålet om de allerede har bruker, og beskjed om å logge inn. `existingUserId` sendes med, slik at «Logg inn med TIHLDE som «x»»-lenken skjemaet allerede har, tennes. Den ekte meldingen logges.
- **`PhotonUnavailableError` får sin egen gren først** — den er også 5xx, og «Får ikke kontakt med TIHLDE» ville ellers blitt overskrevet. Beholder 503 + `Retry-After`.
- **Registreringssiden** sier nå i ingressen at den som allerede har bruker på tihlde.org (f.eks. med Feide) skal logge inn.
- **To nye tester:** at «Internal server error» aldri når skjemaet, og at utilgjengelig Photon gir 503.
- **`docs/photon-issue-register-500.md`:** oppskrivingen av selve Photon-feilen, med reproduksjon, årsak og fiksforslag.

Bevisst konsekvens: mangler `PHOTON_REGISTER_API_KEY`, ser studenten samme melding i stedet for konfigurasjonsfeilen. Den hører uansett ikke hjemme i et skjema — den ligger i loggen.

## Verifisering

- `npm run check` (eslint + tsc + vitest): 184 tester grønne.
- `npm run build`: ok.
- Kjørt i nettleser mot dev-serveren: fylte ut skjemaet med Digital transformasjon og sendte inn. Uten API-nøkkel lokalt treffer det nøyaktig 5xx-grenen — siden viste den norske meldingen og innloggingslenken, og ingen lokal rad ble liggende igjen.

## Oppfølging

Selve feilen ligger i Photon og fikses der; denne PR-en hindrer bare at den lekker ut til studenten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)