### PR TITLE
fix(admin): la betalingskolonnen vise om folk faktisk har betalt

### DIFF
--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -14,6 +14,50 @@ import {
 } from "~/lib/majors";
 
 /**
+ * Hva betalingskolonnen viser for én bruker.
+ *
+ * Kolonnen viste før bare `isFadder` — «Fritatt» eller «Skal betale» — så en
+ * fadderbarn som HADDE betalt sto som «Skal betale». Den leses som en status,
+ * så nå er den det.
+ *
+ * Fritak vinner over betaling: en fadder skylder ingenting uansett hva som står
+ * i `hasPaid`. Unntaket er fadderen som allerede har betalt — de har penger til
+ * gode, og det fortjener en egen tilstand framfor å bli borte bak «Fritatt» til
+ * noen tilfeldigvis åpner Betalinger-fanen.
+ *
+ * Knappen bytter fortsatt fritaket; bare merkelappen er ny. Derfor sier hver
+ * hjelpetekst også hva et klikk faktisk gjør.
+ */
+function betalingsvisning(user: { isFadder: boolean; hasPaid: boolean }) {
+  if (user.isFadder && user.hasPaid) {
+    return {
+      label: "Fritatt · betalt",
+      className: "bg-destructive/10 text-destructive hover:bg-destructive/20",
+      hint: "Fritatt, men har betalt — pengene skal refunderes fra Betalinger-fanen. Klikk for å gjøre betalingspliktig igjen.",
+    };
+  }
+  if (user.isFadder) {
+    return {
+      label: "Fritatt",
+      className: "bg-muted text-muted-foreground hover:bg-muted/80",
+      hint: "Fadder — skylder ingenting. Klikk for å gjøre betalingspliktig.",
+    };
+  }
+  if (user.hasPaid) {
+    return {
+      label: "Betalt",
+      className: "bg-success/10 text-success hover:bg-success/20",
+      hint: "Har betalt for fadderuka. Klikk for å frita som fadder.",
+    };
+  }
+  return {
+    label: "Ikke betalt",
+    className: "bg-warning/10 text-warning hover:bg-warning/20",
+    hint: "Har ikke betalt ennå. Klikk for å frita som fadder.",
+  };
+}
+
+/**
  * Correct the programme TIHLDE reports for a user.
  *
  * Shows the pinned choice when there is one, and otherwise "Følg TIHLDE" with
@@ -111,7 +155,9 @@ export function UsersTab() {
           description: "Refunder betalingen fra Betalinger-fanen.",
         });
       } else {
-        toast("Betalingsstatus oppdatert");
+        // «Betalingsplikt», ikke «betalingsstatus»: bryteren flytter hvem som
+        // skylder penger, og rører aldri om noen har betalt.
+        toast("Betalingsplikt oppdatert");
       }
     },
     onError: (error) => {
@@ -441,6 +487,8 @@ export function UsersTab() {
                           <th className="!px-4 !py-3 font-medium">Studie</th>
                           <th className="!px-4 !py-3 font-medium">Gruppe</th>
                           <th className="!px-4 !py-3 font-medium">Rolle</th>
+                          {/* Se `betalingsvisning`: viser faktisk status
+                              (betalt / ikke betalt), med fritak for faddere. */}
                           <th className="!px-4 !py-3 font-medium">Betaling</th>
                           <th className="!px-4 !py-3 font-medium text-center">Admin</th>
                         </tr>
@@ -533,18 +581,10 @@ export function UsersTab() {
                                     })
                                   }
                                   disabled={fadderMutation.isPending}
-                                  className={`rounded-full !px-3 !py-1 text-xs font-semibold transition ${
-                                    user.isFadder
-                                      ? "bg-success/10 text-success hover:bg-success/20"
-                                      : "bg-warning/10 text-warning hover:bg-warning/20"
-                                  }`}
-                                  title={
-                                    user.isFadder
-                                      ? "Fritatt for betaling. Klikk for å markere som betalende."
-                                      : "Skal betale. Klikk for å markere som fadder."
-                                  }
+                                  className={`rounded-full !px-3 !py-1 text-xs font-semibold transition ${betalingsvisning(user).className}`}
+                                  title={betalingsvisning(user).hint}
                                 >
-                                  {user.isFadder ? "Fritatt" : "Skal betale"}
+                                  {betalingsvisning(user).label}
                                 </button>
                                 {/* Bare for de som ennå ikke er TIHLDE-
                                     medlemmer. Forsvinner av seg selv når de har


### PR DESCRIPTION
## Hva

«Betaling»-kolonnen i Brukere-fanen leste bare `isFadder` og viste enten «Fritatt» eller «Skal betale». Den sa altså aldri om noen hadde betalt. Nå viser den faktisk status, med fritak for faddere.

| tilstand | merkelapp | farge |
|---|---|---|
| fadder | `Fritatt` | nøytral |
| har betalt | `Betalt` | grønn |
| skylder penger | `Ikke betalt` | gul |
| fadder som har betalt | `Fritatt · betalt` | rød |

## Hvorfor

En student meldte fra at han sto som ubetalt etter å ha betalt. Betalingen hans lå riktignok på en duplikatkonto — den saken er ryddet manuelt i prod — men da den var flyttet, sto han fortsatt som «Skal betale» i adminpanelet. Det er teknisk sant (han tilhører de betalingspliktige) og praktisk misvisende, og kostet en ekstra runde med feilsøking før vi fant ut at kolonnen aldri har vist betaling.

## Verdt å vite for review

**«Fritatt · betalt» er nytt utover den rene omskrivingen.** `setUserFadder` varsler allerede med en toast om at en fadder som har betalt skal refunderes, men toasten forsvinner — og da lå de pengene skjult bak «Fritatt» til noen tilfeldigvis åpnet Betalinger-fanen. Si fra hvis dere heller vil ha den slått sammen med vanlig «Fritatt».

**Fritak vinner over betaling** i rekkefølgen: en fadder skylder ingenting uansett hva `hasPaid` sier.

**Knappen oppfører seg som før** — den bytter `isFadder`. Bare merkelappen, fargen og hjelpeteksten er nye. Hver hjelpetekst sier nå både hva raden betyr og hva et klikk gjør, siden en knapp som sier «Betalt» ellers ikke røper at et klikk fritar dem.

Logikken er samlet i `betalingsvisning()` øverst i fila framfor nøstede ternaries i JSX-en.

## Testing

- `tsc --noEmit` rent
- `eslint` rent
- `next build` kompilerer
- `vitest run` — 233/233 i 18 filer

**Ikke verifisert visuelt.** Sida ligger bak admin-innlogging, og den lokale `.env`-en peker på en tom localhost-database, så jeg hadde ingen innlogget adminbruker å se den med. Fargeklassene (`bg-destructive/10`, `bg-muted`, `bg-success/10`, `bg-warning/10`) er alle i bruk andre steder i kodebasen, men radene bør sjekkes i preview før merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
