### PR TITLE
La nye studenter registrere seg uten stud-e-post

### DIFF
--- a/prisma/migrations/20260807130000_local_password_for_pending_accounts/migration.sql
+++ b/prisma/migrations/20260807130000_local_password_for_pending_accounts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "passwordHash" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,14 @@ model User {
     // litt nøtter" to go. FadderKom is who orders the food during fadderuka
     // anyway, so this is the copy that actually gets used.
     allergy       String?
+    // Local password for students who registered here without an @stud.ntnu.no
+    // address. Photon requires them to verify their e-mail before it will let
+    // them sign in, and their TIHLDE membership is not activated until an admin
+    // or a Feide login does it — so without this they could register and pay,
+    // then be locked out of the app they just paid for. Set only at
+    // registration, and cleared the first time a real TIHLDE login succeeds
+    // (see `src/app/api/auth/callback/route.ts`), which is the handover.
+    passwordHash  String?
     isVerified    Boolean   @default(false)
     hasPaid       Boolean   @default(false)
     isAdmin       Boolean   @default(false)

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -202,6 +202,10 @@ export async function GET(request: Request) {
         klasse,
         isAdmin,
         isFadder,
+        // The handover. A local password exists only to bridge the gap until
+        // TIHLDE will answer for this account, and TIHLDE just did — so the
+        // bridge comes down rather than living on as a second, weaker way in.
+        passwordHash: null,
         ...studyGrant,
         ...accessGrant,
       },

--- a/src/app/api/auth/lokal-innlogging/route.ts
+++ b/src/app/api/auth/lokal-innlogging/route.ts
@@ -1,0 +1,115 @@
+import { cookies, headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  createSession,
+} from "~/server/auth/config";
+import { verifyPassword } from "~/server/auth/password";
+import {
+  checkLoginRateLimit,
+  clearLoginFailures,
+  recordFailedLogin,
+} from "~/server/auth/rate-limit";
+import { db } from "~/server/db";
+
+/**
+ * The way back in for students who registered here without an @stud.ntnu.no
+ * address.
+ *
+ * "Logg inn med TIHLDE" cannot serve them yet: Photon refuses a sign-in until
+ * the verification mail is clicked, and their membership is not activated until
+ * an admin or a Feide login does it. They have already paid by then, so leaving
+ * them outside the app is not an option. This accepts the password they chose
+ * at registration, against the local scrypt hash, and mints the same session
+ * every other route would.
+ *
+ * Deliberately talks to nobody: no Photon call, no TIHLDE profile refresh. It
+ * exists precisely for the window where Photon will not answer for this user,
+ * so a dependency on Photon here would defeat the point. Everything derived
+ * from the profile — cohort, study programme, admin status — is refreshed the
+ * first time they do sign in through TIHLDE, which is also when the local hash
+ * is dropped (see `src/app/api/auth/callback/route.ts`).
+ */
+
+const bodySchema = z.object({
+  user_id: z.string().trim().min(1),
+  password: z.string().min(1),
+});
+
+export async function POST(request: Request) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Fyll inn brukernavn og passord." },
+      { status: 400 },
+    );
+  }
+
+  const { user_id, password } = parsed.data;
+  const userId = user_id.toLowerCase();
+
+  const hdrs = await headers();
+  const ip = hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
+
+  // Spend-the-budget check before the lookup, so a blocked attempt costs
+  // nothing. The message is the same whether or not the username exists —
+  // otherwise this would answer that question for free.
+  const limit = await checkLoginRateLimit(userId, ip);
+  if (limit.blocked) {
+    return NextResponse.json(
+      {
+        error: `For mange innloggingsforsøk. Prøv igjen om ${limit.retryAfterMinutes} minutter.`,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(limit.retryAfterMinutes * 60) },
+      },
+    );
+  }
+
+  const user = await db.user.findUnique({
+    where: { tihldeUserId: userId },
+    select: { id: true, passwordHash: true, isVerified: true },
+  });
+
+  // One message for "no such user", "no local password" and "wrong password".
+  // They are the same fact to anyone who is not the account holder, and telling
+  // them apart is how an attacker enumerates who registered here.
+  if (!user || !(await verifyPassword(password, user.passwordHash))) {
+    await recordFailedLogin(userId, ip);
+    return NextResponse.json(
+      {
+        error:
+          "Feil brukernavn eller passord. Har du fått TIHLDE-brukeren din godkjent, logg inn med TIHLDE i stedet.",
+      },
+      { status: 401 },
+    );
+  }
+
+  const { token: sessionToken, expiresAt } = await createSession({
+    userId: user.id,
+    photonAccessToken: null,
+    ipAddress: ip,
+    userAgent: hdrs.get("user-agent"),
+  });
+
+  // Proving they know the password also clears whatever failures came before.
+  await clearLoginFailures(userId, ip);
+
+  const cookieStore = await cookies();
+  cookieStore.set(SESSION_COOKIE, sessionToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+    expires: expiresAt,
+  });
+
+  // `verified` lets the client skip straight to the app for users who don't owe
+  // a payment, instead of bouncing them through the paywall.
+  return NextResponse.json({ ok: true, verified: user.isVerified });
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -8,6 +8,7 @@ import {
   SESSION_MAX_AGE,
   createSession,
 } from "~/server/auth/config";
+import { hashPassword } from "~/server/auth/password";
 import {
   PhotonAuthError,
   PhotonUnavailableError,
@@ -32,38 +33,38 @@ import {
  * registered here got an account that could log in nowhere, and was told "Du må
  * aktiveres som TIHLDE-medlem" when they tried.
  *
- * The password never touches this app's storage now. Photon takes it, hashes
- * it, and owns it from there; the student's next visit signs in through "Logg
- * inn med TIHLDE". We still mint our own session here so the Vipps payment can
- * follow immediately, exactly as before — waiting for a verification mail
- * before letting someone pay would strand them mid-flow.
+ * Photon takes the password, hashes it and owns it from there. We keep a local
+ * hash as well, which is the bridge these students need: Photon will not let
+ * them sign in until they have clicked the verification mail, and their TIHLDE
+ * membership is not activated until an admin or a Feide login does it. Without
+ * it they could register and pay, then be locked out of the app they just paid
+ * for. `POST /api/auth/lokal-innlogging` accepts it, and the first successful
+ * TIHLDE login clears it.
  *
- * The username is no longer chosen. Photon derives it from the @stud.ntnu.no
- * address, which is the student's NTNU username — the same value Lepton used as
- * `user_id`, so it stays the key this app stores everyone under.
+ * The address is deliberately NOT required to be @stud.ntnu.no. Many new
+ * students have not been given theirs when they sign up on stand, and refusing
+ * them is refusing the very group this form exists for. The username is
+ * therefore chosen rather than derived — the form asks for the Feide one — and
+ * passed to Photon explicitly. It stays the key this app stores everyone under.
  */
 
 const bodySchema = z.object({
   full_name: z.string().trim().min(1, "Fyll inn fullt navn."),
-  email: z
+  email: z.string().trim().toLowerCase().email("Ugyldig e-postadresse."),
+  user_id: z
     .string()
     .trim()
     .toLowerCase()
-    .email("Ugyldig e-postadresse.")
-    .refine(
-      (v) => v.endsWith("@stud.ntnu.no"),
-      "Bruk NTNU-e-posten din (@stud.ntnu.no) — den er brukeren din på tihlde.org.",
-    ),
+    .min(1, "Feltet er påkrevd")
+    // Match Kvark's exact wording; the 15-char cap mirrors TIHLDE's model limit
+    // (Kvark leaves that to the backend — we surface it up front).
+    .max(15, "Brukernavn kan være maks 15 tegn.")
+    .refine((v) => !v.includes("@"), "Brukernavn må være uten @stud.ntnu.no"),
   password: z.string().min(8, "Passordet må være minst 8 tegn."),
   study: z.enum(REGISTRATION_STUDY_SLUGS, {
     errorMap: () => ({ message: "Velg hvilken linje du går på." }),
   }),
 });
-
-/** The NTNU username inside a @stud.ntnu.no address — what Photon will assign. */
-function usernameFromEmail(email: string): string {
-  return email.split("@")[0] ?? email;
-}
 
 export async function POST(request: Request) {
   const parsed = bodySchema.safeParse(await request.json().catch(() => null));
@@ -75,8 +76,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { full_name, email, password, study } = parsed.data;
-  const userId = usernameFromEmail(email);
+  const { full_name, email, user_id: userId, password, study } = parsed.data;
   const studieretning = studyLabelForSlug(study);
 
   // This route creates real TIHLDE accounts, so an unthrottled one is an open
@@ -113,10 +113,17 @@ export async function POST(request: Request) {
   });
 
   if (clash) {
+    // Point at the field that actually collided. Now that the username is
+    // chosen again, the two cases come apart: someone re-registering under a
+    // new username owns the address, while someone picking a taken username
+    // may be a different person entirely.
+    const sameUsername = clash.tihldeUserId === userId;
     return NextResponse.json(
       {
-        error: `Du er allerede registrert som «${clash.tihldeUserId}». Logg inn med TIHLDE i stedet.`,
-        field: "email",
+        error: sameUsername
+          ? `Brukernavnet «${userId}» er allerede registrert. Logg inn i stedet.`
+          : `E-postadressen er allerede registrert som «${clash.tihldeUserId}». Logg inn i stedet.`,
+        field: sameUsername ? "user_id" : "email",
         existingUserId: clash.tihldeUserId,
       },
       { status: 409 },
@@ -133,6 +140,9 @@ export async function POST(request: Request) {
         name: full_name,
         email,
         studieretning,
+        // The bridge into the app until TIHLDE takes over. Hashed with scrypt;
+        // the plaintext is never stored or logged.
+        passwordHash: await hashPassword(password),
         isVerified: false,
         hasPaid: false,
         isAdmin: false,
@@ -145,6 +155,7 @@ export async function POST(request: Request) {
         email,
         password,
         studyProgramSlug: study,
+        username: userId,
       });
     } catch (err) {
       await db.user

--- a/src/app/logg-inn/page.tsx
+++ b/src/app/logg-inn/page.tsx
@@ -1,20 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Card, CardDescription, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { authClient } from "~/lib/auth-client";
 import { REGISTRATION_STUDIES } from "~/lib/majors";
 
 /**
- * "Logg inn med TIHLDE".
+ * "Logg inn med TIHLDE", plus the local fallback.
  *
- * No password field any more: the student types it on tihlde.org, and we get
- * back a scoped token. Everything this page still asks for is the one thing
- * their TIHLDE profile cannot tell us — see `nyttStudium` below.
+ * Almost everyone types their password on tihlde.org and comes back with a
+ * scoped token. The exception is students who registered here without an
+ * @stud.ntnu.no address: their TIHLDE account is not usable until it is
+ * activated, so they get the username/password form at the bottom.
  */
 function LoggInnSkjema() {
+  const router = useRouter();
+  const [lokal, setLokal] = useState(false);
+  const [laster, setLaster] = useState(false);
   // Den som begynner på et nytt studium i høst må si fra selv: TIHLDE-profilen
   // deres viser fortsatt bachelorlinja og bachelorkullet, så uten dette valget
   // leses de som 2. klassing — altså fadder — og slipper å betale.
@@ -29,6 +36,29 @@ function LoggInnSkjema() {
     nyttStudium && study
       ? `/api/auth/logg-inn?study=${encodeURIComponent(study)}`
       : "/api/auth/logg-inn";
+
+  async function handleLokalInnlogging(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLaster(true);
+
+    const data = new FormData(e.currentTarget);
+    const { error: innloggingsfeil } = await authClient.localLogin({
+      user_id: (data.get("user_id") as string)?.trim(),
+      password: data.get("password") as string,
+    });
+
+    if (innloggingsfeil) {
+      setError(innloggingsfeil);
+      setLaster(false);
+      return;
+    }
+
+    // Forsiden uansett: betalingsmuren der slipper inn den som har betalt og
+    // tar imot den som ikke har, så det er ikke denne siden sin avgjørelse.
+    router.push("/");
+    router.refresh();
+  }
 
   return (
     <div className="flex flex-1 items-center justify-center px-4 py-8">
@@ -125,6 +155,63 @@ function LoggInnSkjema() {
                   Registrer deg her
                 </Link>
               </p>
+
+              {/* Broen for de som registrerte seg her uten NTNU-e-post.
+                  TIHLDE-brukeren deres er ikke aktivert ennå, så «Logg inn med
+                  TIHLDE» avviser dem — men de har allerede betalt. Bevisst
+                  nedtonet: alle andre skal bruke knappen over. */}
+              <div className="border-input border-t pt-5">
+                {!lokal ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setLokal(true);
+                      setError(null);
+                    }}
+                    className="text-muted-foreground w-full text-center text-sm underline"
+                  >
+                    Registrerte du deg her uten NTNU-e-post? Logg inn med
+                    brukernavn og passord
+                  </button>
+                ) : (
+                  <form onSubmit={handleLokalInnlogging} className="grid gap-4">
+                    <p className="text-muted-foreground text-sm">
+                      Bruk brukernavnet og passordet du valgte da du registrerte
+                      deg. Når TIHLDE-brukeren din er aktivert, logger du inn
+                      med TIHLDE i stedet.
+                    </p>
+                    <div className="grid gap-2">
+                      <Label htmlFor="lokal-user-id">Brukernavn</Label>
+                      <Input
+                        id="lokal-user-id"
+                        name="user_id"
+                        autoComplete="username"
+                        required
+                        className="h-12"
+                      />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="lokal-passord">Passord</Label>
+                      <Input
+                        id="lokal-passord"
+                        name="password"
+                        type="password"
+                        autoComplete="current-password"
+                        required
+                        className="h-12"
+                      />
+                    </div>
+                    <Button
+                      type="submit"
+                      variant="secondary"
+                      disabled={laster}
+                      className="h-12 w-full text-base"
+                    >
+                      {laster ? "Logger inn …" : "Logg inn"}
+                    </Button>
+                  </form>
+                )}
+              </div>
             </div>
           </div>
         </Card>

--- a/src/app/registrering/page.tsx
+++ b/src/app/registrering/page.tsx
@@ -34,6 +34,7 @@ export default function RegistreringPage() {
     const formData = new FormData(e.currentTarget);
     const full_name = (formData.get("full_name") as string)?.trim();
     const email = (formData.get("email") as string)?.trim();
+    const user_id = (formData.get("user_id") as string)?.trim();
     const password = formData.get("password") as string;
     const allergies = (formData.get("allergies") as string)?.trim();
 
@@ -52,6 +53,7 @@ export default function RegistreringPage() {
     } = await authClient.register({
       full_name,
       email,
+      user_id,
       password,
       study,
     });
@@ -160,7 +162,7 @@ export default function RegistreringPage() {
 
               <div className="grid gap-2">
                 <Label htmlFor="reg-email">
-                  NTNU-e-post <span className="text-destructive">*</span>
+                  E-post <span className="text-destructive">*</span>
                 </Label>
                 <Input
                   id="reg-email"
@@ -173,8 +175,31 @@ export default function RegistreringPage() {
                   className="h-12"
                 />
                 <p className="text-muted-foreground text-xs">
-                  Bruk NTNU-e-posten din. Brukernavnet ditt på tihlde.org blir
-                  det som står foran @stud.ntnu.no.
+                  Bruk NTNU-e-posten din hvis du har fått den. Har du ikke det
+                  ennå, går det fint med en privat adresse.
+                </p>
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="reg-user-id">
+                  Brukernavn <span className="text-destructive">*</span>{" "}
+                  <span className="text-muted-foreground font-normal">
+                    (helst Feide)
+                  </span>
+                </Label>
+                <Input
+                  id="reg-user-id"
+                  name="user_id"
+                  autoComplete="username"
+                  required
+                  maxLength={15}
+                  placeholder="olanord"
+                  aria-invalid={errorField === "user_id"}
+                  className="h-12"
+                />
+                <p className="text-muted-foreground text-xs">
+                  Dette blir brukernavnet ditt på tihlde.org. Bruk Feide-brukernavnet
+                  ditt — da blir det samme konto når du senere logger inn med Feide.
                 </p>
               </div>
 

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,9 +1,9 @@
 /**
  * Thin client-side auth helpers that talk to our own /api/auth routes.
  *
- * Signing IN is not here: it is a plain link to `/api/auth/logg-inn`, which
- * redirects to Photon. There is nothing to submit, and nothing this app could
- * do with a password.
+ * Signing in with TIHLDE is not here: it is a plain link to
+ * `/api/auth/logg-inn`, which redirects to Photon. `localLogin` is the
+ * exception, and only for students whose TIHLDE account is not usable yet.
  */
 
 interface Result {
@@ -13,10 +13,20 @@ interface Result {
 /** New-user self-registration payload (mirrors /api/auth/register). */
 export interface RegisterInput {
   full_name: string;
-  /** Must be @stud.ntnu.no — Photon derives the username from it. */
+  /**
+   * Any address. New students often have not been given their @stud.ntnu.no
+   * one when they sign up on stand.
+   */
   email: string;
+  /** The TIHLDE username, ideally the Feide one. Chosen, not derived. */
+  user_id: string;
   password: string;
   study: string;
+}
+
+interface LocalLoginResult extends Result {
+  /** Whether they already have app access, so the form can skip the paywall. */
+  verified?: boolean;
 }
 
 interface RegisterResult extends Result {
@@ -69,6 +79,35 @@ export const authClient = {
       return { error, field, existingUserId };
     }
     return { error: null };
+  },
+
+  /**
+   * Log in with the password chosen at registration.
+   *
+   * Only works while the TIHLDE account cannot be used yet — the hash is
+   * dropped the first time they sign in through TIHLDE.
+   */
+  async localLogin(input: {
+    user_id: string;
+    password: string;
+  }): Promise<LocalLoginResult> {
+    const res = await fetch("/api/auth/lokal-innlogging", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+
+    if (!res.ok) {
+      return {
+        error: await readError(
+          res,
+          "Fikk ikke svar fra serveren. Sjekk nettet og prøv igjen.",
+        ),
+      };
+    }
+
+    const body = (await res.json().catch(() => ({}))) as { verified?: boolean };
+    return { error: null, verified: body.verified };
   },
 
   /** Destroy the current session. */

--- a/src/server/auth/password.ts
+++ b/src/server/auth/password.ts
@@ -1,0 +1,53 @@
+import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
+
+/**
+ * Local password hashing, used only as a bridge for students who registered
+ * here without an @stud.ntnu.no address.
+ *
+ * Photon will not let them sign in until they have clicked the verification
+ * mail, and their TIHLDE membership is not activated until an admin or a Feide
+ * login does it. Without a local password they could register and pay, then be
+ * locked out of the app they just paid for. So we keep a hash of the password
+ * they chose during registration and accept it here until TIHLDE takes over.
+ * The hash is dropped the first time a real TIHLDE login succeeds — see
+ * `src/app/api/auth/callback/route.ts`.
+ *
+ * scrypt from node:crypto keeps this dependency-free; parameters follow the
+ * OWASP minimum (N=2^16, r=8, p=1).
+ */
+
+const KEY_LENGTH = 64;
+const SCRYPT_OPTIONS = { N: 65536, r: 8, p: 1, maxmem: 128 * 65536 * 8 * 2 };
+
+/** Promise wrapper around node's callback-style scrypt. */
+function derive(password: string, salt: Buffer): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, KEY_LENGTH, SCRYPT_OPTIONS, (err, key) => {
+      if (err) reject(err);
+      else resolve(key);
+    });
+  });
+}
+
+/** Hash a plaintext password into a self-describing `scrypt:salt:hash` string. */
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16);
+  const derived = await derive(password, salt);
+  return `scrypt:${salt.toString("hex")}:${derived.toString("hex")}`;
+}
+
+/** Constant-time check of a plaintext password against a stored hash. */
+export async function verifyPassword(
+  password: string,
+  stored: string | null | undefined,
+): Promise<boolean> {
+  if (!stored) return false;
+  const [scheme, saltHex, hashHex] = stored.split(":");
+  if (scheme !== "scrypt" || !saltHex || !hashHex) return false;
+
+  const expected = Buffer.from(hashHex, "hex");
+  if (expected.length !== KEY_LENGTH) return false;
+
+  const derived = await derive(password, Buffer.from(saltHex, "hex"));
+  return timingSafeEqual(derived, expected);
+}

--- a/src/server/auth/photon.ts
+++ b/src/server/auth/photon.ts
@@ -326,15 +326,24 @@ export function isMemberOfAnyGroup(
  * could approve them — every student who registered here got an account that
  * could not log in anywhere, including here.
  *
- * Photon owns the rules: the address must be @stud.ntnu.no, the username is
- * derived from it rather than chosen, and a verification mail goes out. We
+ * Photon owns the password rules and sends the verification mail. We
  * authenticate with an API key, so this must only run on the server.
+ *
+ * `username` is what lets a student without an @stud.ntnu.no address register
+ * at all. Photon derives the username from the address when none is given, and
+ * refuses anything that is not a stud address — which locks out exactly the
+ * new students this form exists for, since many have not been given their NTNU
+ * address yet. Passing it explicitly is the contract Lepton had, and the form
+ * asks for the Feide username, so the account they create here *is* their NTNU
+ * identity: a later Feide login lands on the same account rather than a second
+ * one.
  */
 export async function photonCreateUser(input: {
   name: string;
   email: string;
   password: string;
   studyProgramSlug: string;
+  username?: string;
 }): Promise<{ id: string; username: string; email: string }> {
   const apiKey = env.PHOTON_REGISTER_API_KEY;
   if (!apiKey) {

--- a/src/server/auth/rate-limit.ts
+++ b/src/server/auth/rate-limit.ts
@@ -9,6 +9,91 @@ export interface RateLimitVerdict {
 }
 
 /**
+ * Throttling for the local password login.
+ *
+ * Every other way into this app is answered by Photon, who absorbs the
+ * brute-force problem. `POST /api/auth/lokal-innlogging` is the exception: it
+ * opens an account against a password *we* verify, so an unthrottled endpoint
+ * there is worth guessing against.
+ *
+ * Counters live in Postgres rather than in memory: on Vercel the app scales out
+ * across instances, so an in-memory counter would only limit whichever instance
+ * happened to serve the request — exactly the guarantee an attacker gets to
+ * ignore by sending requests faster.
+ *
+ * Only failures are recorded, and a successful login clears them, so a user who
+ * mistypes a few times and then gets it right is never held back.
+ */
+const WINDOW_MS = 15 * 60 * 1000;
+
+/** Failed attempts per username before we stop answering. */
+const MAX_PER_USER = 10;
+/** Failed attempts from one IP, across usernames — catches spraying. */
+const MAX_PER_IP = 30;
+
+const userKey = (userId: string) => `user:${userId.trim().toLowerCase()}`;
+const ipKey = (ip: string) => `ip:${ip}`;
+
+/** Whether this username/IP has spent its budget. Checked before any lookup. */
+export async function checkLoginRateLimit(
+  userId: string,
+  ip: string | null,
+): Promise<RateLimitVerdict> {
+  const since = new Date(Date.now() - WINDOW_MS);
+  const keys = ip ? [userKey(userId), ipKey(ip)] : [userKey(userId)];
+
+  const attempts = await db.loginAttempt.findMany({
+    where: { key: { in: keys }, createdAt: { gte: since } },
+    select: { key: true, createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const forUser = attempts.filter((a) => a.key === keys[0]);
+  const forIp = ip ? attempts.filter((a) => a.key === ipKey(ip)) : [];
+
+  const overUser = forUser.length >= MAX_PER_USER;
+  const overIp = forIp.length >= MAX_PER_IP;
+  if (!overUser && !overIp) return { blocked: false, retryAfterMinutes: 0 };
+
+  // The block lifts when the oldest attempt in the offending bucket ages out.
+  const oldest = (overUser ? forUser : forIp)[0]!.createdAt;
+  const msLeft = oldest.getTime() + WINDOW_MS - Date.now();
+  return {
+    blocked: true,
+    retryAfterMinutes: Math.max(1, Math.ceil(msLeft / 60_000)),
+  };
+}
+
+/** Record a failed attempt and drop rows that have aged out of the window. */
+export async function recordFailedLogin(
+  userId: string,
+  ip: string | null,
+): Promise<void> {
+  const rows = [{ key: userKey(userId) }];
+  if (ip) rows.push({ key: ipKey(ip) });
+
+  await db.loginAttempt.createMany({ data: rows });
+  // Scoped to this counter's own keys. An unscoped delete would also take the
+  // `register-ip:` rows, which run on a window four times as long — quietly
+  // handing back registration budget every time someone mistypes a password.
+  await db.loginAttempt.deleteMany({
+    where: {
+      key: { not: { startsWith: "register-ip:" } },
+      createdAt: { lt: new Date(Date.now() - WINDOW_MS) },
+    },
+  });
+}
+
+/** Wipe the counters for a username/IP after they prove they know the password. */
+export async function clearLoginFailures(
+  userId: string,
+  ip: string | null,
+): Promise<void> {
+  const keys = ip ? [userKey(userId), ipKey(ip)] : [userKey(userId)];
+  await db.loginAttempt.deleteMany({ where: { key: { in: keys } } });
+}
+
+/**
  * Registration throttling.
  *
  * `POST /api/auth/register` forwards straight to Photon's user-creation endpoint,

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -45,6 +45,7 @@ export async function createUser(
     klasse: string | null;
     isFadder: boolean;
     fadderOverride: boolean | null;
+    passwordHash: string | null;
     createdAt: Date;
   }> = {},
 ) {
@@ -63,6 +64,7 @@ export async function createUser(
       klasse: overrides.klasse ?? null,
       isFadder: overrides.isFadder ?? false,
       fadderOverride: overrides.fadderOverride ?? null,
+      passwordHash: overrides.passwordHash ?? null,
       ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
     },
   });

--- a/tests/integration/auth-callback.route.test.ts
+++ b/tests/integration/auth-callback.route.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET as callback } from "~/app/api/auth/callback/route";
+import { hashPassword, verifyPassword } from "~/server/auth/password";
+
+import { createUser, db } from "../helpers/db";
+import { fetchMock, json } from "../helpers/fetch-mock";
+import { cookieJar, resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+const STATE = "teststate";
+const VERIFIER = "testverifier";
+const PASSORD = "hemmeligpassord";
+
+/** An id token payload, base64url-encoded the way `readIdToken` reads it. */
+function idToken(claims: Record<string, unknown>): string {
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+function stubPhoton(
+  overrides: {
+    username?: string;
+    studyStartYear?: number | null;
+    groups?: { slug: string; role: string }[];
+  } = {},
+) {
+  const username = overrides.username ?? "ola";
+
+  fetchMock.on("POST", "/api/auth/oauth2/token", () =>
+    json({
+      access_token: "photon-access-token",
+      id_token: idToken({
+        sub: "photon-sub",
+        email: "ola@stud.ntnu.no",
+        name: "Ola Nordmann",
+        preferred_username: username,
+      }),
+    }),
+  );
+
+  // Profilen slås opp på `sub` fra id-tokenet, ikke på brukernavnet.
+  fetchMock.on("GET", "/api/user/photon-sub", () =>
+    json({
+      id: "photon-sub",
+      name: "Ola Nordmann",
+      username,
+      image: null,
+      studyProgram: null,
+      studyStartYear:
+        overrides.studyStartYear === undefined ? 2026 : overrides.studyStartYear,
+      groups: overrides.groups ?? [],
+    }),
+  );
+}
+
+const get = () =>
+  callback(
+    new Request(
+      `https://fadderuka.test/api/auth/callback?code=testcode&state=${STATE}`,
+    ),
+  );
+
+beforeEach(() => {
+  resetNextHeaders({ "user-agent": "vitest" });
+  cookieJar.seed("fadderuke.oauth_state", STATE);
+  cookieJar.seed("fadderuke.oauth_verifier", VERIFIER);
+});
+
+describe("GET /api/auth/callback", () => {
+  /**
+   * The handover. A local password exists only to bridge the gap until TIHLDE
+   * will answer for this account — leaving it in place afterwards would keep a
+   * second, weaker way into an account that no longer needs one.
+   */
+  it("nullstiller det lokale passordet ved første TIHLDE-innlogging", async () => {
+    const user = await createUser({
+      tihldeUserId: "ola",
+      passwordHash: await hashPassword(PASSORD),
+    });
+    stubPhoton();
+
+    await get();
+
+    const etter = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(etter.passwordHash).toBeNull();
+    await expect(verifyPassword(PASSORD, etter.passwordHash)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("matcher fortsatt eksisterende brukere på tihldeUserId", async () => {
+    const user = await createUser({ tihldeUserId: "ola", name: "Gammelt Navn" });
+    stubPhoton();
+
+    await get();
+
+    // Ingen ny rad: den eksisterende ble oppdatert.
+    await expect(db.user.count()).resolves.toBe(1);
+    await expect(
+      db.user.findUniqueOrThrow({ where: { id: user.id } }),
+    ).resolves.toMatchObject({ name: "Ola Nordmann", tihldeUserId: "ola" });
+  });
+});

--- a/tests/integration/auth-lokal-innlogging.route.test.ts
+++ b/tests/integration/auth-lokal-innlogging.route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as lokalInnlogging } from "~/app/api/auth/lokal-innlogging/route";
+import { SESSION_COOKIE } from "~/server/auth/config";
+import { hashPassword } from "~/server/auth/password";
+
+import { createUser, db } from "../helpers/db";
+import { lastSetCookie, resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+const PASSORD = "hemmeligpassord";
+
+const post = (body: unknown) =>
+  lokalInnlogging(
+    new Request("https://fadderuka.test/api/auth/lokal-innlogging", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+
+/** A student who registered here without an NTNU address. */
+async function createPendingStudent(
+  overrides: Parameters<typeof createUser>[0] = {},
+) {
+  return createUser({
+    tihldeUserId: "ola",
+    email: "ola@gmail.com",
+    passwordHash: await hashPassword(PASSORD),
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  resetNextHeaders({ "user-agent": "vitest" });
+});
+
+describe("POST /api/auth/lokal-innlogging", () => {
+  it("slipper inn den som registrerte seg uten NTNU-e-post", async () => {
+    const user = await createPendingStudent({ isVerified: true, hasPaid: true });
+
+    const response = await post({ user_id: "ola", password: PASSORD });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, verified: true });
+
+    // Ingen har logget inn på TIHLDE-kontoen, så sesjonen bærer ikke noe token.
+    const session = await db.session.findFirstOrThrow({
+      where: { userId: user.id },
+    });
+    expect(session.photonAccessToken).toBeNull();
+    expect(lastSetCookie(SESSION_COOKIE)?.value).toBe(session.token);
+  });
+
+  it("godtar brukernavn uansett store og små bokstaver", async () => {
+    await createPendingStudent();
+
+    const response = await post({ user_id: "  OLA  ", password: PASSORD });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("avviser feil passord uten å opprette sesjon", async () => {
+    const user = await createPendingStudent();
+
+    const response = await post({ user_id: "ola", password: "feilpassord" });
+
+    expect(response.status).toBe(401);
+    await expect(
+      db.session.findFirst({ where: { userId: user.id } }),
+    ).resolves.toBeNull();
+  });
+
+  /**
+   * De tre måtene å mislykkes på må se like ut utenfra. Skiller de seg, kan
+   * hvem som helst spørre seg fram til hvem som har registrert seg her.
+   */
+  it("skiller ikke ukjent bruker fra feil passord fra manglende hash", async () => {
+    await createPendingStudent();
+    await createUser({ tihldeUserId: "kari", passwordHash: null });
+
+    const svar = await Promise.all([
+      post({ user_id: "finnesikke", password: PASSORD }),
+      post({ user_id: "ola", password: "feilpassord" }),
+      post({ user_id: "kari", password: PASSORD }),
+    ]);
+
+    const meldinger = await Promise.all(
+      svar.map(async (r) => ((await r.json()) as { error: string }).error),
+    );
+
+    expect(svar.map((r) => r.status)).toEqual([401, 401, 401]);
+    expect(new Set(meldinger).size).toBe(1);
+  });
+
+  /**
+   * Brukere som har fått TIHLDE-kontoen aktivert har fått hashen nullstilt i
+   * callback-ruten. Da er dette ikke lenger en vei inn for dem.
+   */
+  it("stenger ute den som har gått over til TIHLDE-innlogging", async () => {
+    await createUser({
+      tihldeUserId: "aktivert",
+      passwordHash: null,
+      isVerified: true,
+    });
+
+    const response = await post({ user_id: "aktivert", password: PASSORD });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rate-limiter etter gjentatte feil, og nullstiller ved suksess", async () => {
+    await createPendingStudent();
+
+    for (let i = 0; i < 10; i++) {
+      await post({ user_id: "ola", password: "feilpassord" });
+    }
+
+    const blokkert = await post({ user_id: "ola", password: PASSORD });
+    expect(blokkert.status).toBe(429);
+    expect(blokkert.headers.get("Retry-After")).not.toBeNull();
+
+    // Riktig passord etter at telleren er tømt skal både slippe inn og fjerne
+    // resten av forsøkene, så et par skrivefeil aldri henger igjen.
+    await db.loginAttempt.deleteMany({});
+    const ok = await post({ user_id: "ola", password: PASSORD });
+    expect(ok.status).toBe(200);
+    await expect(db.loginAttempt.count()).resolves.toBe(0);
+  });
+
+  it("krever både brukernavn og passord", async () => {
+    const response = await post({ user_id: "ola" });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/integration/auth-register.route.test.ts
+++ b/tests/integration/auth-register.route.test.ts
@@ -20,6 +20,7 @@ const post = (body: unknown) =>
 const FORM = {
   full_name: "Ola Nordmann",
   email: "Ola@stud.ntnu.no",
+  user_id: "ola",
   password: "hemmeligpassord",
   study: "dataingenir",
 };
@@ -48,18 +49,17 @@ describe("POST /api/auth/register", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
 
-    // Photon eier brukernavnet og utleder det fra e-posten, så vi sender bare
-    // navn, e-post, passord og linje.
+    // Brukernavnet velges av studenten og sendes eksplisitt: uten det ville
+    // Photon utledet det av e-posten og avvist alt som ikke er @stud.ntnu.no.
     const [call] = fetchMock.callsTo("/api/user/register");
     expect(call?.body).toEqual({
       name: "Ola Nordmann",
       email: "ola@stud.ntnu.no",
       password: FORM.password,
       studyProgramSlug: "dataingenir",
+      username: "ola",
     });
 
-    // Brukernavnet vi lagrer lokalt er e-postens lokaldel — samme verdi som
-    // Photon tildeler, og nøkkelen alle radene her ligger under.
     const user = await db.user.findUniqueOrThrow({
       where: { tihldeUserId: "ola" },
     });
@@ -76,12 +76,48 @@ describe("POST /api/auth/register", () => {
     expect(lastSetCookie(SESSION_COOKIE)?.value).toBe(session.token);
   });
 
-  it("krever NTNU-e-post, siden brukernavnet utledes av den", async () => {
+  // Hele poenget med endringen: den ferske studenten som ikke har fått
+  // NTNU-adressen sin ennå skal kunne registrere seg og betale.
+  it("godtar privat e-post, siden brukernavnet velges og ikke utledes", async () => {
+    fetchMock.on("POST", "/api/user/register", photonCreated);
+
     const response = await post({ ...FORM, email: "ola@gmail.com" });
 
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({ field: "email" });
-    // Ingenting skal ha nådd Photon.
+    expect(response.status).toBe(200);
+
+    const [call] = fetchMock.callsTo("/api/user/register");
+    expect(call?.body).toMatchObject({
+      email: "ola@gmail.com",
+      username: "ola",
+    });
+
+    await expect(
+      db.user.findUniqueOrThrow({ where: { tihldeUserId: "ola" } }),
+    ).resolves.toMatchObject({ email: "ola@gmail.com" });
+  });
+
+  // Broen inn i appen mens TIHLDE-kontoen ikke er brukbar. Uten den kunne de
+  // registrere seg og betale, og så bli stengt ute av det de nettopp betalte for.
+  it("lagrer et lokalt passord-hash, aldri klarteksten", async () => {
+    fetchMock.on("POST", "/api/user/register", photonCreated);
+
+    await post(FORM);
+
+    const user = await db.user.findUniqueOrThrow({
+      where: { tihldeUserId: "ola" },
+    });
+    expect(user.passwordHash).toMatch(/^scrypt:[0-9a-f]+:[0-9a-f]+$/);
+    expect(user.passwordHash).not.toContain(FORM.password);
+  });
+
+  it("avviser brukernavn med @ og over 15 tegn", async () => {
+    for (const user_id of ["ola@stud.ntnu.no", "a".repeat(16)]) {
+      const response = await post({ ...FORM, user_id });
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        field: "user_id",
+      });
+    }
     expect(fetchMock.callsTo("/api/user/register")).toHaveLength(0);
   });
 
@@ -114,8 +150,24 @@ describe("POST /api/auth/register", () => {
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({
       existingUserId: "ola",
+      field: "user_id",
     });
     expect(fetchMock.callsTo("/api/user/register")).toHaveLength(0);
+  });
+
+  // Nå som brukernavnet velges igjen, er «e-posten er tatt» og «brukernavnet er
+  // tatt» to ulike feil. Å peke på feil felt sender studenten på jakt etter noe
+  // som ikke er galt.
+  it("peker på e-postfeltet når det er adressen som er tatt", async () => {
+    await createUser({ tihldeUserId: "kari", email: "ola@stud.ntnu.no" });
+
+    const response = await post(FORM);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      existingUserId: "kari",
+      field: "email",
+    });
   });
 
   it("sier fra når Photon ikke svarer, i stedet for å skylde på skjemaet", async () => {


### PR DESCRIPTION
Ferske studenter har ofte ikke fått `@stud.ntnu.no`-adressen sin når de står på stand under fadderuka. OAuth-cutoveren gjorde adressen obligatorisk — fordi Photon utleder brukernavnet fra den — og stengte dermed ute nøyaktig den gruppa registreringsskjemaet finnes for.

Dette gjenoppretter flyten som fungerte fram til cutoveren, på Photon i stedet for Lepton.

## Hva som endres

**Brukernavnet velges igjen av studenten** og sendes eksplisitt til Photon, i stedet for å utledes av adressen. Skjemaet ber om Feide-brukernavnet, så kontoen de lager her *er* NTNU-identiteten deres — en senere Feide-innlogging lander på samme konto i stedet for på en ny.

**Det lokale passordet er tilbake.** Photon slipper dem ikke inn før verifiserings-e-posten er klikket, og TIHLDE-medlemskapet aktiveres ikke før en admin eller en Feide-innlogging gjør det. Uten broen kunne de registrere seg og betale, og så bli stengt ute av det de nettopp betalte for. `POST /api/auth/lokal-innlogging` tar imot passordet, og callback-ruten nullstiller hashen ved første ekte TIHLDE-innlogging — det er overleveringen.

## Avhengighet

Krever TIHLDE/Photon#… (eksplisitt `username` på `POST /api/user/register`). **Uten den avvises private adresser fortsatt med 400 fra Photon**, så Photon må deployes først.

## Migrasjon

`20260807130000_local_password_for_pending_accounts` legger tilbake `User.passwordHash`. Tidsstempelet er satt etter `20260807120000_gruppe_publication`, som prod allerede har kjørt, for å unngå en out-of-order-migrasjon. Vercel kjører ikke `prisma migrate deploy` — den må kjøres manuelt.

## Opprydding på veien

Opprydningen i innloggingstelleren er avgrenset til sine egne nøkler. Den gamle varianten slettet alle rader eldre enn 15 minutter, også registreringstellerne, som kjører på et fire ganger så langt vindu — altså ga den tilbake registreringsbudsjett hver gang noen skrev feil passord.

## Verifisering

- `bun run typecheck`, `bun run lint` (0 feil), `bun run build` — rent
- `bun run test` — 217 tester i 17 filer, mot en fersk migrert testdatabase
- Nye tester: privat e-post godtas, hash lagres og aldri klartekst, brukernavnvalidering, riktig felt ved duplikat, lokal innlogging inkludert rate limiting og at ukjent bruker / feil passord / manglende hash ikke lar seg skille fra hverandre, og at hashen nullstilles ved første TIHLDE-innlogging

## Merk

Denne PR-en løser ikke at de **113 som allerede har betalt** ikke kommer inn — hashene deres ble slettet av `DROP COLUMN` i cutover-migrasjonen og må gjenopprettes fra Neon-historikken separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)