### PR TITLE
Én bruker kan bare være med i én faddergruppe

### DIFF
--- a/src/app/(authenticated)/admin/grupper-tab.tsx
+++ b/src/app/(authenticated)/admin/grupper-tab.tsx
@@ -88,12 +88,12 @@ export function GrupperTab() {
     createMutation.mutate({ name: newGruppeName.trim() });
   };
 
-  // Get verified users who are not in the currently expanded group
-  const getAvailableUsers = (gruppeId: string) => {
-    if (!users || !grupper) return [];
-    const gruppe = grupper.find((g) => g.id === gruppeId);
-    const memberIds = new Set(gruppe?.members.map((m) => m.userId) ?? []);
-    return users.filter((u) => u.isVerified && !memberIds.has(u.id));
+  // Verified users who are not in a faddergruppe at all. A user belongs to
+  // exactly one group, so someone already placed elsewhere must be removed
+  // from that group before they can be added here.
+  const getAvailableUsers = () => {
+    if (!users) return [];
+    return users.filter((u) => u.isVerified && u.memberships.length === 0);
   };
 
   // Categorize grupper by major, sorted in canonical major order
@@ -315,7 +315,7 @@ export function GrupperTab() {
                           <AddMemberForm
                             gruppeId={gruppe.id}
                             role={addMemberState.role}
-                            availableUsers={getAvailableUsers(gruppe.id)}
+                            availableUsers={getAvailableUsers()}
                             onAdd={(userId) =>
                               addMemberMutation.mutate({
                                 userId,
@@ -504,7 +504,8 @@ function AddMemberForm({
         ))}
         {filtered.length === 0 && (
           <p className="text-center text-xs text-muted-foreground !py-2">
-            Ingen tilgjengelige brukere
+            Ingen tilgjengelige brukere. Brukere som allerede er i en
+            faddergruppe må fjernes derfra først.
           </p>
         )}
       </div>

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -76,6 +76,9 @@ export function UsersTab() {
       setVerifyingUserId(null);
       toast("Bruker verifisert og lagt til i gruppe som fadderbarn");
     },
+    onError: (error) => {
+      toast.error("Feil", { description: error.message });
+    },
   });
 
   const deleteMutation = api.admin.deleteUser.useMutation({

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -252,7 +252,14 @@ export const adminRouter = createTRPCRouter({
       });
     }),
 
-  /** Add a user to a faddergruppe with a role */
+  /**
+   * Add a user to a faddergruppe with a role.
+   *
+   * A user belongs to exactly one faddergruppe: the schema only stops the same
+   * user being added to the *same* group twice, so this is where "one group per
+   * person" is enforced. Moving someone means removing the old membership
+   * first, which keeps the fadderbarn lists unambiguous.
+   */
   addMember: adminProcedure
     .input(
       z.object({
@@ -262,18 +269,17 @@ export const adminRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const existing = await ctx.db.fadderGruppeMember.findUnique({
-        where: {
-          userId_gruppeId: {
-            userId: input.userId,
-            gruppeId: input.gruppeId,
-          },
-        },
+      const existing = await ctx.db.fadderGruppeMember.findFirst({
+        where: { userId: input.userId },
+        select: { gruppeId: true, gruppe: { select: { name: true } } },
       });
       if (existing) {
         throw new TRPCError({
           code: "CONFLICT",
-          message: "Brukeren er allerede medlem av denne gruppen",
+          message:
+            existing.gruppeId === input.gruppeId
+              ? "Brukeren er allerede medlem av denne gruppen"
+              : `Brukeren er allerede medlem av «${existing.gruppe.name}». Fjern brukeren derfra først.`,
         });
       }
       const membership = await ctx.db.fadderGruppeMember.create({
@@ -350,15 +356,18 @@ export const adminRouter = createTRPCRouter({
         where: { id: input.userId },
         data: { isVerified: true },
       });
-      // Only create membership if not already a member
-      const existing = await ctx.db.fadderGruppeMember.findUnique({
-        where: {
-          userId_gruppeId: {
-            userId: input.userId,
-            gruppeId: input.gruppeId,
-          },
-        },
+      // One group per person (see `addMember`): an existing membership in
+      // another group is a conflict, in the same group a no-op.
+      const existing = await ctx.db.fadderGruppeMember.findFirst({
+        where: { userId: input.userId },
+        select: { gruppeId: true, gruppe: { select: { name: true } } },
       });
+      if (existing && existing.gruppeId !== input.gruppeId) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `Brukeren er allerede medlem av «${existing.gruppe.name}». Fjern brukeren derfra først.`,
+        });
+      }
       if (!existing) {
         await ctx.db.fadderGruppeMember.create({
           data: {

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -150,6 +150,51 @@ describe("admin: brukere og grupper", () => {
     );
   });
 
+  it("avviser medlemskap i en ny gruppe når brukeren allerede har en", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    const gruppe1 = await createGruppe();
+    const gruppe2 = await createGruppe();
+    await addMember(user.id, gruppe1.id, "FADDERBARN");
+
+    await expectCode(
+      callerFor(admin).admin.addMember({
+        userId: user.id,
+        gruppeId: gruppe2.id,
+        role: "FADDERBARN",
+      }),
+      "CONFLICT",
+    );
+
+    const memberships = await db.fadderGruppeMember.findMany({
+      where: { userId: user.id },
+    });
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0]!.gruppeId).toBe(gruppe1.id);
+  });
+
+  it("verifyAndAssign avviser bruker som allerede er i en annen gruppe", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+    const gruppe1 = await createGruppe();
+    const gruppe2 = await createGruppe();
+    await addMember(user.id, gruppe1.id, "FADDERBARN");
+
+    await expectCode(
+      callerFor(admin).admin.verifyAndAssign({
+        userId: user.id,
+        gruppeId: gruppe2.id,
+      }),
+      "CONFLICT",
+    );
+
+    const memberships = await db.fadderGruppeMember.findMany({
+      where: { userId: user.id },
+    });
+    expect(memberships).toHaveLength(1);
+    expect(memberships[0]!.gruppeId).toBe(gruppe1.id);
+  });
+
   it("verifyAndAssign er idempotent og bytter ikke rolle", async () => {
     const admin = await createAdmin();
     const user = await createUser();


### PR DESCRIPTION
## Hva

Hindrer at samme bruker legges til i flere faddergrupper.

Rapportert: «Hvis du ser på Preben som ligger i gruppe 1 her, så har jeg fremdeles muligheten til å legge han til i gruppe 2. Tror det kanskje kan bli rot når de skal legge inn fadderbarn.»

## Hvorfor

`@@unique([userId, gruppeId])` i schemaet stopper bare samme bruker i *samme* gruppe, og `addMember` slo opp nøyaktig den nøkkelen. Ingenting hindret altså gruppe 2 i å plukke en person som allerede lå i gruppe 1 — og da blir det uklart hvilken gruppe fadderbarnet faktisk hører til når faddere fyller inn barna sine.

## Endringer

**Server** — `src/server/api/routers/admin.ts`
- `addMember` slår nå opp om brukeren har *noe* medlemskap, og kaster `CONFLICT` med navnet på gruppa de allerede står i: «Brukeren er allerede medlem av «Gruppe 1». Fjern brukeren derfra først.»
- `verifyAndAssign` (verifiser + plasser fra Brukere-fanen) hadde samme hull og har fått samme sjekk. Fortsatt idempotent hvis det er den samme gruppa.

**UI** — `src/app/(authenticated)/admin/`
- `grupper-tab.tsx`: «Legg til medlem»-listen viser bare verifiserte brukere uten gruppe. Den filtrerte tidligere kun bort medlemmer av gruppa du sto i, som er grunnen til at Preben dukket opp under gruppe 2. Tom-tilstanden forklarer hvorfor.
- `users-tab.tsx`: feil-toast på `verifyAndAssign`, som manglet — avvisningen fra serveren ville ellers vært usynlig.

Å flytte noen fungerer som før: fjern fra gammel gruppe, legg til i ny.

## Tester

To nye tester i `tests/integration/admin-router.test.ts` — én per mutasjon — som sjekker at en bruker i gruppe 1 avvises med `CONFLICT` mot gruppe 2, og at det opprinnelige medlemskapet står urørt.

## Verifisert

`eslint` (0 errors, 5 preeksisterende `<img>`-warnings), `tsc --noEmit`, `next build` og hele suiten: 264/264.

## Verdt å vite

Ingen migrasjon. Regelen håndheves i applikasjonslaget, ikke i schemaet — en partiell unique på `userId` ville også fungert, men er ikke tatt med her siden det ville låst muligheten for å utvide til flere medlemskap senere. Eventuelle eksisterende dobbeltmedlemskap i databasen ryddes ikke opp av denne PR-en; de må fjernes manuelt i adminpanelet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)