### PR TITLE
«Glemt passord», og veien tilbake for de 130 (mot dev)

### DIFF
--- a/prisma/migrations/20260807134002_password_reset_token/migration.sql
+++ b/prisma/migrations/20260807134002_password_reset_token/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,25 @@ model User {
     groupMessages GroupMessage[]
     notifications Notification[]
     payments      Payment[]
+    passwordResets PasswordResetToken[]
+}
+
+model PasswordResetToken {
+    // A "glemt passord"-link, for accounts that log in with the local password
+    // chosen at registration (tihlde.org owns the password for everyone else).
+    //
+    // Only the SHA-256 of the token is stored: the plaintext lives in the email
+    // and nowhere else, so a leaked database does not hand over live reset
+    // links. Single-use (`usedAt`) and short-lived (`expiresAt`).
+    id        String    @id @default(cuid())
+    tokenHash String    @unique
+    userId    String
+    user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+    expiresAt DateTime
+    usedAt    DateTime?
+    createdAt DateTime  @default(now())
+
+    @@index([userId])
 }
 
 model AppSetting {

--- a/scripts/marker-passord-for-reset.ts
+++ b/scripts/marker-passord-for-reset.ts
@@ -1,0 +1,117 @@
+/**
+ * One-off repair after the OAuth cutover destroyed the stored passwords.
+ *
+ * `20260806211849_photon_oauth_cutover` dropped `User.passwordHash` from
+ * production. That was the only credential the students who signed up through
+ * Fadderuka's own form had — 130 of them, 113 of whom had already paid — and
+ * they have no usable TIHLDE account to fall back on, because theirs were
+ * created in Lepton after the Photon migration. They are locked out of the app
+ * they paid for.
+ *
+ * The hashes are not recoverable: Neon runs a six-hour history window on the
+ * free plan, and the migration ran roughly eight hours before the earliest
+ * restorable point. There are no snapshots.
+ *
+ * So this restores the one fact that can be restored — that these accounts have
+ * a local password — by writing the `RESET_REQUIRED` sentinel. That is not a
+ * valid hash, so nobody can sign in with it; but it is non-null, which is what
+ * `glemt-passord` requires before it will send a reset link. The student sets a
+ * new password themselves from there.
+ *
+ * Usage:
+ *   bun run scripts/marker-passord-for-reset.ts [--apply]
+ *
+ * Prints who it would touch and changes nothing unless `--apply` is passed.
+ * READ THE DRY RUN FIRST: the selection is a heuristic (see below), and a
+ * mismatch would hand a TIHLDE-authenticated account a local password it should
+ * never have.
+ *
+ * Idempotent. Rows that already hold a real hash are never touched.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+import { RESET_REQUIRED } from "../src/server/auth/password";
+
+const db = new PrismaClient();
+
+/**
+ * Who counts as self-registered.
+ *
+ * There is no column recording it — the accounts predate the flag we would want
+ * — so this reconstructs it from what a self-registration leaves behind:
+ *
+ *   - a private address, because the old form asked for any e-mail and TIHLDE
+ *     members arrive with whatever their profile carries;
+ *   - no `klasse`, because the cohort is only ever written by a TIHLDE profile
+ *     read, which these accounts have never had;
+ *   - not an admin, who all came in through TIHLDE;
+ *   - `passwordHash` null, which after the drop is everyone, but keeps the
+ *     script idempotent once it has run.
+ */
+const SELF_REGISTERED = {
+  klasse: null,
+  isAdmin: false,
+  passwordHash: null,
+  NOT: { email: { endsWith: "@stud.ntnu.no", mode: "insensitive" as const } },
+};
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+
+  const users = await db.user.findMany({
+    where: SELF_REGISTERED,
+    select: {
+      id: true,
+      tihldeUserId: true,
+      name: true,
+      email: true,
+      hasPaid: true,
+      isVerified: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (users.length === 0) {
+    console.log("Ingen kontoer å markere. Ingenting å gjøre.");
+    return;
+  }
+
+  console.log(
+    `${apply ? "Markerer" : "[tørrkjøring] Ville markert"} ${users.length} kontoer for passordbytte:\n`,
+  );
+  for (const user of users) {
+    console.log(
+      `  ${user.tihldeUserId.padEnd(16)} ${user.name} <${user.email ?? "uten e-post"}>` +
+        `  registrert=${user.createdAt.toISOString().slice(0, 10)}` +
+        `  ${user.hasPaid ? "BETALT" : "ikke betalt"}`,
+    );
+  }
+
+  const betalt = users.filter((u) => u.hasPaid).length;
+  console.log(`\nAv disse har ${betalt} betalt.`);
+
+  if (!apply) {
+    console.log(
+      "\n(Tørrkjøring – ingenting ble skrevet.)\n" +
+        "Les lista over. Kjenner du igjen noen som logger inn med TIHLDE, skal de\n" +
+        "IKKE stå her — da må utvalget strammes inn før du kjører med --apply.",
+    );
+    return;
+  }
+
+  const result = await db.user.updateMany({
+    where: SELF_REGISTERED,
+    data: { passwordHash: RESET_REQUIRED },
+  });
+
+  console.log(`\nFerdig. ${result.count} kontoer kan nå bruke «Glemt passord».`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => void db.$disconnect());

--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -119,6 +119,22 @@ export function UsersTab() {
     },
   });
 
+  // «Aktiver»: gir en selvregistrert student en ekte TIHLDE-bruker. Photon har
+  // ingen godkjenningskø, så opprettelsen ER aktiveringen.
+  const aktiverMutation = api.admin.createTihldeAccount.useMutation({
+    onSuccess: (result) => {
+      void utils.admin.getUsers.invalidate();
+      toast(`${result.username} har fått TIHLDE-bruker`, {
+        description: `Studenten setter sitt eget passord med «glemt passord» på tihlde.org. Verifiserings-e-post er sendt til ${result.email}.`,
+      });
+    },
+    onError: (error) => {
+      toast.error("Fikk ikke opprettet TIHLDE-bruker", {
+        description: error.message,
+      });
+    },
+  });
+
   const studieMutation = api.admin.setUserStudieretning.useMutation({
     onSuccess: (result, variables) => {
       void utils.admin.getUsers.invalidate();
@@ -530,6 +546,23 @@ export function UsersTab() {
                                 >
                                   {user.isFadder ? "Fritatt" : "Skal betale"}
                                 </button>
+                                {/* Bare for de som ennå ikke er TIHLDE-
+                                    medlemmer. Forsvinner av seg selv når de har
+                                    logget inn med TIHLDE, siden det nullstiller
+                                    det lokale passordet. */}
+                                {user.harLokalKonto && (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      aktiverMutation.mutate({ userId: user.id })
+                                    }
+                                    disabled={aktiverMutation.isPending}
+                                    className="bg-primary/10 text-primary hover:bg-primary/20 !ml-2 rounded-full !px-3 !py-1 text-xs font-semibold transition"
+                                    title="Oppretter TIHLDE-bruker på tihlde.org. Studenten setter selv passord med «glemt passord» der."
+                                  >
+                                    Aktiver
+                                  </button>
+                                )}
                               </td>
                               <td className="!px-4 !py-3 text-center">
                                 <button

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -104,17 +104,48 @@ export async function GET(request: Request) {
       );
     }
 
-    const existing = await db.user.findUnique({
+    const selectExisting = {
+      id: true,
+      tihldeUserId: true,
+      adminOverride: true,
+      fadderOverride: true,
+      studieretningOverride: true,
+      isFadder: true,
+      hasPaid: true,
+      memberships: { where: { role: "FADDER" as const }, select: { id: true } },
+    };
+
+    /**
+     * The username is the key, and for almost everyone it matches outright.
+     *
+     * The exception is a student who self-registered here and typed something
+     * other than their real NTNU username — the form asks for the Feide one,
+     * but nothing can enforce it. Their row holds a payment and possibly a
+     * fadder exemption, and creating a second row under the real username would
+     * silently orphan both: to an admin reading the payment overview they would
+     * look like someone who never paid.
+     *
+     * So fall back to the address before giving up. A hit means this is the
+     * same person arriving under the name TIHLDE knows them by, and the row is
+     * adopted — `tihldeUserId` is rewritten to the real username below, which
+     * also stops the fallback from being needed a second time.
+     */
+    let existing = await db.user.findUnique({
       where: { tihldeUserId },
-      select: {
-        adminOverride: true,
-        fadderOverride: true,
-        studieretningOverride: true,
-        isFadder: true,
-        hasPaid: true,
-        memberships: { where: { role: "FADDER" }, select: { id: true } },
-      },
+      select: selectExisting,
     });
+
+    if (!existing && email) {
+      existing = await db.user.findFirst({
+        where: { email: { equals: email, mode: "insensitive" } },
+        select: selectExisting,
+      });
+      if (existing) {
+        console.info(
+          `[auth/callback] adopting ${existing.tihldeUserId} as ${tihldeUserId} (matched on e-mail)`,
+        );
+      }
+    }
 
     /**
      * A manual decision in the admin panel (`adminOverride`) always wins and
@@ -178,38 +209,45 @@ export async function GET(request: Request) {
       ? { studieretningOverride: declaredStudy, fadderOverride: false }
       : {};
 
-    const user = await db.user.upsert({
-      where: { tihldeUserId },
-      create: {
-        tihldeUserId,
-        name: name ?? tihldeUserId,
-        email: email ?? "",
-        image: picture,
-        studieretning,
-        klasse,
-        isAdmin,
-        isFadder,
-        ...studyGrant,
-        ...accessGrant,
-      },
-      update: {
-        // Payment flags for non-exempt users are earned via Vipps and owned by
-        // us, so they are deliberately absent here.
-        name: name ?? undefined,
-        email: email ?? undefined,
-        image: picture,
-        studieretning,
-        klasse,
-        isAdmin,
-        isFadder,
-        // The handover. A local password exists only to bridge the gap until
-        // TIHLDE will answer for this account, and TIHLDE just did — so the
-        // bridge comes down rather than living on as a second, weaker way in.
-        passwordHash: null,
-        ...studyGrant,
-        ...accessGrant,
-      },
-    });
+    // Keyed on the row we resolved above rather than on `tihldeUserId`, since
+    // an adopted row is still stored under the username the student typed.
+    const user = existing
+      ? await db.user.update({
+          where: { id: existing.id },
+          data: {
+            // Payment flags for non-exempt users are earned via Vipps and owned
+            // by us, so they are deliberately absent here.
+            tihldeUserId,
+            name: name ?? undefined,
+            email: email ?? undefined,
+            image: picture,
+            studieretning,
+            klasse,
+            isAdmin,
+            isFadder,
+            // The handover. A local password exists only to bridge the gap
+            // until TIHLDE will answer for this account, and TIHLDE just did —
+            // so the bridge comes down rather than living on as a second,
+            // weaker way in.
+            passwordHash: null,
+            ...studyGrant,
+            ...accessGrant,
+          },
+        })
+      : await db.user.create({
+          data: {
+            tihldeUserId,
+            name: name ?? tihldeUserId,
+            email: email ?? "",
+            image: picture,
+            studieretning,
+            klasse,
+            isAdmin,
+            isFadder,
+            ...studyGrant,
+            ...accessGrant,
+          },
+        });
 
     const hdrs = await headers();
     const { token: sessionToken, expiresAt } = await createSession({

--- a/src/app/api/auth/glemt-passord/route.ts
+++ b/src/app/api/auth/glemt-passord/route.ts
@@ -1,0 +1,113 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  createResetToken,
+  sendResetEmail,
+} from "~/server/auth/password-reset";
+import { checkResetRateLimit, recordResetAttempt } from "~/server/auth/rate-limit";
+import { db } from "~/server/db";
+import { isEmailConfigured } from "~/server/email/photon";
+
+/**
+ * Ask for a password reset link.
+ *
+ * Only accounts that actually have a local password get one. For everyone else
+ * tihlde.org owns the password, and minting a local one from an email link
+ * would be a second door into an approved TIHLDE account — see
+ * `src/server/auth/password-reset.ts`.
+ *
+ * The answer is the same either way: whether an account exists, whether it has
+ * a local password, and whether the mail went out are all invisible from the
+ * outside. Otherwise this endpoint would answer "does this person have an
+ * account here?" for anyone who asks.
+ */
+
+const bodySchema = z.object({
+  user_id: z.string().min(1, "Fyll inn brukernavnet eller e-posten din."),
+});
+
+/** Same answer for every outcome. */
+const GENERIC_OK = {
+  ok: true,
+  message:
+    "Har du en bruker her, sender vi deg en e-post med en lenke. Sjekk også søppelposten.",
+};
+
+async function clientIp(): Promise<string | null> {
+  const hdrs = await headers();
+  return hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
+}
+
+export async function POST(request: Request) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ugyldig forespørsel." },
+      { status: 400 },
+    );
+  }
+
+  // Without a mail key nothing can be sent, and claiming otherwise would leave
+  // people waiting for an email that never comes.
+  if (!isEmailConfigured()) {
+    return NextResponse.json(
+      {
+        error:
+          "Tilbakestilling av passord er ikke tilgjengelig akkurat nå. Ta kontakt med fadderkomiteen.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const userId = parsed.data.user_id.trim().toLowerCase();
+  const ip = await clientIp();
+
+  const limit = await checkResetRateLimit(userId, ip);
+  if (limit.blocked) {
+    return NextResponse.json(
+      {
+        error: `For mange forespørsler. Prøv igjen om ${limit.retryAfterMinutes} minutter.`,
+      },
+      { status: 429 },
+    );
+  }
+
+  // Username or e-mail. Several of the students this exists for signed up
+  // weeks ago and no longer remember the username they picked, while the
+  // address they used is the one thing they are sure of. The answer is generic
+  // either way, so accepting both tells an outsider nothing new.
+  const user = await db.user.findFirst({
+    where: {
+      OR: [
+        { tihldeUserId: userId },
+        { email: { equals: userId, mode: "insensitive" } },
+      ],
+    },
+    select: { id: true, email: true, passwordHash: true, tihldeUserId: true },
+  });
+
+  // No account, no local password, or no address to send to: answer as if it
+  // worked. `passwordHash` is null for everyone TIHLDE authenticates.
+  if (!user?.passwordHash || !user.email) {
+    return NextResponse.json(GENERIC_OK);
+  }
+
+  await recordResetAttempt(userId, ip);
+
+  try {
+    const token = await createResetToken(user.id);
+    await sendResetEmail({
+      to: user.email,
+      tihldeUserId: user.tihldeUserId,
+      token,
+    });
+  } catch (error) {
+    // Logged for us, invisible to the caller: a failing mail provider must not
+    // become a way to probe which usernames exist.
+    console.error("Klarte ikke sende reset-e-post:", error);
+  }
+
+  return NextResponse.json(GENERIC_OK);
+}

--- a/src/app/api/auth/lokal-innlogging/route.ts
+++ b/src/app/api/auth/lokal-innlogging/route.ts
@@ -75,15 +75,25 @@ export async function POST(request: Request) {
     select: { id: true, passwordHash: true, isVerified: true },
   });
 
-  // One message for "no such user", "no local password" and "wrong password".
-  // They are the same fact to anyone who is not the account holder, and telling
-  // them apart is how an attacker enumerates who registered here.
+  /**
+   * One answer for "no such user", "no local password", "must reset" and
+   * "wrong password". They are the same fact to anyone who is not the account
+   * holder, and telling them apart is how an attacker enumerates who
+   * registered here.
+   *
+   * The text leads with the reset, because that is what the great majority of
+   * people hitting this actually need: the cutover destroyed the stored hashes,
+   * so everyone who registered before it must set a new password. `code` lets
+   * the login page render «Glemt passord» as a link — the string is kept as the
+   * fallback for anything reading the API directly.
+   */
   if (!user || !(await verifyPassword(password, user.passwordHash))) {
     await recordFailedLogin(userId, ip);
     return NextResponse.json(
       {
+        code: "ma_sette_nytt_passord",
         error:
-          "Feil brukernavn eller passord. Har du fått TIHLDE-brukeren din godkjent, logg inn med TIHLDE i stedet.",
+          "Vi har lansert ny hovedside, og du må sette nytt passord via «Glemt passord». Om du har godkjent TIHLDE-bruker, logg inn med den i stedet.",
       },
       { status: 401 },
     );

--- a/src/app/api/auth/nytt-passord/route.ts
+++ b/src/app/api/auth/nytt-passord/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { consumableToken, consumeToken } from "~/server/auth/password-reset";
+import { hashPassword } from "~/server/auth/password";
+
+/**
+ * Spend a reset link: set the new password and burn the token.
+ *
+ * The token in the URL is the only thing proving who this is, which is why it
+ * is single-use, short-lived, and why every session on the account is dropped
+ * when it is spent.
+ */
+
+const bodySchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8, "Passordet må være minst 8 tegn."),
+});
+
+const INVALID = {
+  error:
+    "Lenka er ugyldig eller utløpt. Be om en ny på «Glemt passord»-sida.",
+};
+
+export async function POST(request: Request) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ugyldig forespørsel." },
+      { status: 400 },
+    );
+  }
+
+  const stored = await consumableToken(parsed.data.token);
+  if (!stored) return NextResponse.json(INVALID, { status: 400 });
+
+  const spent = await consumeToken(
+    stored.id,
+    stored.userId,
+    await hashPassword(parsed.data.password),
+  );
+  // Lost a race against another request using the same link.
+  if (!spent) return NextResponse.json(INVALID, { status: 400 });
+
+  return NextResponse.json({ ok: true, tihldeUserId: stored.user.tihldeUserId });
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -55,11 +55,14 @@ const bodySchema = z.object({
     .string()
     .trim()
     .toLowerCase()
-    .min(1, "Feltet er påkrevd")
-    // Match Kvark's exact wording; the 15-char cap mirrors TIHLDE's model limit
-    // (Kvark leaves that to the backend — we surface it up front).
+    .min(1, "Fyll inn brukernavnet du vil ha.")
+    // The 15-char cap mirrors TIHLDE's own model limit; we surface it up front
+    // rather than letting Photon reject the form after the fact.
     .max(15, "Brukernavn kan være maks 15 tegn.")
-    .refine((v) => !v.includes("@"), "Brukernavn må være uten @stud.ntnu.no"),
+    .refine(
+      (v) => !v.includes("@"),
+      "Skriv bare brukernavnet, ikke hele e-postadressen.",
+    ),
   password: z.string().min(8, "Passordet må være minst 8 tegn."),
   study: z.enum(REGISTRATION_STUDY_SLUGS, {
     errorMap: () => ({ message: "Velg hvilken linje du går på." }),
@@ -71,7 +74,11 @@ export async function POST(request: Request) {
   if (!parsed.success) {
     const first = parsed.error?.issues[0];
     return NextResponse.json(
-      { error: first?.message ?? "Ugyldig skjema.", field: first?.path[0] },
+      {
+        error:
+          first?.message ?? "Noe mangler i skjemaet. Sjekk at alle felt er fylt ut.",
+        field: first?.path[0],
+      },
       { status: 400 },
     );
   }
@@ -117,12 +124,19 @@ export async function POST(request: Request) {
     // chosen again, the two cases come apart: someone re-registering under a
     // new username owns the address, while someone picking a taken username
     // may be a different person entirely.
+    // Mention the reset too. Registering again is exactly what someone does
+    // when they cannot get in, and for everyone who signed up before the
+    // cutover "log in instead" is a dead end — their password is gone.
     const sameUsername = clash.tihldeUserId === userId;
+    const utvei =
+      " Kommer du ikke inn, sett nytt passord med «Glemt passord».";
     return NextResponse.json(
       {
-        error: sameUsername
-          ? `Brukernavnet «${userId}» er allerede registrert. Logg inn i stedet.`
-          : `E-postadressen er allerede registrert som «${clash.tihldeUserId}». Logg inn i stedet.`,
+        error:
+          (sameUsername
+            ? `Brukernavnet «${userId}» er allerede registrert. Logg inn i stedet.`
+            : `E-postadressen er allerede registrert som «${clash.tihldeUserId}». Logg inn i stedet.`) +
+          utvei,
         field: sameUsername ? "user_id" : "email",
         existingUserId: clash.tihldeUserId,
       },

--- a/src/app/glemt-passord/page.tsx
+++ b/src/app/glemt-passord/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Card, CardDescription, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+/**
+ * Ask for a reset link. Only useful for accounts with a local password — those
+ * whose TIHLDE account is still pending — so the copy points everyone else at
+ * tihlde.org rather than leaving them to guess why no mail arrives.
+ */
+export default function GlemtPassordPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData(e.currentTarget);
+    const userId = (formData.get("user_id") as string)?.trim();
+
+    const res = await fetch("/api/auth/glemt-passord", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId }),
+    });
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+      message?: string;
+    } | null;
+
+    setLoading(false);
+    if (!res.ok) {
+      setError(body?.error ?? "Noe gikk galt. Prøv igjen.");
+      return;
+    }
+    setSent(body?.message ?? "Sjekk e-posten din.");
+  };
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 py-8">
+      <div className="w-full max-w-xl">
+        <Card>
+          <div className="flex flex-col gap-6 p-8 sm:p-12">
+            <div className="flex flex-col gap-2">
+              <CardTitle className="text-3xl font-bold">Glemt passord</CardTitle>
+              <CardDescription>
+                Skriv inn brukernavnet ditt, så sender vi en lenke til
+                e-postadressen som står på kontoen din.
+              </CardDescription>
+            </div>
+
+            {sent ? (
+              <>
+                <p className="rounded-lg border border-border bg-secondary px-4 py-3 text-sm">
+                  {sent}
+                </p>
+                <Link href="/logg-inn" className="text-sm underline">
+                  Tilbake til innlogging
+                </Link>
+              </>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="user_id">Brukernavn</Label>
+                  <Input
+                    id="user_id"
+                    name="user_id"
+                    type="text"
+                    autoComplete="username"
+                    placeholder="ditt TIHLDE-brukernavn"
+                    required
+                    className="h-12"
+                  />
+                </div>
+
+                {error && <p className="text-destructive text-sm">{error}</p>}
+
+                <Button type="submit" disabled={loading} className="h-12 w-full">
+                  {loading ? "Sender..." : "Send lenke"}
+                </Button>
+
+                <CardDescription>
+                  Er TIHLDE-brukeren din godkjent på tihlde.org, logger du inn
+                  med TIHLDE-passordet ditt — det tilbakestiller du på{" "}
+                  <a
+                    href="https://tihlde.org/glemt-passord"
+                    className="underline"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    tihlde.org
+                  </a>
+                  , ikke her.
+                </CardDescription>
+              </form>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/logg-inn/page.tsx
+++ b/src/app/logg-inn/page.tsx
@@ -28,6 +28,9 @@ function LoggInnSkjema() {
   const [nyttStudium, setNyttStudium] = useState(false);
   const [study, setStudy] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // Settes når serveren ber om at passordet må fornyes, så meldingen kan vises
+  // med «Glemt passord» som lenke i stedet for som ren tekst.
+  const [feilkode, setFeilkode] = useState<string | null>(null);
   const feilFraTihlde = useSearchParams().get("error");
 
   const vist = error ?? feilFraTihlde;
@@ -40,16 +43,18 @@ function LoggInnSkjema() {
   async function handleLokalInnlogging(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
+    setFeilkode(null);
     setLaster(true);
 
     const data = new FormData(e.currentTarget);
-    const { error: innloggingsfeil } = await authClient.localLogin({
+    const { error: innloggingsfeil, code } = await authClient.localLogin({
       user_id: (data.get("user_id") as string)?.trim(),
       password: data.get("password") as string,
     });
 
     if (innloggingsfeil) {
       setError(innloggingsfeil);
+      setFeilkode(code ?? null);
       setLaster(false);
       return;
     }
@@ -74,7 +79,22 @@ function LoggInnSkjema() {
 
             {vist && (
               <div className="bg-destructive/10 text-destructive rounded-md px-4 py-3 text-sm">
-                {vist}
+                {/* Samme setning som serveren sender, men med «Glemt passord»
+                    som lenke. Å plukke teksten fra hverandre på klienten ville
+                    knekt neste gang noen retter et komma, så koden styrer
+                    hvilken variant som vises. */}
+                {feilkode === "ma_sette_nytt_passord" ? (
+                  <>
+                    Vi har lansert ny hovedside, og du må sette nytt passord via{" "}
+                    <Link href="/glemt-passord" className="font-semibold underline">
+                      Glemt passord
+                    </Link>
+                    . Om du har godkjent TIHLDE-bruker, logg inn med den i
+                    stedet.
+                  </>
+                ) : (
+                  vist
+                )}
               </div>
             )}
 
@@ -175,6 +195,25 @@ function LoggInnSkjema() {
                   </button>
                 ) : (
                   <form onSubmit={handleLokalInnlogging} className="grid gap-4">
+                    {/* De som registrerte seg før cutoveren har ikke lenger et
+                        passord — hashen deres ble slettet. De kommer hit,
+                        prøver det gamle passordet, og må få vite hvorfor det
+                        ikke virker før de gir opp. */}
+                    <div className="bg-muted rounded-md px-4 py-3 text-sm">
+                      <p className="font-medium">
+                        Registrerte du deg før vi lanserte ny hovedside?
+                      </p>
+                      <p className="text-muted-foreground mt-1">
+                        Da må du sette nytt passord før du kommer inn.{" "}
+                        <Link
+                          href="/glemt-passord"
+                          className="font-semibold underline"
+                        >
+                          Sett nytt passord
+                        </Link>
+                      </p>
+                    </div>
+
                     <p className="text-muted-foreground text-sm">
                       Bruk brukernavnet og passordet du valgte da du registrerte
                       deg. Når TIHLDE-brukeren din er aktivert, logger du inn

--- a/src/app/nytt-passord/[token]/nytt-passord-form.tsx
+++ b/src/app/nytt-passord/[token]/nytt-passord-form.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+
+export function NyttPassordForm({ token }: { token: string }) {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    const formData = new FormData(e.currentTarget);
+    const password = formData.get("password") as string;
+    const repeat = formData.get("password_repeat") as string;
+
+    if (password !== repeat) {
+      setError("Passordene er ikke like.");
+      return;
+    }
+
+    setLoading(true);
+    const res = await fetch("/api/auth/nytt-passord", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, password }),
+    });
+
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      setError(body?.error ?? "Noe gikk galt. Prøv igjen.");
+      setLoading(false);
+      return;
+    }
+
+    // Setting the password logs every session out, so the way back in is the
+    // login page — with the new password.
+    const body = (await res.json().catch(() => null)) as {
+      tihldeUserId?: string;
+    } | null;
+    const query = body?.tihldeUserId
+      ? `?user_id=${encodeURIComponent(body.tihldeUserId)}`
+      : "";
+    router.push(`/logg-inn${query}`);
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="password">Nytt passord</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="minst 8 tegn"
+          required
+          minLength={8}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="password_repeat">Gjenta passordet</Label>
+        <Input
+          id="password_repeat"
+          name="password_repeat"
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={8}
+        />
+      </div>
+
+      {error && <p className="text-destructive text-sm">{error}</p>}
+
+      <Button type="submit" disabled={loading} className="h-12 w-full">
+        {loading ? "Lagrer..." : "Lagre passord"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/nytt-passord/[token]/page.tsx
+++ b/src/app/nytt-passord/[token]/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import { Card, CardDescription, CardTitle } from "~/components/ui/card";
+import { consumableToken } from "~/server/auth/password-reset";
+
+import { NyttPassordForm } from "./nytt-passord-form";
+
+/**
+ * The page a reset link lands on. The token is checked here so a dead link says
+ * so immediately instead of after the user has typed a password twice — it is
+ * checked again on submit, since anything can happen in between.
+ */
+export default async function NyttPassordPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const stored = await consumableToken(token);
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 py-8">
+      <div className="w-full max-w-xl">
+        <Card>
+          <div className="flex flex-col gap-6 p-8 sm:p-12">
+            {stored ? (
+              <>
+                <div className="flex flex-col gap-2">
+                  <CardTitle className="text-3xl font-bold">
+                    Velg nytt passord
+                  </CardTitle>
+                  <CardDescription>
+                    Du setter nytt passord for{" "}
+                    <span className="text-foreground font-semibold">
+                      {stored.user.tihldeUserId}
+                    </span>
+                    . Passordet gjelder bare denne siden — passordet ditt på
+                    tihlde.org endres ikke.
+                  </CardDescription>
+                </div>
+                <NyttPassordForm token={token} />
+              </>
+            ) : (
+              <>
+                <div className="flex flex-col gap-2">
+                  <CardTitle className="text-3xl font-bold">
+                    Lenka virker ikke
+                  </CardTitle>
+                  <CardDescription>
+                    Lenker varer i én time og kan bare brukes én gang. Denne er
+                    enten brukt opp, utløpt eller erstattet av en nyere.
+                  </CardDescription>
+                </div>
+                <Link href="/glemt-passord" className="text-sm underline">
+                  Be om en ny lenke
+                </Link>
+              </>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -27,6 +27,12 @@ export interface RegisterInput {
 interface LocalLoginResult extends Result {
   /** Whether they already have app access, so the form can skip the paywall. */
   verified?: boolean;
+  /**
+   * Stable identifier for the failure, so the page can render the message with
+   * a working «Glemt passord»-link instead of picking the words apart. The
+   * `error` string stays the plain-text version of the same thing.
+   */
+  code?: string;
 }
 
 interface RegisterResult extends Result {
@@ -98,11 +104,14 @@ export const authClient = {
     });
 
     if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+      };
       return {
-        error: await readError(
-          res,
-          "Fikk ikke svar fra serveren. Sjekk nettet og prøv igjen.",
-        ),
+        error:
+          body.error ?? "Fikk ikke svar fra serveren. Sjekk nettet og prøv igjen.",
+        code: body.code,
       };
     }
 

--- a/src/lib/majors.ts
+++ b/src/lib/majors.ts
@@ -36,6 +36,26 @@ export function studyLabelForSlug(slug: string): string | null {
   return REGISTRATION_STUDIES.find((s) => s.slug === slug)?.label ?? null;
 }
 
+/**
+ * The inverse: the slug TIHLDE knows a stored `studieretning` by.
+ *
+ * Needed when we create a TIHLDE account on a student's behalf, since Photon
+ * enrols them by slug. Case-insensitive, because the label may have come back
+ * from a TIHLDE profile rather than from `REGISTRATION_STUDIES`. Returns null
+ * for a programme fadderuka does not register for, which the caller has to
+ * treat as "cannot create the account yet" rather than guessing.
+ */
+export function slugForStudyLabel(
+  label: string | null | undefined,
+): RegistrationStudySlug | null {
+  if (!label) return null;
+  const wanted = label.trim().toLowerCase();
+  return (
+    REGISTRATION_STUDIES.find((s) => s.label.toLowerCase() === wanted)?.slug ??
+    null
+  );
+}
+
 export const UKJENT_STUDIERETNING = "Ukjent studieretning";
 
 /** TIHLDE's casing for studieretning names isn't guaranteed, so match case-insensitively. */

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -1,7 +1,10 @@
+import { randomBytes } from "node:crypto";
+
 import { TRPCError } from "@trpc/server";
 import type { PaymentStatus, PrismaClient } from "@prisma/client";
 import { z } from "zod";
-import { MAJORS } from "~/lib/majors";
+import { MAJORS, slugForStudyLabel } from "~/lib/majors";
+import { photonCreateUser } from "~/server/auth/photon";
 import { deriveIsFadder } from "~/server/fadder";
 import {
   getGruppePublishedAt,
@@ -77,7 +80,7 @@ async function resyncFadderStatus(
 export const adminRouter = createTRPCRouter({
   /** List all users with their verification/admin status and group memberships */
   getUsers: adminProcedure.query(async ({ ctx }) => {
-    return ctx.db.user.findMany({
+    const users = await ctx.db.user.findMany({
       select: {
         id: true,
         tihldeUserId: true,
@@ -91,6 +94,7 @@ export const adminRouter = createTRPCRouter({
         hasPaid: true,
         isFadder: true,
         fadderOverride: true,
+        passwordHash: true,
         createdAt: true,
         memberships: {
           select: {
@@ -102,7 +106,86 @@ export const adminRouter = createTRPCRouter({
       },
       orderBy: { createdAt: "desc" },
     });
+
+    // The hash itself never leaves the server — only the one fact the panel
+    // acts on: this account signs in with a local password, so TIHLDE has not
+    // taken it over and the "aktiver"-button still applies. A login through
+    // TIHLDE clears the hash, which is what makes the button disappear on its
+    // own once the student is a real member.
+    return users.map(({ passwordHash, ...user }) => ({
+      ...user,
+      harLokalKonto: passwordHash !== null,
+    }));
   }),
+
+  /**
+   * Give a self-registered student a real TIHLDE account.
+   *
+   * This is the "aktiver"-button FadderKom presses when the student turns up in
+   * person. Everyone who signs up here without an @stud.ntnu.no address gets a
+   * local account only; they can pay and use the app, but they are not TIHLDE
+   * members and cannot sign in through tihlde.org.
+   *
+   * There is no approval queue to put them in: Photon's register endpoint gives
+   * the `member` role outright (`syncBaselineRoles`), so creating the account IS
+   * the activation. The old Lepton model — created pending, approved later in
+   * Kvark — no longer exists.
+   *
+   * The password is random and never shown to anyone. The student sets their
+   * own through "glemt passord" on tihlde.org, and Photon's verification mail
+   * goes out as it does for any other sign-up. Handing an admin a password to
+   * read aloud would be worse than making them do that.
+   *
+   * The username we pass is the one already stored here, so the two systems
+   * agree and a later Feide login lands on this same account rather than a
+   * second one.
+   */
+  createTihldeAccount: adminProcedure
+    .input(z.object({ userId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const user = await ctx.db.user.findUnique({
+        where: { id: input.userId },
+        select: {
+          tihldeUserId: true,
+          name: true,
+          email: true,
+          studieretning: true,
+        },
+      });
+      if (!user) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Bruker ikke funnet" });
+      }
+      if (!user.email) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Brukeren har ingen e-postadresse å opprette kontoen med.",
+        });
+      }
+
+      const study = slugForStudyLabel(user.studieretning);
+      if (!study) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Brukeren mangler en linje vi kan melde dem inn i. Sett linje først.",
+        });
+      }
+
+      try {
+        const created = await photonCreateUser({
+          name: user.name,
+          email: user.email,
+          // Never stored, never shown. "Glemt passord" på tihlde.org is how
+          // they get one they know.
+          password: randomBytes(24).toString("base64url"),
+          studyProgramSlug: study,
+          username: user.tihldeUserId,
+        });
+        return { username: created.username, email: created.email };
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
 
   /** Verify or unverify a user */
   setUserVerified: adminProcedure

--- a/src/server/auth/password-reset.ts
+++ b/src/server/auth/password-reset.ts
@@ -1,0 +1,152 @@
+import "server-only";
+
+import { createHash, randomBytes } from "node:crypto";
+
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { sendEmail } from "~/server/email/photon";
+
+/**
+ * Self-service password reset for the local login bridge.
+ *
+ * Who this is for: students who registered here without an @stud.ntnu.no
+ * address, and cannot use their TIHLDE account until it is activated. They log
+ * in with a password chosen during registration, and we hold the only hash of
+ * it — so a forgotten one otherwise means an admin handing out a replacement by
+ * hand.
+ *
+ * It is also the way back in for the accounts whose hash was destroyed by the
+ * OAuth cutover's `DROP COLUMN`. They carry the `reset-required` sentinel
+ * instead of a hash: unusable for signing in, but non-null, which is precisely
+ * what lets them through the guard below.
+ *
+ * Who it is deliberately NOT for: accounts TIHLDE authenticates. Their
+ * `passwordHash` is null — tihlde.org owns their password, and letting an
+ * email link mint a local one would build a second way into an approved
+ * account that bypasses TIHLDE entirely.
+ */
+
+/** How long a link works. Long enough to find the mail, short enough to matter. */
+const TOKEN_TTL_MS = 60 * 60 * 1000;
+
+/** Bytes of entropy in the token. 32 is far beyond guessable. */
+const TOKEN_BYTES = 32;
+
+/**
+ * Only the hash is stored, so a database leak yields no working links. SHA-256
+ * without a salt is right here (unlike for passwords): the input is 256 bits of
+ * randomness, so there is nothing to brute-force or rainbow-table.
+ */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+/** The public origin, for building the link. See `APP_URL` in `src/env.js`. */
+function appUrl(): string {
+  const url = env.APP_URL ?? env.VIPPS_CALLBACK_URL ?? "http://localhost:3000";
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Create a reset token for `userId`, invalidating any earlier unused ones so a
+ * second request cannot leave two live links behind. Returns the plaintext,
+ * which exists only in the returned value and the email built from it.
+ */
+export async function createResetToken(userId: string): Promise<string> {
+  const token = randomBytes(TOKEN_BYTES).toString("base64url");
+
+  await db.$transaction([
+    db.passwordResetToken.deleteMany({ where: { userId, usedAt: null } }),
+    db.passwordResetToken.create({
+      data: {
+        tokenHash: hashToken(token),
+        userId,
+        expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
+      },
+    }),
+  ]);
+
+  return token;
+}
+
+/**
+ * Look up a token and return the user it belongs to, or null when it is
+ * unknown, already used or expired. The lookup is by hash, so the plaintext is
+ * never compared against anything stored.
+ */
+export async function consumableToken(token: string) {
+  if (!token) return null;
+
+  const stored = await db.passwordResetToken.findUnique({
+    where: { tokenHash: hashToken(token) },
+    include: { user: { select: { id: true, tihldeUserId: true } } },
+  });
+
+  if (!stored) return null;
+  if (stored.usedAt) return null;
+  if (stored.expiresAt.getTime() <= Date.now()) return null;
+
+  return stored;
+}
+
+/**
+ * Spend a token: set the new password hash, mark the token used, and drop every
+ * session the account has. Logging the sessions out matters — whoever asked for
+ * the reset may be locking out someone who is signed in on their account right
+ * now, and that is the whole point of a password reset.
+ *
+ * Guarded on `usedAt: null` inside the transaction so two requests racing on
+ * the same link cannot both succeed.
+ */
+export async function consumeToken(
+  tokenId: string,
+  userId: string,
+  passwordHash: string,
+): Promise<boolean> {
+  return db.$transaction(async (tx) => {
+    // Claim the token first. Losing this race has to mean writing nothing at
+    // all — a batched transaction would have set the password anyway and then
+    // reported failure.
+    const marked = await tx.passwordResetToken.updateMany({
+      where: { id: tokenId, usedAt: null },
+      data: { usedAt: new Date() },
+    });
+    if (marked.count !== 1) return false;
+
+    await tx.user.update({ where: { id: userId }, data: { passwordHash } });
+    await tx.session.deleteMany({ where: { userId } });
+    return true;
+  });
+}
+
+/** Build and send the reset mail through Photon. */
+export async function sendResetEmail(input: {
+  to: string;
+  tihldeUserId: string;
+  token: string;
+}): Promise<void> {
+  const link = `${appUrl()}/nytt-passord/${input.token}`;
+
+  await sendEmail({
+    to: input.to,
+    subject: "Tilbakestill passordet ditt på Fadderuka",
+    content: [
+      { type: "title", content: "Glemt passord" },
+      {
+        type: "text",
+        content: `Noen har bedt om å tilbakestille passordet for «${input.tihldeUserId}» på Fadderuka-sida. Trykk på knappen for å velge et nytt passord.`,
+      },
+      { type: "button", text: "Velg nytt passord", url: link },
+      {
+        type: "text",
+        content:
+          "Lenka virker i én time og kan bare brukes én gang. Har du ikke bedt om dette, kan du se bort fra e-posten — passordet ditt er uendret.",
+      },
+      {
+        type: "text",
+        content:
+          "Passordet gjelder kun Fadderuka-sida. Passordet ditt på tihlde.org endres ikke.",
+      },
+    ],
+  });
+}

--- a/src/server/auth/password.ts
+++ b/src/server/auth/password.ts
@@ -16,6 +16,24 @@ import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
  * OWASP minimum (N=2^16, r=8, p=1).
  */
 
+/**
+ * Stands in for a hash nobody knows, marking an account that must set a new
+ * password before it can be used.
+ *
+ * The OAuth cutover dropped the `passwordHash` column from production, which
+ * destroyed the only credential 130 self-registered students had — 113 of whom
+ * had already paid. The hashes are gone for good: Neon's history window is six
+ * hours and the migration ran eight hours before the earliest restorable point.
+ *
+ * Writing this value restores the one fact that matters, that these accounts
+ * have a local password, without pretending to know what it was. It is not a
+ * valid `scrypt:` string, so `verifyPassword` can never accept it; but it is
+ * non-null, so `glemt-passord` will send them a reset link. Storing a random
+ * hash instead would do the same job while being unreadable to whoever opens
+ * the table next.
+ */
+export const RESET_REQUIRED = "reset-required";
+
 const KEY_LENGTH = 64;
 const SCRYPT_OPTIONS = { N: 65536, r: 8, p: 1, maxmem: 128 * 65536 * 8 * 2 };
 

--- a/src/server/auth/rate-limit.ts
+++ b/src/server/auth/rate-limit.ts
@@ -73,12 +73,13 @@ export async function recordFailedLogin(
   if (ip) rows.push({ key: ipKey(ip) });
 
   await db.loginAttempt.createMany({ data: rows });
-  // Scoped to this counter's own keys. An unscoped delete would also take the
-  // `register-ip:` rows, which run on a window four times as long — quietly
-  // handing back registration budget every time someone mistypes a password.
+  // Scoped to this counter's own keys, and listed positively so a counter added
+  // later is not swept by accident. Every other counter in this table runs on a
+  // window four times as long, so an unscoped delete would quietly hand their
+  // budget back every time someone mistyped a password.
   await db.loginAttempt.deleteMany({
     where: {
-      key: { not: { startsWith: "register-ip:" } },
+      OR: [{ key: { startsWith: "user:" } }, { key: { startsWith: "ip:" } }],
       createdAt: { lt: new Date(Date.now() - WINDOW_MS) },
     },
   });
@@ -91,6 +92,74 @@ export async function clearLoginFailures(
 ): Promise<void> {
   const keys = ip ? [userKey(userId), ipKey(ip)] : [userKey(userId)];
   await db.loginAttempt.deleteMany({ where: { key: { in: keys } } });
+}
+
+/**
+ * Reset-mail throttling.
+ *
+ * Every request sends mail to somebody else's inbox, so the thing being bounded
+ * is not guessing but nuisance: without it, anyone could point this endpoint at
+ * a student and keep their inbox filling up. Counted per account *and* per IP,
+ * so neither one address nor one distributed caller can keep hitting the same
+ * inbox.
+ */
+const RESET_WINDOW_MS = 60 * 60 * 1000;
+
+/** Reset mails one account may trigger per hour. */
+const MAX_RESETS_PER_USER = 5;
+/** Reset mails one IP may trigger per hour, across accounts. */
+const MAX_RESETS_PER_IP = 15;
+
+const resetUserKey = (userId: string) =>
+  `reset-user:${userId.trim().toLowerCase()}`;
+const resetIpKey = (ip: string) => `reset-ip:${ip}`;
+
+/** Whether this account/IP has used up its reset budget. */
+export async function checkResetRateLimit(
+  userId: string,
+  ip: string | null,
+): Promise<RateLimitVerdict> {
+  const since = new Date(Date.now() - RESET_WINDOW_MS);
+  const keys = ip
+    ? [resetUserKey(userId), resetIpKey(ip)]
+    : [resetUserKey(userId)];
+
+  const attempts = await db.loginAttempt.findMany({
+    where: { key: { in: keys }, createdAt: { gte: since } },
+    select: { key: true, createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const forUser = attempts.filter((a) => a.key === keys[0]);
+  const forIp = ip ? attempts.filter((a) => a.key === resetIpKey(ip)) : [];
+
+  const overUser = forUser.length >= MAX_RESETS_PER_USER;
+  const overIp = forIp.length >= MAX_RESETS_PER_IP;
+  if (!overUser && !overIp) return { blocked: false, retryAfterMinutes: 0 };
+
+  const oldest = (overUser ? forUser : forIp)[0]!.createdAt;
+  const msLeft = oldest.getTime() + RESET_WINDOW_MS - Date.now();
+  return {
+    blocked: true,
+    retryAfterMinutes: Math.max(1, Math.ceil(msLeft / 60_000)),
+  };
+}
+
+/** Record a sent reset mail and drop rows that have aged out. */
+export async function recordResetAttempt(
+  userId: string,
+  ip: string | null,
+): Promise<void> {
+  const rows = [{ key: resetUserKey(userId) }];
+  if (ip) rows.push({ key: resetIpKey(ip) });
+
+  await db.loginAttempt.createMany({ data: rows });
+  await db.loginAttempt.deleteMany({
+    where: {
+      key: { startsWith: "reset-" },
+      createdAt: { lt: new Date(Date.now() - RESET_WINDOW_MS) },
+    },
+  });
 }
 
 /**

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -8,6 +8,7 @@ import { setGrupperPublished } from "~/server/gruppe-visibility";
  */
 const TABLES = [
   "AppSetting",
+  "PasswordResetToken",
   "LoginAttempt",
   "Payment",
   "Notification",

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -44,6 +44,7 @@ const ADMIN_PROCEDURE_INPUTS: Record<string, unknown> = {
   removeMember: { membershipId: "x" },
   updateMemberRole: { membershipId: "x", role: "FADDER" },
   deleteUser: { userId: "x" },
+  createTihldeAccount: { userId: "x" },
   verifyAndAssign: { userId: "x", gruppeId: "y" },
   getRegistrations: undefined,
   getPayments: undefined,

--- a/tests/integration/auth-callback.route.test.ts
+++ b/tests/integration/auth-callback.route.test.ts
@@ -90,6 +90,44 @@ describe("GET /api/auth/callback", () => {
     );
   });
 
+  /**
+   * Studenten som skrev noe annet enn NTNU-brukernavnet sitt i skjemaet. Uten
+   * adopsjonen ville de fått en ny rad, og betalingen blitt liggende igjen på
+   * den gamle — usynlig for alle andre enn den som leter etter den.
+   */
+  it("adopterer raden på e-post når brukernavnet ikke stemmer", async () => {
+    const gammel = await createUser({
+      tihldeUserId: "olanordmann",
+      email: "ola@stud.ntnu.no",
+      hasPaid: true,
+      isFadder: true,
+      fadderOverride: true,
+      passwordHash: await hashPassword(PASSORD),
+    });
+    stubPhoton({ username: "ola" });
+
+    await get();
+
+    await expect(db.user.count()).resolves.toBe(1);
+    const etter = await db.user.findUniqueOrThrow({ where: { id: gammel.id } });
+    expect(etter.tihldeUserId).toBe("ola");
+    expect(etter.hasPaid).toBe(true);
+    expect(etter.isFadder).toBe(true);
+    expect(etter.passwordHash).toBeNull();
+  });
+
+  it("lager ny rad når verken brukernavn eller e-post kjennes igjen", async () => {
+    await createUser({ tihldeUserId: "kari", email: "kari@stud.ntnu.no" });
+    stubPhoton({ username: "ola" });
+
+    await get();
+
+    await expect(db.user.count()).resolves.toBe(2);
+    await expect(
+      db.user.findUniqueOrThrow({ where: { tihldeUserId: "ola" } }),
+    ).resolves.toMatchObject({ name: "Ola Nordmann" });
+  });
+
   it("matcher fortsatt eksisterende brukere på tihldeUserId", async () => {
     const user = await createUser({ tihldeUserId: "ola", name: "Gammelt Navn" });
     stubPhoton();

--- a/tests/integration/auth-glemt-passord.route.test.ts
+++ b/tests/integration/auth-glemt-passord.route.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as glemtPassord } from "~/app/api/auth/glemt-passord/route";
+import { POST as nyttPassord } from "~/app/api/auth/nytt-passord/route";
+import { POST as lokalInnlogging } from "~/app/api/auth/lokal-innlogging/route";
+import {
+  RESET_REQUIRED,
+  hashPassword,
+  verifyPassword,
+} from "~/server/auth/password";
+import { hashToken } from "~/server/auth/password-reset";
+
+import { createUser, db } from "../helpers/db";
+import { fetchMock, json } from "../helpers/fetch-mock";
+import { resetNextHeaders } from "../helpers/next-headers";
+
+vi.mock("next/headers", () => import("../helpers/next-headers"));
+
+const post = (
+  handler: (request: Request) => Promise<Response>,
+  path: string,
+  body: unknown,
+) =>
+  handler(
+    new Request(`https://fadderuka.test${path}`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+
+const askFor = (user_id: string) =>
+  post(glemtPassord, "/api/auth/glemt-passord", { user_id });
+
+/** Photon's mail endpoint, which `sendResetEmail` goes through. */
+function stubEmail() {
+  fetchMock.on("POST", /\/api\/email/, () => json({ ok: true }));
+}
+
+/** The plaintext token out of the mail we just "sent". */
+function sentToken(): string | undefined {
+  const [call] = fetchMock.callsTo(/\/api\/email/);
+  const body = JSON.stringify(call?.body ?? {});
+  return /nytt-passord\/([A-Za-z0-9_-]+)/.exec(body)?.[1];
+}
+
+beforeEach(() => {
+  resetNextHeaders({ "user-agent": "vitest" });
+  stubEmail();
+});
+
+describe("POST /api/auth/glemt-passord", () => {
+  it("sender lenke til den som må sette nytt passord etter cutoveren", async () => {
+    await createUser({
+      tihldeUserId: "ola",
+      email: "ola@gmail.com",
+      passwordHash: RESET_REQUIRED,
+    });
+
+    const response = await askFor("ola");
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.callsTo(/\/api\/email/)).toHaveLength(1);
+    await expect(db.passwordResetToken.count()).resolves.toBe(1);
+  });
+
+  it("finner brukeren på e-post òg, ikke bare brukernavn", async () => {
+    await createUser({
+      tihldeUserId: "ola",
+      email: "ola@gmail.com",
+      passwordHash: RESET_REQUIRED,
+    });
+
+    const response = await askFor("OLA@GMAIL.COM");
+
+    expect(response.status).toBe(200);
+    await expect(db.passwordResetToken.count()).resolves.toBe(1);
+  });
+
+  /**
+   * Kontoer TIHLDE autentiserer har `passwordHash = null`. Å la en e-postlenke
+   * mynte et lokalt passord for dem ville vært en andre vei inn i en godkjent
+   * TIHLDE-konto, utenom TIHLDE.
+   */
+  it("sender ikke lenke til en konto TIHLDE eier", async () => {
+    await createUser({
+      tihldeUserId: "kari",
+      email: "kari@stud.ntnu.no",
+      passwordHash: null,
+    });
+
+    const response = await askFor("kari");
+
+    expect(response.status).toBe(200);
+    expect(fetchMock.callsTo(/\/api\/email/)).toHaveLength(0);
+    await expect(db.passwordResetToken.count()).resolves.toBe(0);
+  });
+
+  it("svarer likt enten kontoen finnes, mangler lokalt passord eller fikk mail", async () => {
+    await createUser({
+      tihldeUserId: "ola",
+      email: "ola@gmail.com",
+      passwordHash: RESET_REQUIRED,
+    });
+    await createUser({
+      tihldeUserId: "kari",
+      email: "kari@stud.ntnu.no",
+      passwordHash: null,
+    });
+
+    const svar = [
+      await askFor("ola"),
+      await askFor("kari"),
+      await askFor("finnesikke"),
+    ];
+    const kropper = await Promise.all(svar.map((r) => r.json()));
+
+    expect(svar.map((r) => r.status)).toEqual([200, 200, 200]);
+    expect(new Set(kropper.map((b) => JSON.stringify(b))).size).toBe(1);
+  });
+
+  it("rate-limiter gjentatte forespørsler for samme konto", async () => {
+    await createUser({
+      tihldeUserId: "ola",
+      email: "ola@gmail.com",
+      passwordHash: RESET_REQUIRED,
+    });
+
+    for (let i = 0; i < 5; i++) await askFor("ola");
+    const blokkert = await askFor("ola");
+
+    expect(blokkert.status).toBe(429);
+  });
+});
+
+describe("POST /api/auth/nytt-passord", () => {
+  async function requestLink() {
+    const user = await createUser({
+      tihldeUserId: "ola",
+      email: "ola@gmail.com",
+      passwordHash: RESET_REQUIRED,
+    });
+    await askFor("ola");
+    const token = sentToken();
+    expect(token).toBeDefined();
+    return { user, token: token! };
+  }
+
+  it("setter nytt passord, som deretter virker på lokal innlogging", async () => {
+    const { token } = await requestLink();
+
+    const response = await post(nyttPassord, "/api/auth/nytt-passord", {
+      token,
+      password: "mittnyepassord",
+    });
+    expect(response.status).toBe(200);
+
+    const innlogging = await lokalInnlogging(
+      new Request("https://fadderuka.test/api/auth/lokal-innlogging", {
+        method: "POST",
+        body: JSON.stringify({ user_id: "ola", password: "mittnyepassord" }),
+      }),
+    );
+    expect(innlogging.status).toBe(200);
+  });
+
+  it("lagrer en ekte hash, ikke sentinelen eller klarteksten", async () => {
+    const { user, token } = await requestLink();
+
+    await post(nyttPassord, "/api/auth/nytt-passord", {
+      token,
+      password: "mittnyepassord",
+    });
+
+    const etter = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(etter.passwordHash).not.toBe(RESET_REQUIRED);
+    expect(etter.passwordHash).not.toContain("mittnyepassord");
+    await expect(
+      verifyPassword("mittnyepassord", etter.passwordHash),
+    ).resolves.toBe(true);
+  });
+
+  it("brenner lenka, så den ikke kan brukes to ganger", async () => {
+    const { token } = await requestLink();
+
+    const første = await post(nyttPassord, "/api/auth/nytt-passord", {
+      token,
+      password: "mittnyepassord",
+    });
+    const andre = await post(nyttPassord, "/api/auth/nytt-passord", {
+      token,
+      password: "enda-et-passord",
+    });
+
+    expect(første.status).toBe(200);
+    expect(andre.status).toBe(400);
+  });
+
+  /**
+   * Den som ber om reset kan være i ferd med å låse ute noen som sitter
+   * innlogget på kontoen akkurat nå. Det er hele poenget med et passordbytte.
+   */
+  it("logger ut alle eksisterende sesjoner", async () => {
+    const { user, token } = await requestLink();
+    await db.session.create({
+      data: {
+        token: "gammel-sesjon",
+        userId: user.id,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    });
+
+    await post(nyttPassord, "/api/auth/nytt-passord", {
+      token,
+      password: "mittnyepassord",
+    });
+
+    await expect(
+      db.session.count({ where: { userId: user.id } }),
+    ).resolves.toBe(0);
+  });
+
+  it("avviser en utløpt lenke", async () => {
+    const user = await createUser({
+      tihldeUserId: "ola",
+      passwordHash: RESET_REQUIRED,
+    });
+    await db.passwordResetToken.create({
+      data: {
+        tokenHash: hashToken("utloept"),
+        userId: user.id,
+        expiresAt: new Date(Date.now() - 1000),
+      },
+    });
+
+    const response = await post(nyttPassord, "/api/auth/nytt-passord", {
+      token: "utloept",
+      password: "mittnyepassord",
+    });
+
+    expect(response.status).toBe(400);
+    const etter = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(etter.passwordHash).toBe(RESET_REQUIRED);
+  });
+
+  it("avviser et ukjent token", async () => {
+    const response = await post(nyttPassord, "/api/auth/nytt-passord", {
+      token: "finnes-ikke",
+      password: "mittnyepassord",
+    });
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("RESET_REQUIRED", () => {
+  it("kan aldri brukes som passord", async () => {
+    await expect(verifyPassword(RESET_REQUIRED, RESET_REQUIRED)).resolves.toBe(
+      false,
+    );
+    await expect(verifyPassword("", RESET_REQUIRED)).resolves.toBe(false);
+    // Og et ekte passord virker fortsatt, så sentinelen ikke har ødelagt noe.
+    const hash = await hashPassword("hemmeligpassord");
+    await expect(verifyPassword("hemmeligpassord", hash)).resolves.toBe(true);
+  });
+});

--- a/tests/integration/auth-lokal-innlogging.route.test.ts
+++ b/tests/integration/auth-lokal-innlogging.route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { POST as lokalInnlogging } from "~/app/api/auth/lokal-innlogging/route";
 import { SESSION_COOKIE } from "~/server/auth/config";
-import { hashPassword } from "~/server/auth/password";
+import { RESET_REQUIRED, hashPassword } from "~/server/auth/password";
 
 import { createUser, db } from "../helpers/db";
 import { lastSetCookie, resetNextHeaders } from "../helpers/next-headers";
@@ -78,19 +78,37 @@ describe("POST /api/auth/lokal-innlogging", () => {
   it("skiller ikke ukjent bruker fra feil passord fra manglende hash", async () => {
     await createPendingStudent();
     await createUser({ tihldeUserId: "kari", passwordHash: null });
+    await createUser({ tihldeUserId: "trine", passwordHash: RESET_REQUIRED });
 
     const svar = await Promise.all([
       post({ user_id: "finnesikke", password: PASSORD }),
       post({ user_id: "ola", password: "feilpassord" }),
       post({ user_id: "kari", password: PASSORD }),
+      post({ user_id: "trine", password: PASSORD }),
     ]);
 
-    const meldinger = await Promise.all(
-      svar.map(async (r) => ((await r.json()) as { error: string }).error),
+    const kropper = await Promise.all(
+      svar.map((r) => r.json() as Promise<{ error: string; code?: string }>),
     );
 
-    expect(svar.map((r) => r.status)).toEqual([401, 401, 401]);
-    expect(new Set(meldinger).size).toBe(1);
+    expect(svar.map((r) => r.status)).toEqual([401, 401, 401, 401]);
+    expect(new Set(kropper.map((b) => JSON.stringify(b))).size).toBe(1);
+  });
+
+  /**
+   * Teksten leder med passordbyttet, fordi det er det de aller fleste som
+   * treffer denne faktisk trenger — cutoveren slettet hashene deres. `code`
+   * lar innloggingssida vise «Glemt passord» som lenke.
+   */
+  it("ber om nytt passord og bærer koden som gjør lenka mulig", async () => {
+    await createPendingStudent();
+
+    const response = await post({ user_id: "ola", password: "feilpassord" });
+    const body = (await response.json()) as { error: string; code?: string };
+
+    expect(body.code).toBe("ma_sette_nytt_passord");
+    expect(body.error).toContain("Glemt passord");
+    expect(body.error).toContain("ny hovedside");
   });
 
   /**


### PR DESCRIPTION
Samme innhold som #122, som ble merget inn i `claude/registrering-uten-stud-epost` **etter** at den branchen allerede var merget til `dev` — så innholdet nådde aldri fram. Dette er den ene commiten cherry-picket rent på toppen av dagens `dev`.

Ingen konflikter, og verifisert på nytt mot dev-grunnlaget: `typecheck`, `lint` (0 feil), `build` og **233 tester i 18 filer**.

Beskrivelsen i #122 gjelder uendret. Kort oppsummert:

- **«Glemt passord»** hentet tilbake fra commiten før cutoveren, med oppslag på brukernavn **eller** e-post
- **Sentinelverdien `reset-required`** for de 130 hvis hash ble slettet — ubrukelig til innlogging, men non-null, som er det porten krever. Porten selv står urørt
- **Callback-ruten** faller tilbake på e-post og adopterer raden, så betalingen ikke blir liggende igjen når brukernavnet ikke stemmer
- **«Aktiver»** i adminpanelet oppretter TIHLDE-brukeren. Photon har ingen godkjenningskø — opprettelsen *er* aktiveringen
- **Feilmeldingene** gjennomgått; 401-en sier nå hva studenten faktisk må gjøre, fortsatt ordrett lik for alle utfall
- **`scripts/marker-passord-for-reset.ts`** — tørrkjørt mot prod: treffer 130, hvorav 113 har betalt

## Etter merge

1. Deploy
2. Kjør migrasjonene manuelt — Vercel kjører ikke `prisma migrate deploy`
3. `bun run scripts/marker-passord-for-reset.ts`, les lista, så `--apply`

**De 113 kommer ikke inn før steg 3.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)