### PR TITLE
Hold faddergruppene skjult for fadderbarna til FadderKom trykker «Publiser»

### DIFF
--- a/prisma/migrations/20260807120000_gruppe_publication/migration.sql
+++ b/prisma/migrations/20260807120000_gruppe_publication/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "AppSetting" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "gruppePublishedAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AppSetting_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,18 @@ model User {
     payments      Payment[]
 }
 
+model AppSetting {
+    // One row, always keyed "singleton": app-wide switches FadderKom flips by
+    // hand. A fixed id makes every read a primary-key lookup and an upsert
+    // instead of a "first row wins" gamble.
+    id String @id @default("singleton")
+    // When the faddergrupper were released to fadderbarn. `null` means they
+    // are still hidden, so faddere can be assigned and can prepare their
+    // gruppe before the fadderbarn get to see who they ended up with.
+    gruppePublishedAt DateTime?
+    updatedAt         DateTime  @updatedAt
+}
+
 model FadderGruppe {
     id            String   @id @default(cuid())
     name          String

--- a/src/app/(authenticated)/admin/grupper-tab.tsx
+++ b/src/app/(authenticated)/admin/grupper-tab.tsx
@@ -3,6 +3,8 @@
 import {
   ChevronDown,
   ChevronUp,
+  Eye,
+  EyeOff,
   Plus,
   Trash2,
   UserMinus,
@@ -118,6 +120,8 @@ export function GrupperTab() {
 
   return (
     <div className="!space-y-6">
+      <PublicationBanner />
+
       {/* Create new gruppe */}
       <form onSubmit={handleCreateGruppe} className="flex flex-wrap !gap-3">
         <input
@@ -395,6 +399,103 @@ export function GrupperTab() {
       </div>
     </div>
   );
+}
+
+/**
+ * Bryteren som slipper faddergruppene til fadderbarna — alle på én gang.
+ *
+ * Ligger øverst i fanen fordi den er statusen man vil se før man rører noe
+ * annet: er gruppene fortsatt hemmelige, eller er de ute?
+ */
+function PublicationBanner() {
+  const utils = api.useUtils();
+  const { data, isLoading } = api.admin.getGruppePublication.useQuery();
+
+  const setPublication = api.admin.setGruppePublication.useMutation({
+    onSuccess: (result) => {
+      void utils.admin.getGruppePublication.invalidate();
+      toast(
+        result.published
+          ? "Faddergruppene er publisert"
+          : "Faddergruppene er skjult igjen",
+      );
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  if (isLoading || !data) return null;
+
+  const { published, publishedAt } = data;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between !gap-4 rounded-xl border border-border bg-card !px-5 !py-4">
+      <div className="!space-y-1">
+        <div className="flex items-center !gap-2">
+          {published ? (
+            <Eye className="h-4 w-4 text-primary" />
+          ) : (
+            <EyeOff className="h-4 w-4 text-muted-foreground" />
+          )}
+          <h3 className="text-base font-semibold text-foreground">
+            {published
+              ? "Faddergruppene er publisert"
+              : "Faddergruppene er skjult"}
+          </h3>
+        </div>
+        <p className="max-w-xl text-sm text-muted-foreground">
+          {published
+            ? `Fadderbarna ser gruppa si, medlemmene og meldingene. Publisert ${formatDateTime(publishedAt)}.`
+            : "Fadderbarna ser hverken gruppa, medlemmene eller meldingene. Faddere og admins ser alt hele tiden."}
+        </p>
+      </div>
+      <button
+        type="button"
+        disabled={setPublication.isPending}
+        onClick={() => {
+          if (
+            published &&
+            !confirm(
+              "Skjule faddergruppene igjen? Fadderbarna mister tilgangen til gruppa si.",
+            )
+          ) {
+            return;
+          }
+          setPublication.mutate({ published: !published });
+        }}
+        className={`inline-flex items-center !gap-2 rounded-xl !px-4 !py-2.5 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 ${
+          published
+            ? "border border-border bg-secondary text-foreground hover:bg-secondary/80"
+            : "bg-primary text-primary-foreground hover:bg-primary/90"
+        }`}
+      >
+        {published ? (
+          <>
+            <EyeOff className="h-4 w-4" />
+            Skjul igjen
+          </>
+        ) : (
+          <>
+            <Eye className="h-4 w-4" />
+            Publiser til fadderbarna
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+/** Dato på norsk format, eller «—» når tidspunktet mangler. */
+function formatDateTime(value: Date | string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("no-NO", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 function AddMemberForm({

--- a/src/app/(authenticated)/faddergruppe/page.tsx
+++ b/src/app/(authenticated)/faddergruppe/page.tsx
@@ -4,6 +4,7 @@ import { PageHeader, PageShell } from "~/components/layout/page-shell";
 import { Card } from "~/components/ui/card";
 import { auth } from "~/server/auth/config";
 import { db } from "~/server/db";
+import { areGrupperPublished, canSeeGruppe } from "~/server/gruppe-visibility";
 import { GroupView } from "./group-view";
 
 export default async function FaddergroupPage() {
@@ -45,6 +46,28 @@ export default async function FaddergroupPage() {
           className="max-w-md"
           title="Ingen faddergruppe"
           description="Du er ikke tildelt en faddergruppe enda. Kontakt en administrator for å bli lagt til i en gruppe."
+        />
+      </PageShell>
+    );
+  }
+
+  // Fadderbarna får ikke se gruppa si før FadderKom publiserer alle gruppene.
+  // Faddere ser sin hele tiden, så de rekker å bli kjent og skrive velkomst.
+  const published = await areGrupperPublished(db);
+  if (
+    !canSeeGruppe({
+      isAdmin: session.user.isAdmin,
+      role: membership.role,
+      published,
+    })
+  ) {
+    return (
+      <PageShell className="flex-1 items-center justify-center">
+        <PageHeader
+          centered
+          className="max-w-md"
+          title="Faddergruppene slippes snart"
+          description="Vi holder fortsatt gruppene hemmelige. Så snart de er klare finner du gruppa di, fadderne dine og resten av gjengen her."
         />
       </PageShell>
     );

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -4,6 +4,10 @@ import { z } from "zod";
 import { MAJORS } from "~/lib/majors";
 import { deriveIsFadder } from "~/server/fadder";
 import {
+  getGruppePublishedAt,
+  setGrupperPublished,
+} from "~/server/gruppe-visibility";
+import {
   adminProcedure,
   createTRPCRouter,
 } from "~/server/api/trpc";
@@ -205,6 +209,26 @@ export const adminRouter = createTRPCRouter({
         },
         select: { id: true, name: true, studieretning: true },
       });
+    }),
+
+  /** Whether fadderbarn can see their faddergruppe yet, and since when. */
+  getGruppePublication: adminProcedure.query(async ({ ctx }) => {
+    const publishedAt = await getGruppePublishedAt(ctx.db);
+    return { published: publishedAt !== null, publishedAt };
+  }),
+
+  /**
+   * Release every faddergruppe to its fadderbarn — or take them back.
+   *
+   * One switch for all grupper at once, which is how FadderKom runs it: the
+   * groups are announced together, and publishing them one by one would leave
+   * some fadderbarn staring at an empty page while others got theirs.
+   */
+  setGruppePublication: adminProcedure
+    .input(z.object({ published: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const publishedAt = await setGrupperPublished(ctx.db, input.published);
+      return { published: publishedAt !== null, publishedAt };
     }),
 
   /** List all faddergrupper with member counts */

--- a/src/server/api/routers/gruppe.ts
+++ b/src/server/api/routers/gruppe.ts
@@ -4,11 +4,23 @@ import {
   createTRPCRouter,
   verifiedProcedure,
 } from "~/server/api/trpc";
+import { areGrupperPublished, canSeeGruppe } from "~/server/gruppe-visibility";
 
 const channelSchema = z.enum(["ANNOUNCEMENT", "CHAT"]);
 
 export const gruppeRouter = createTRPCRouter({
-  /** Get the current user's faddergruppe membership(s) */
+  /** Whether the faddergrupper have been released to fadderbarn. */
+  getPublication: verifiedProcedure.query(async ({ ctx }) => {
+    return { published: await areGrupperPublished(ctx.db) };
+  }),
+
+  /**
+   * Get the current user's faddergruppe membership(s).
+   *
+   * A fadderbarn gets `null` until the grupper are published — the same answer
+   * as "you have no gruppe yet", which is deliberate: before publication the
+   * assignment simply doesn't exist as far as they're concerned.
+   */
   getMyGruppe: verifiedProcedure.query(async ({ ctx }) => {
     const membership = await ctx.db.fadderGruppeMember.findFirst({
       where: { userId: ctx.session.user.id },
@@ -25,7 +37,14 @@ export const gruppeRouter = createTRPCRouter({
         },
       },
     });
-    return membership;
+    if (!membership) return null;
+
+    const visible = canSeeGruppe({
+      isAdmin: ctx.session.user.isAdmin,
+      role: membership.role,
+      published: await areGrupperPublished(ctx.db),
+    });
+    return visible ? membership : null;
   }),
 
   /** Get messages for a group (user must be a member or admin) */
@@ -47,6 +66,16 @@ export const gruppeRouter = createTRPCRouter({
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Du har ikke tilgang til denne gruppen",
+          });
+        }
+        // An unpublished gruppe is closed to its fadderbarn, messages included:
+        // the announcements are written by the faddere before release, and
+        // reading them would give away the gruppe the page still hides.
+        const published = await areGrupperPublished(ctx.db);
+        if (!canSeeGruppe({ role: membership.role, published })) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Faddergruppene er ikke publisert enda",
           });
         }
       }
@@ -97,6 +126,13 @@ export const gruppeRouter = createTRPCRouter({
             message: "Kun faddere kan poste meldinger",
           });
         }
+        const published = await areGrupperPublished(ctx.db);
+        if (!canSeeGruppe({ role: membership.role, published })) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Faddergruppene er ikke publisert enda",
+          });
+        }
       }
 
       const created = await ctx.db.groupMessage.create({
@@ -111,10 +147,15 @@ export const gruppeRouter = createTRPCRouter({
         },
       });
 
+      // Faddere write their welcome messages before the grupper are released.
+      // Notifying the fadderbarn then would announce the very gruppe we are
+      // still hiding, so they only get pinged once publication has happened.
+      const published = await areGrupperPublished(ctx.db);
       const otherMembers = await ctx.db.fadderGruppeMember.findMany({
         where: {
           gruppeId: input.gruppeId,
           userId: { not: ctx.session.user.id },
+          ...(published ? {} : { role: "FADDER" as const }),
         },
         select: { userId: true },
       });

--- a/src/server/gruppe-visibility.ts
+++ b/src/server/gruppe-visibility.ts
@@ -1,0 +1,72 @@
+/**
+ * Når fadderbarn får se faddergruppa si.
+ *
+ * Gruppene settes sammen lenge før fadderuka, og FadderKom vil ikke at
+ * fadderbarna skal se hvem de havner sammen med før alt er klart — navnene
+ * flytter seg helt til siste liten. Publiseringen er derfor én manuell bryter
+ * for *alle* gruppene samtidig, ikke per gruppe eller per studieretning.
+ *
+ * Faddere og admins ser gruppene hele tiden: de er de som skal forberede seg,
+ * og de vet allerede hvem som er i gruppa. Det er bare fadderbarna som venter.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import type { MemberRole } from "@prisma/client";
+
+/** Primærnøkkelen til den ene raden i `AppSetting`. */
+export const APP_SETTING_ID = "singleton";
+
+type Db = Pick<PrismaClient, "appSetting">;
+
+/** Når gruppene ble publisert, eller `null` hvis de fortsatt er skjult. */
+export async function getGruppePublishedAt(db: Db): Promise<Date | null> {
+  const setting = await db.appSetting.findUnique({
+    where: { id: APP_SETTING_ID },
+    select: { gruppePublishedAt: true },
+  });
+  return setting?.gruppePublishedAt ?? null;
+}
+
+/** Er gruppene sluppet til fadderbarna? Ingen rad = ikke publisert. */
+export async function areGrupperPublished(db: Db): Promise<boolean> {
+  return (await getGruppePublishedAt(db)) !== null;
+}
+
+/**
+ * Slå publiseringen av eller på. Å publisere på nytt setter et nytt tidspunkt;
+ * å skjule nullstiller det, slik at bryteren er helt reverserbar hvis noen
+ * trykker for tidlig.
+ */
+export async function setGrupperPublished(
+  db: Db,
+  published: boolean,
+  now: Date = new Date(),
+): Promise<Date | null> {
+  const gruppePublishedAt = published ? now : null;
+  const setting = await db.appSetting.upsert({
+    where: { id: APP_SETTING_ID },
+    create: { id: APP_SETTING_ID, gruppePublishedAt },
+    update: { gruppePublishedAt },
+    select: { gruppePublishedAt: true },
+  });
+  return setting.gruppePublishedAt;
+}
+
+/**
+ * Den ene regelen alle gruppevisningene spør: får denne brukeren se gruppa?
+ *
+ * `role` er rollen i den aktuelle gruppa — `null` for en admin uten medlemskap.
+ */
+export function canSeeGruppe({
+  isAdmin,
+  role,
+  published,
+}: {
+  isAdmin?: boolean | null;
+  role: MemberRole | null;
+  published: boolean;
+}): boolean {
+  if (isAdmin === true) return true;
+  if (role === "FADDER") return true;
+  return published;
+}

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,4 +1,5 @@
 import { db } from "~/server/db";
+import { setGrupperPublished } from "~/server/gruppe-visibility";
 
 /**
  * Every table, ordered so the single TRUNCATE covers them all. CASCADE handles
@@ -6,6 +7,7 @@ import { db } from "~/server/db";
  * model that isn't added here will show up as leaked rows between tests.
  */
 const TABLES = [
+  "AppSetting",
   "LoginAttempt",
   "Payment",
   "Notification",
@@ -99,6 +101,17 @@ export async function addMember(
   role: "FADDER" | "FADDERBARN",
 ) {
   return db.fadderGruppeMember.create({ data: { userId, gruppeId, role } });
+}
+
+/**
+ * Release the faddergrupper to their fadderbarn.
+ *
+ * The reset leaves publication off, which mirrors production before FadderKom
+ * flips the switch — so any test about what a fadderbarn can actually see has
+ * to say so out loud.
+ */
+export async function publishGrupper() {
+  return setGrupperPublished(db, true);
 }
 
 export async function createPayment(

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -35,6 +35,8 @@ const ADMIN_PROCEDURE_INPUTS: Record<string, unknown> = {
   setUserFadder: { userId: "x", isFadder: true },
   setUserStudieretning: { userId: "x", studieretning: "Dataingeniør" },
   getGrupper: undefined,
+  getGruppePublication: undefined,
+  setGruppePublication: { published: true },
   createGruppe: { name: "Gruppe" },
   updateGruppe: { gruppeId: "x", name: "Gruppe" },
   deleteGruppe: { gruppeId: "x" },
@@ -185,6 +187,50 @@ describe("admin: brukere og grupper", () => {
     expect(await db.fadderGruppe.count()).toBe(0);
     expect(await db.groupMessage.count()).toBe(0);
     expect(await db.fadderGruppeMember.count()).toBe(0);
+  });
+});
+
+describe("publisering av faddergruppene fra adminpanelet", () => {
+  it("starter skjult, publiserer og skjuler igjen", async () => {
+    const admin = await createAdmin();
+    const caller = callerFor(admin);
+
+    await expect(caller.admin.getGruppePublication()).resolves.toMatchObject({
+      published: false,
+      publishedAt: null,
+    });
+
+    const publisert = await caller.admin.setGruppePublication({
+      published: true,
+    });
+    expect(publisert.published).toBe(true);
+    expect(publisert.publishedAt).toBeInstanceOf(Date);
+    await expect(caller.admin.getGruppePublication()).resolves.toMatchObject({
+      published: true,
+    });
+
+    await expect(
+      caller.admin.setGruppePublication({ published: false }),
+    ).resolves.toMatchObject({ published: false, publishedAt: null });
+  });
+
+  it("gjelder alle gruppene samtidig", async () => {
+    const admin = await createAdmin();
+    const gruppeA = await createGruppe("A");
+    const gruppeB = await createGruppe("B");
+    const barnA = await createUser({ isVerified: true });
+    const barnB = await createUser({ isVerified: true });
+    await addMember(barnA.id, gruppeA.id, "FADDERBARN");
+    await addMember(barnB.id, gruppeB.id, "FADDERBARN");
+
+    await callerFor(admin).admin.setGruppePublication({ published: true });
+
+    await expect(callerFor(barnA).gruppe.getMyGruppe()).resolves.toMatchObject({
+      gruppe: { name: "A" },
+    });
+    await expect(callerFor(barnB).gruppe.getMyGruppe()).resolves.toMatchObject({
+      gruppe: { name: "B" },
+    });
   });
 });
 

--- a/tests/integration/gruppe-router.test.ts
+++ b/tests/integration/gruppe-router.test.ts
@@ -8,6 +8,7 @@ import {
   createGruppe,
   createMember,
   db,
+  publishGrupper,
 } from "../helpers/db";
 
 async function expectCode(promise: Promise<unknown>, code: string) {
@@ -24,6 +25,7 @@ describe("gruppe.getMyGruppe", () => {
     const barn = await createMember({ name: "Barn" });
     await addMember(fadder.id, gruppe.id, "FADDER");
     await addMember(barn.id, gruppe.id, "FADDERBARN");
+    await publishGrupper();
 
     const membership = await callerFor(barn).gruppe.getMyGruppe();
 
@@ -42,6 +44,105 @@ describe("gruppe.getMyGruppe", () => {
 
   it("krever innlogging", async () => {
     await expectCode(anonCaller().gruppe.getMyGruppe(), "UNAUTHORIZED");
+  });
+});
+
+describe("publisering av faddergruppene", () => {
+  it("skjuler gruppa for et fadderbarn før publisering", async () => {
+    const gruppe = await createGruppe();
+    const barn = await createMember();
+    await addMember(barn.id, gruppe.id, "FADDERBARN");
+
+    await expect(callerFor(barn).gruppe.getMyGruppe()).resolves.toBeNull();
+    await expectCode(
+      callerFor(barn).gruppe.getMessages({
+        gruppeId: gruppe.id,
+        channel: "ANNOUNCEMENT",
+      }),
+      "FORBIDDEN",
+    );
+    await expectCode(
+      callerFor(barn).gruppe.postMessage({
+        gruppeId: gruppe.id,
+        content: "hei",
+        channel: "CHAT",
+      }),
+      "FORBIDDEN",
+    );
+  });
+
+  it("lar fadderen se og forberede gruppa før publisering", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createMember();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+
+    await expect(
+      callerFor(fadder).gruppe.getMyGruppe(),
+    ).resolves.toMatchObject({ role: "FADDER" });
+    await expect(
+      callerFor(fadder).gruppe.postMessage({
+        gruppeId: gruppe.id,
+        content: "Velkommen!",
+        channel: "ANNOUNCEMENT",
+      }),
+    ).resolves.toMatchObject({ content: "Velkommen!" });
+  });
+
+  it("varsler ikke fadderbarna om meldinger skrevet før publisering", async () => {
+    const gruppe = await createGruppe();
+    const fadder = await createMember();
+    const annenFadder = await createMember();
+    const barn = await createMember();
+    await addMember(fadder.id, gruppe.id, "FADDER");
+    await addMember(annenFadder.id, gruppe.id, "FADDER");
+    await addMember(barn.id, gruppe.id, "FADDERBARN");
+
+    await callerFor(fadder).gruppe.postMessage({
+      gruppeId: gruppe.id,
+      content: "Velkommen!",
+      channel: "ANNOUNCEMENT",
+    });
+
+    const notifications = await db.notification.findMany();
+    expect(notifications.map((n) => n.userId)).toEqual([annenFadder.id]);
+  });
+
+  it("åpner gruppa for fadderbarnet når den publiseres", async () => {
+    const gruppe = await createGruppe("Gruppe 1");
+    const barn = await createMember();
+    await addMember(barn.id, gruppe.id, "FADDERBARN");
+
+    await publishGrupper();
+
+    await expect(callerFor(barn).gruppe.getMyGruppe()).resolves.toMatchObject({
+      gruppe: { name: "Gruppe 1" },
+    });
+  });
+
+  it("slipper admin inn uansett", async () => {
+    const gruppe = await createGruppe();
+    const admin = await createAdmin();
+
+    await expect(
+      callerFor(admin).gruppe.getMessages({
+        gruppeId: gruppe.id,
+        channel: "ANNOUNCEMENT",
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("rapporterer publiseringsstatusen", async () => {
+    const user = await createMember();
+
+    await expect(callerFor(user).gruppe.getPublication()).resolves.toEqual({
+      published: false,
+    });
+
+    await publishGrupper();
+
+    await expect(callerFor(user).gruppe.getPublication()).resolves.toEqual({
+      published: true,
+    });
   });
 });
 
@@ -111,6 +212,7 @@ describe("gruppe.postMessage", () => {
     const gruppe = await createGruppe();
     const barn = await createMember();
     await addMember(barn.id, gruppe.id, "FADDERBARN");
+    await publishGrupper();
     const caller = callerFor(barn);
 
     await expect(
@@ -154,6 +256,7 @@ describe("gruppe.postMessage", () => {
     await addMember(fadder.id, gruppe.id, "FADDER");
     await addMember(barn1.id, gruppe.id, "FADDERBARN");
     await addMember(barn2.id, gruppe.id, "FADDERBARN");
+    await publishGrupper();
 
     await callerFor(fadder).gruppe.postMessage({
       gruppeId: gruppe.id,
@@ -176,6 +279,7 @@ describe("gruppe.postMessage", () => {
     const barn = await createMember();
     await addMember(fadder.id, gruppe.id, "FADDER");
     await addMember(barn.id, gruppe.id, "FADDERBARN");
+    await publishGrupper();
 
     await callerFor(fadder).gruppe.postMessage({
       gruppeId: gruppe.id,


### PR DESCRIPTION
Etter avklaring med Faddersjef: fadderbarna skal ikke se hvem de er på gruppe med før gruppene slippes. Preben ba om at det gjøres **manuelt, for alle gruppene samtidig** — ikke per gruppe eller per studieretning.

## Hva som endres

**Adminpanelet → Faddergrupper** har fått et statusfelt øverst med én knapp: «Publiser til fadderbarna» / «Skjul igjen», med tidspunkt for når det ble publisert. Fullt reverserbart hvis noen trykker for tidlig.

**Før publisering** ser et fadderbarn siden «Faddergruppene slippes snart». De får hverken gruppa, medlemslista eller meldingene.

**Faddere og admins** ser gruppa hele tiden, så fadderne rekker å bli kjent og skrive velkomstmeldinga på forhånd.

**Varsler holdes tilbake.** En kunngjøring skrevet før publisering pinger bare de andre fadderne — ellers ville «X postet i faddergruppa» avslørt akkurat den gruppa vi nettopp skjulte.

## For reviewer

- **Porten står i serveren, ikke bare i UI-et.** `gruppe.getMyGruppe`, `getMessages` og `postMessage` avviser fadderbarn før publisering, så det holder ikke å fjerne et element i devtools. Samme lærdom som paywall-en i `verifiedProcedure`.
- **`getMyGruppe` returnerer `null`** for et skjult fadderbarn — samme svar som «du har ingen gruppe». Bevisst: før publisering finnes ikke tildelingen for dem.
- **Regelen ligger ett sted**, `src/server/gruppe-visibility.ts` (`canSeeGruppe`), slik at siden, tRPC-laget og adminpanelet ikke kan drifte fra hverandre.
- **Ny tabell:** `AppSetting` — én rad med fast id `singleton` og `gruppePublishedAt`. `null` = skjult. Migrasjonen må kjøres manuelt mot prod (`prisma migrate deploy`); Vercel gjør det ikke.
- Testene starter med publisering **av**, som speiler prod før bryteren trykkes. Derfor har eksisterende tester om hva et fadderbarn ser fått et eksplisitt `publishGrupper()`.

## Verifisert

`tsc --noEmit` rent, eslint 0 errors, `next build` OK, og 194/194 tester grønne — inkludert 8 nye som dekker at fadderbarn stenges ute før publisering, at fadderen slipper inn og kan forberede seg, at varsler holdes tilbake, at admin slipper inn uansett, og at bryteren treffer alle grupper samtidig.

Ikke verifisert: adminknappen er ikke sett i nettleseren — innlogging går via Photon OAuth, så jeg fikk ikke kjørt den gjennom en ekte sesjon.

## Åpent spørsmål

Publiseringen sender **ingen varsel**. Fadderbarna må selv gå inn på siden for å oppdage at gruppene er sluppet. Hvis «Publiser» også bør pinge alle fadderbarn, er det en liten tilleggsendring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
