### PR TITLE
Fiks blank side for bruker med flyttet betaling

### DIFF
--- a/src/components/vipps-payment-overlay.tsx
+++ b/src/components/vipps-payment-overlay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2, Wallet } from "lucide-react";
+import type { ReactNode } from "react";
 import { Button } from "~/components/ui/button";
 import { toast } from "sonner";
 import { api } from "~/trpc/react";
@@ -37,41 +38,72 @@ export default function VippsPaymentOverlay() {
 
   // Nothing to ask for if they've paid, are already verified, or owe nothing
   // at all — faddere and admins never see a payment prompt.
+  //
+  // Rendering `null` here is NOT the same as rendering nothing extra: the
+  // layout swaps the entire app out for this overlay, so a bare `null` is a
+  // blank page. Reaching this branch means the server said "no access" while
+  // the status says otherwise, which a reload resolves once the flag that
+  // granted access is visible to the layout too.
   if (
     paymentStatus.data?.hasPaid ||
     paymentStatus.data?.isVerified ||
     paymentStatus.data?.isExempt
   ) {
-    return null;
+    return (
+      <Notice
+        title="Betalingen er registrert"
+        body="Vi fant betalingen din, men siden ble lastet før tilgangen var på plass. Last inn siden på nytt for å komme videre."
+        action={
+          <Button
+            onClick={() => window.location.reload()}
+            className="h-11 w-full text-base"
+          >
+            Last inn på nytt
+          </Button>
+        }
+      />
+    );
   }
 
-  // Show loading state while checking status
+  // Status not known yet. Same reasoning as above — this is the whole screen,
+  // so it gets a spinner rather than an empty document.
   if (paymentStatus.isLoading) {
-    return null;
+    return (
+      <Notice
+        title="Laster..."
+        body="Sjekker betalingsstatusen din."
+        action={
+          <Loader2 className="text-muted-foreground mx-auto size-6 animate-spin" />
+        }
+      />
+    );
+  }
+
+  // The status query failed outright — network, session, or server. Silence
+  // here is the same blank page, so say what happened and offer a retry.
+  if (paymentStatus.isError) {
+    return (
+      <Notice
+        title="Kunne ikke hente betalingsstatus"
+        body="Noe gikk galt da vi sjekket om du er registrert. Prøv igjen, eller ta kontakt med FadderKom hvis det fortsetter."
+        action={
+          <Button
+            onClick={() => void paymentStatus.refetch()}
+            className="h-11 w-full text-base"
+          >
+            Prøv igjen
+          </Button>
+        }
+      />
+    );
   }
 
   return (
-    // `overflow-y-auto` på wrapperen og `my-auto` på panelet: dette er den
-    // eneste skjermen en ubetalt bruker ser, og med tastaturet oppe på en liten
-    // telefon ble innholdet før klippet uten noen vei til å scrolle.
-    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/60 p-4 supports-[backdrop-filter]:backdrop-blur-xs">
-      <div className="bg-popover text-popover-foreground ring-foreground/10 my-auto flex w-full max-w-md flex-col gap-6 rounded-xl p-6 ring-1 sm:p-8">
-        <div className="flex flex-col items-center gap-4 text-center">
-          <div className="bg-primary/10 grid size-14 place-items-center rounded-full">
-            <Wallet className="text-primary size-7" />
-          </div>
-          <div className="flex flex-col gap-2">
-            <h2 className="font-heading text-xl font-semibold tracking-tight">
-              Fullfør registreringen
-            </h2>
-            <p className="text-muted-foreground text-sm text-pretty">
-              Du må betale for fadderuka før du kan se innholdet. Betal enkelt
-              med Vipps for å bli registrert som fadderbarn.
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-2">
+    <Notice
+      title="Fullfør registreringen"
+      body="Du må betale for fadderuka før du kan se innholdet. Betal enkelt med Vipps for å bli registrert som fadderbarn."
+      action={
+        <>
           <Button
             onClick={() => initiatePayment.mutate()}
             disabled={initiatePayment.isPending}
@@ -97,7 +129,45 @@ export default function VippsPaymentOverlay() {
               ? "Sjekker betaling..."
               : "Jeg har allerede betalt"}
           </Button>
+        </>
+      }
+    />
+  );
+}
+
+/**
+ * Panelet denne skjermen alltid består av. Overlayet er hele appen for en
+ * bruker uten tilgang, så hver tilstand — også «laster» og «noe gikk galt» —
+ * må ha noe å vise. Ellers er resultatet en blank side.
+ */
+function Notice({
+  title,
+  body,
+  action,
+}: {
+  title: string;
+  body: string;
+  action: ReactNode;
+}) {
+  return (
+    // `overflow-y-auto` på wrapperen og `my-auto` på panelet: dette er den
+    // eneste skjermen en ubetalt bruker ser, og med tastaturet oppe på en liten
+    // telefon ble innholdet før klippet uten noen vei til å scrolle.
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/60 p-4 supports-[backdrop-filter]:backdrop-blur-xs">
+      <div className="bg-popover text-popover-foreground ring-foreground/10 my-auto flex w-full max-w-md flex-col gap-6 rounded-xl p-6 ring-1 sm:p-8">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <div className="bg-primary/10 grid size-14 place-items-center rounded-full">
+            <Wallet className="text-primary size-7" />
+          </div>
+          <div className="flex flex-col gap-2">
+            <h2 className="font-heading text-xl font-semibold tracking-tight">
+              {title}
+            </h2>
+            <p className="text-muted-foreground text-sm text-pretty">{body}</p>
+          </div>
         </div>
+
+        <div className="flex flex-col gap-2">{action}</div>
       </div>
     </div>
   );

--- a/src/server/fadder.ts
+++ b/src/server/fadder.ts
@@ -153,11 +153,22 @@ export function isPaymentExempt(user: {
  *
  * Exempt users are in without paying; everyone else needs the verification a
  * captured payment (or an admin) grants them.
+ *
+ * `hasPaid` counts on its own, and that is the point: the two flags are set
+ * together when Vipps captures, but a payment moved between accounts by hand
+ * sets only `hasPaid`. That left the user locked out of the app while the
+ * payment overlay — which hides itself the moment `hasPaid` is true — rendered
+ * nothing, i.e. a completely blank page with only header and footer. Money
+ * having changed hands is the strongest signal we have; it must never be the
+ * thing that produces less access than no payment at all.
  */
 export function hasAppAccess(user: {
   isAdmin?: boolean | null;
   isFadder?: boolean | null;
   isVerified?: boolean | null;
+  hasPaid?: boolean | null;
 }): boolean {
-  return isPaymentExempt(user) || user.isVerified === true;
+  return (
+    isPaymentExempt(user) || user.isVerified === true || user.hasPaid === true
+  );
 }

--- a/tests/unit/fadder.test.ts
+++ b/tests/unit/fadder.test.ts
@@ -138,4 +138,12 @@ describe("isPaymentExempt / hasAppAccess", () => {
     expect(hasAppAccess({ isAdmin: true, isVerified: false })).toBe(true);
     expect(hasAppAccess({ isVerified: false })).toBe(false);
   });
+
+  // En betaling flyttet mellom kontoer for hånd setter bare `hasPaid`. Uten
+  // dette ble brukeren låst ute samtidig som betalingsoverlayet skjulte seg,
+  // altså en helt blank side.
+  it("gir tilgang når pengene har skiftet hender, selv uten verifisering", () => {
+    expect(hasAppAccess({ hasPaid: true, isVerified: false })).toBe(true);
+    expect(hasAppAccess({ hasPaid: false, isVerified: false })).toBe(false);
+  });
 });


### PR DESCRIPTION
## Bakgrunn

En førsteårsstudent betalte for fadderuka før han fikk koblet Feide til TIHLDE-kontoen, og endte med betalingen på feil konto. Betalingen ble flyttet manuelt til riktig konto. Etterpå fikk han ikke lenger opp betalingsprompten — men heller ikke noe innhold. Siden var helt blank, med bare header og footer.

## Årsak

`hasPaid` («penger har skiftet hender») og `isVerified` («slipper inn») settes normalt samtidig når Vipps capturer, så de følges ad. En betaling flyttet for hånd setter bare `hasPaid`. Da spriker to steder som ikke er enige:

1. `hasAppAccess` så bare på `isVerified`/fadder/admin, så `(authenticated)/layout.tsx` byttet ut hele appen med betalingsoverlayet.
2. Overlayet skjuler seg selv (`return null`) straks `hasPaid` er true.

Overlayet *er* hele skjermen for en bruker uten tilgang, så `null` der er ikke «ingenting ekstra» — det er en blank side. Brukeren var samtidig låst ute av alle tRPC-kall, siden `protectedProcedure` bruker samme predikat.

## Endringer

- **`src/server/fadder.ts`** — `hasAppAccess` godtar nå `hasPaid === true` alene. En betaling skal aldri gi *mindre* tilgang enn ingen betaling.
- **`src/components/vipps-payment-overlay.tsx`** — ingen gren returnerer `null` lenger. «Laster», «kunne ikke hente status» (med retry) og «betalingen er registrert» (med «Last inn på nytt») har hver sin paneltilstand. Panelmarkupen er trukket ut til en delt `Notice`-komponent, så betalingsprompten og de nye tilstandene ser like ut.
- **`tests/unit/fadder.test.ts`** — ny test for `hasPaid: true, isVerified: false`.

## Verifisering

| Sjekk | Resultat |
|---|---|
| `eslint .` | 0 feil (5 warnings, alle fra før) |
| `tsc --noEmit` | rent |
| `next build` | ok |
| `vitest run` | 263/263 |

Den lokale testdatabasen måtte nullstilles først — den hadde en migrasjon fra en annen worktree (`20260806211849_photon_oauth_cutover`) som ikke finnes på denne branchen. Ikke relatert til endringene her.

## Til reviewer

- Semantikken flyttes bevisst: tilgang er nå `fadder || admin || isVerified || hasPaid`. `hasPaid` settes kun av en capturet Vipps-betaling eller manuelt av admin, så dette utvider ikke tilgang for noen som ikke har betalt. `refundPayment` setter `hasPaid: false` igjen.
- `isVerified` røres ikke — den er fortsatt adgangsflagget admin styrer, og `deleteUser`/gruppetildeling bruker den som før.
- Brukeren i saken løses raskest ved å verifisere ham i adminpanelet; denne PR-en hindrer at neste manuelt flyttede betaling gir samme blanke side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)