### PR TITLE
feat(admin): verifiser bruker uten faddergruppe

### DIFF
--- a/src/app/(authenticated)/admin/users-tab.tsx
+++ b/src/app/(authenticated)/admin/users-tab.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { ChevronDown, Shield, ShieldOff, Trash2, UserCheck } from "lucide-react";
+import {
+  ChevronDown,
+  Shield,
+  ShieldOff,
+  Trash2,
+  UserCheck,
+} from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 import { api } from "~/trpc/react";
@@ -83,7 +89,7 @@ function StudieVelger({
         onChange(e.target.value === "" ? null : (e.target.value as Major))
       }
       title="Overstyr studieretningen TIHLDE oppgir, f.eks. for en som begynner på Digital transformasjon"
-      className="max-w-[13rem] rounded-lg border border-border bg-background !px-2 !py-1 text-xs text-foreground transition focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+      className="border-border bg-background text-foreground focus:ring-ring max-w-[13rem] rounded-lg border !px-2 !py-1 text-xs transition focus:ring-2 focus:outline-none disabled:opacity-60"
     >
       <option value="">
         Følg TIHLDE{studieretning ? ` (${studieretning})` : ""}
@@ -119,6 +125,22 @@ export function UsersTab() {
       void utils.admin.getGrupper.invalidate();
       setVerifyingUserId(null);
       toast("Bruker verifisert og lagt til i gruppe som fadderbarn");
+    },
+    onError: (error) => {
+      toast.error("Feil", { description: error.message });
+    },
+  });
+
+  // Verifisering uten gruppe: brukeren slipper inn med en gang, og dukker opp
+  // som kandidat i Faddergrupper-fanen til den skal plasseres.
+  const verifyOnlyMutation = api.admin.setUserVerified.useMutation({
+    onSuccess: () => {
+      void utils.admin.getUsers.invalidate();
+      setVerifyingUserId(null);
+      toast("Bruker verifisert uten gruppe", {
+        description:
+          "Legg brukeren i en faddergruppe senere fra Faddergrupper-fanen.",
+      });
     },
     onError: (error) => {
       toast.error("Feil", { description: error.message });
@@ -237,7 +259,7 @@ export function UsersTab() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center !py-12">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-transparent" />
+        <div className="border-border h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
       </div>
     );
   }
@@ -247,11 +269,11 @@ export function UsersTab() {
       {/* Unverified users — nedtonet, men fortsatt lett å komme til */}
       <section className="!space-y-3">
         <div className="flex items-center !gap-2">
-          <h3 className="text-sm font-medium text-muted-foreground">
+          <h3 className="text-muted-foreground text-sm font-medium">
             Nye uverifiserte brukere
           </h3>
           {unverifiedUsers.length > 0 && (
-            <span className="rounded-full bg-muted !px-2 !py-0.5 text-xs font-medium text-muted-foreground">
+            <span className="bg-muted text-muted-foreground rounded-full !px-2 !py-0.5 text-xs font-medium">
               {unverifiedUsers.length}
             </span>
           )}
@@ -262,28 +284,30 @@ export function UsersTab() {
             {unverifiedUsers.map((user) => (
               <div
                 key={user.id}
-                className="flex flex-col !gap-3 rounded-xl border border-border bg-card !p-4 sm:flex-row sm:items-center sm:justify-between"
+                className="border-border bg-card flex flex-col !gap-3 rounded-xl border !p-4 sm:flex-row sm:items-center sm:justify-between"
               >
                 <div className="min-w-0">
-                  <p className="font-medium break-words text-foreground">
+                  <p className="text-foreground font-medium break-words">
                     {user.name}
                   </p>
-                  <p className="text-sm break-all text-muted-foreground">
+                  <p className="text-muted-foreground text-sm break-all">
                     {user.email}
                   </p>
                   <div className="mt-1 flex flex-wrap !gap-1.5">
                     {user.klasse && (
-                      <span className="rounded-full bg-primary/10 !px-2 !py-0.5 text-xs font-medium text-primary">
+                      <span className="bg-primary/10 text-primary rounded-full !px-2 !py-0.5 text-xs font-medium">
                         {user.klasse}
                       </span>
                     )}
                     {user.studieretning && (
-                      <span className="rounded-full bg-primary/10 !px-2 !py-0.5 text-xs font-medium text-primary">
+                      <span className="bg-primary/10 text-primary rounded-full !px-2 !py-0.5 text-xs font-medium">
                         {user.studieretning}
                       </span>
                     )}
                     {!user.klasse && !user.studieretning && (
-                      <span className="text-xs text-muted-foreground">Ingen klasse/retning oppgitt</span>
+                      <span className="text-muted-foreground text-xs">
+                        Ingen klasse/retning oppgitt
+                      </span>
                     )}
                   </div>
                   <div className="!mt-2">
@@ -292,11 +316,14 @@ export function UsersTab() {
                       studieretningOverride={user.studieretningOverride}
                       disabled={studieMutation.isPending}
                       onChange={(studieretning) =>
-                        studieMutation.mutate({ userId: user.id, studieretning })
+                        studieMutation.mutate({
+                          userId: user.id,
+                          studieretning,
+                        })
                       }
                     />
                   </div>
-                  <p className="!mt-2 text-xs text-muted-foreground">
+                  <p className="text-muted-foreground !mt-2 text-xs">
                     Registrert{" "}
                     {new Date(user.createdAt).toLocaleDateString("no-NO", {
                       day: "numeric",
@@ -308,7 +335,7 @@ export function UsersTab() {
 
                 {verifyingUserId === user.id ? (
                   <div className="flex flex-col !gap-2 sm:items-end">
-                    <p className="text-xs font-medium text-muted-foreground">
+                    <p className="text-muted-foreground text-xs font-medium">
                       Velg faddergruppe:
                     </p>
                     <div className="flex flex-wrap !gap-2">
@@ -322,44 +349,68 @@ export function UsersTab() {
                               gruppeId: gruppe.id,
                             })
                           }
-                          disabled={verifyAndAssignMutation.isPending}
-                          className="rounded-lg border border-border bg-secondary !px-3 !py-1.5 text-xs font-medium text-foreground transition hover:bg-secondary/80 disabled:opacity-60"
+                          disabled={
+                            verifyAndAssignMutation.isPending ||
+                            verifyOnlyMutation.isPending
+                          }
+                          className="border-border bg-secondary text-foreground hover:bg-secondary/80 rounded-lg border !px-3 !py-1.5 text-xs font-medium transition disabled:opacity-60"
                         >
                           {gruppe.name}
                         </button>
                       ))}
                       <button
                         type="button"
+                        onClick={() =>
+                          verifyOnlyMutation.mutate({
+                            userId: user.id,
+                            isVerified: true,
+                          })
+                        }
+                        disabled={
+                          verifyAndAssignMutation.isPending ||
+                          verifyOnlyMutation.isPending
+                        }
+                        className="border-border text-muted-foreground hover:text-foreground hover:bg-secondary/60 rounded-lg border border-dashed !px-3 !py-1.5 text-xs font-medium transition disabled:opacity-60"
+                      >
+                        Uten gruppe
+                      </button>
+                      <button
+                        type="button"
                         onClick={() => setVerifyingUserId(null)}
-                        className="rounded-lg !px-3 !py-1.5 text-xs text-muted-foreground hover:text-foreground transition"
+                        className="text-muted-foreground hover:text-foreground rounded-lg !px-3 !py-1.5 text-xs transition"
                       >
                         Avbryt
                       </button>
                     </div>
                     {(!grupper || grupper.length === 0) && (
-                      <p className="text-xs text-destructive">
-                        Opprett en faddergruppe forst (i Faddergrupper-fanen)
+                      <p className="text-muted-foreground text-xs sm:text-right">
+                        Ingen faddergrupper enda — verifiser «Uten gruppe»,
+                        eller opprett en i Faddergrupper-fanen.
                       </p>
                     )}
                   </div>
                 ) : deletingUserId === user.id ? (
                   <div className="flex flex-col !gap-2 sm:items-end">
-                    <p className="text-xs font-medium text-destructive">
+                    <p className="text-destructive text-xs font-medium">
                       Sikker på at du vil slette denne brukeren?
                     </p>
                     <div className="flex flex-wrap !gap-2">
                       <button
                         type="button"
-                        onClick={() => deleteMutation.mutate({ userId: user.id })}
+                        onClick={() =>
+                          deleteMutation.mutate({ userId: user.id })
+                        }
                         disabled={deleteMutation.isPending}
-                        className="rounded-lg border border-destructive/40 bg-destructive/10 !px-3 !py-1.5 text-xs font-semibold text-destructive transition hover:bg-destructive/20 disabled:opacity-60"
+                        className="border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20 rounded-lg border !px-3 !py-1.5 text-xs font-semibold transition disabled:opacity-60"
                       >
-                        {deleteMutation.isPending ? "Sletter..." : "Bekreft sletting"}
+                        {deleteMutation.isPending
+                          ? "Sletter..."
+                          : "Bekreft sletting"}
                       </button>
                       <button
                         type="button"
                         onClick={() => setDeletingUserId(null)}
-                        className="rounded-lg !px-3 !py-1.5 text-xs text-muted-foreground transition hover:text-foreground"
+                        className="text-muted-foreground hover:text-foreground rounded-lg !px-3 !py-1.5 text-xs transition"
                       >
                         Avbryt
                       </button>
@@ -372,7 +423,7 @@ export function UsersTab() {
                     <button
                       type="button"
                       onClick={() => setVerifyingUserId(user.id)}
-                      className="inline-flex items-center !gap-2 rounded-xl border border-success/40 bg-success/10 !px-4 !py-2 text-sm font-semibold text-success transition hover:bg-success/20"
+                      className="border-success/40 bg-success/10 text-success hover:bg-success/20 inline-flex items-center !gap-2 rounded-xl border !px-4 !py-2 text-sm font-semibold transition"
                     >
                       <UserCheck className="h-4 w-4" />
                       Verifiser
@@ -380,7 +431,7 @@ export function UsersTab() {
                     <button
                       type="button"
                       onClick={() => setDeletingUserId(user.id)}
-                      className="inline-flex items-center !gap-2 rounded-xl border border-destructive/40 bg-destructive/10 !px-4 !py-2 text-sm font-semibold text-destructive transition hover:bg-destructive/20"
+                      className="border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20 inline-flex items-center !gap-2 rounded-xl border !px-4 !py-2 text-sm font-semibold transition"
                     >
                       <Trash2 className="h-4 w-4" />
                       Slett
@@ -391,7 +442,7 @@ export function UsersTab() {
             ))}
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Ingen uverifiserte brukere
           </p>
         )}
@@ -399,7 +450,7 @@ export function UsersTab() {
 
       {/* Verified users grouped by studieretning */}
       <section className="!space-y-4">
-        <h3 className="text-lg font-semibold text-foreground">
+        <h3 className="text-foreground text-lg font-semibold">
           Verifiserte brukere ({verifiedUsers.length})
         </h3>
 
@@ -411,19 +462,20 @@ export function UsersTab() {
             setSearch(e.target.value);
             setCollapsedWhileSearching(new Set());
           }}
-          className="w-full max-w-sm rounded-xl border border-border bg-background !px-4 !py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          className="border-border bg-background text-foreground placeholder:text-muted-foreground focus:ring-ring w-full max-w-sm rounded-xl border !px-4 !py-2.5 text-sm focus:ring-2 focus:outline-none"
         />
 
         <div className="!space-y-4">
           {studieretninger.map((studieretning) => {
-            const usersInGroup = verifiedByStudieretning.get(studieretning) ?? [];
+            const usersInGroup =
+              verifiedByStudieretning.get(studieretning) ?? [];
             const isExpanded = isSearching
               ? !collapsedWhileSearching.has(studieretning)
               : expandedMajor === studieretning;
             return (
               <div
                 key={studieretning}
-                className="overflow-hidden rounded-xl border border-border bg-card"
+                className="border-border bg-card overflow-hidden rounded-xl border"
               >
                 <button
                   type="button"
@@ -442,14 +494,16 @@ export function UsersTab() {
                   className="flex w-full items-center justify-between !gap-3 !p-4 text-left"
                 >
                   <div>
-                    <p className="font-semibold text-foreground">{studieretning}</p>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-foreground font-semibold">
+                      {studieretning}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
                       {usersInGroup.length}{" "}
                       {usersInGroup.length === 1 ? "bruker" : "brukere"}
                     </p>
                   </div>
                   <span className="flex items-center !gap-2">
-                    <span className="rounded-full bg-primary/10 !px-2.5 !py-0.5 text-sm font-semibold text-primary">
+                    <span className="bg-primary/10 text-primary rounded-full !px-2.5 !py-0.5 text-sm font-semibold">
                       {usersInGroup.length}
                     </span>
                     <motion.span
@@ -463,195 +517,215 @@ export function UsersTab() {
                 </button>
 
                 <AnimatePresence initial={false}>
-                {isExpanded && (
-                  <motion.div
-                    key="content"
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: "auto", opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
-                    transition={{
-                      height: { duration: 0.25, ease: [0.4, 0, 0.2, 1] },
-                      opacity: { duration: 0.15 },
-                    }}
-                    className="overflow-hidden border-t border-border"
-                  >
-                    {/* Se kommentaren i betalinger-tab: min-bredde framfor
+                  {isExpanded && (
+                    <motion.div
+                      key="content"
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: "auto", opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={{
+                        height: { duration: 0.25, ease: [0.4, 0, 0.2, 1] },
+                        opacity: { duration: 0.15 },
+                      }}
+                      className="border-border overflow-hidden border-t"
+                    >
+                      {/* Se kommentaren i betalinger-tab: min-bredde framfor
                         sammenklemte kolonner, med scroll ut til skjermkanten. */}
-                    <div className="overflow-x-auto">
-                    <table className="w-full min-w-[64rem] text-left text-sm">
-                      <thead>
-                        <tr className="border-b border-border text-muted-foreground">
-                          <th className="!px-4 !py-3 font-medium">Navn</th>
-                          <th className="!px-4 !py-3 font-medium">E-post</th>
-                          <th className="!px-4 !py-3 font-medium">Klasse</th>
-                          <th className="!px-4 !py-3 font-medium">Studie</th>
-                          <th className="!px-4 !py-3 font-medium">Gruppe</th>
-                          <th className="!px-4 !py-3 font-medium">Rolle</th>
-                          {/* Se `betalingsvisning`: viser faktisk status
+                      <div className="overflow-x-auto">
+                        <table className="w-full min-w-[64rem] text-left text-sm">
+                          <thead>
+                            <tr className="border-border text-muted-foreground border-b">
+                              <th className="!px-4 !py-3 font-medium">Navn</th>
+                              <th className="!px-4 !py-3 font-medium">
+                                E-post
+                              </th>
+                              <th className="!px-4 !py-3 font-medium">
+                                Klasse
+                              </th>
+                              <th className="!px-4 !py-3 font-medium">
+                                Studie
+                              </th>
+                              <th className="!px-4 !py-3 font-medium">
+                                Gruppe
+                              </th>
+                              <th className="!px-4 !py-3 font-medium">Rolle</th>
+                              {/* Se `betalingsvisning`: viser faktisk status
                               (betalt / ikke betalt), med fritak for faddere. */}
-                          <th className="!px-4 !py-3 font-medium">Betaling</th>
-                          <th className="!px-4 !py-3 font-medium text-center">Admin</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {usersInGroup.map((user) => {
-                          const membership = user.memberships[0];
-                          return (
-                            <tr
-                              key={user.id}
-                              className="border-b border-border last:border-0 hover:bg-muted/50"
-                            >
-                              <td className="!px-4 !py-3 font-medium text-foreground">
-                                {user.name}
-                              </td>
-                              <td className="!px-4 !py-3 text-muted-foreground">
-                                {user.email}
-                              </td>
-                              <td className="!px-4 !py-3">
-                                {user.klasse ? (
-                                  <span className="rounded-full bg-primary/10 !px-2 !py-0.5 text-xs font-medium text-primary">
-                                    {user.klasse}
-                                  </span>
-                                ) : (
-                                  <span className="text-muted-foreground">—</span>
-                                )}
-                              </td>
-                              {/* TIHLDE eier studieretningen, men henger etter
+                              <th className="!px-4 !py-3 font-medium">
+                                Betaling
+                              </th>
+                              <th className="!px-4 !py-3 text-center font-medium">
+                                Admin
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {usersInGroup.map((user) => {
+                              const membership = user.memberships[0];
+                              return (
+                                <tr
+                                  key={user.id}
+                                  className="border-border hover:bg-muted/50 border-b last:border-0"
+                                >
+                                  <td className="text-foreground !px-4 !py-3 font-medium">
+                                    {user.name}
+                                  </td>
+                                  <td className="text-muted-foreground !px-4 !py-3">
+                                    {user.email}
+                                  </td>
+                                  <td className="!px-4 !py-3">
+                                    {user.klasse ? (
+                                      <span className="bg-primary/10 text-primary rounded-full !px-2 !py-0.5 text-xs font-medium">
+                                        {user.klasse}
+                                      </span>
+                                    ) : (
+                                      <span className="text-muted-foreground">
+                                        —
+                                      </span>
+                                    )}
+                                  </td>
+                                  {/* TIHLDE eier studieretningen, men henger etter
                                   for den som begynner på et påbygg som Digital
                                   transformasjon. Da er dette veien inn. */}
-                              <td className="!px-4 !py-3">
-                                <StudieVelger
-                                  studieretning={user.studieretning}
-                                  studieretningOverride={user.studieretningOverride}
-                                  disabled={studieMutation.isPending}
-                                  onChange={(studieretning) =>
-                                    studieMutation.mutate({
-                                      userId: user.id,
-                                      studieretning,
-                                    })
-                                  }
-                                />
-                              </td>
-                              <td className="!px-4 !py-3 text-muted-foreground">
-                                {membership ? membership.gruppe.name : "—"}
-                              </td>
-                              <td className="!px-4 !py-3">
-                                {membership ? (
-                                  <button
-                                    type="button"
-                                    onClick={() =>
-                                      updateRoleMutation.mutate({
-                                        membershipId: membership.id,
-                                        role:
+                                  <td className="!px-4 !py-3">
+                                    <StudieVelger
+                                      studieretning={user.studieretning}
+                                      studieretningOverride={
+                                        user.studieretningOverride
+                                      }
+                                      disabled={studieMutation.isPending}
+                                      onChange={(studieretning) =>
+                                        studieMutation.mutate({
+                                          userId: user.id,
+                                          studieretning,
+                                        })
+                                      }
+                                    />
+                                  </td>
+                                  <td className="text-muted-foreground !px-4 !py-3">
+                                    {membership ? membership.gruppe.name : "—"}
+                                  </td>
+                                  <td className="!px-4 !py-3">
+                                    {membership ? (
+                                      <button
+                                        type="button"
+                                        onClick={() =>
+                                          updateRoleMutation.mutate({
+                                            membershipId: membership.id,
+                                            role:
+                                              membership.role === "FADDER"
+                                                ? "FADDERBARN"
+                                                : "FADDER",
+                                          })
+                                        }
+                                        disabled={updateRoleMutation.isPending}
+                                        className={`rounded-full !px-3 !py-1 text-xs font-semibold transition ${
                                           membership.role === "FADDER"
-                                            ? "FADDERBARN"
-                                            : "FADDER",
-                                      })
-                                    }
-                                    disabled={updateRoleMutation.isPending}
-                                    className={`rounded-full !px-3 !py-1 text-xs font-semibold transition ${
-                                      membership.role === "FADDER"
-                                        ? "bg-primary/10 text-primary hover:bg-primary/20"
-                                        : "bg-primary/10 text-primary hover:bg-primary/20"
-                                    }`}
-                                    title={
-                                      membership.role === "FADDER"
-                                        ? "Klikk for a endre til fadderbarn"
-                                        : "Klikk for a endre til fadder"
-                                    }
-                                  >
-                                    {membership.role === "FADDER"
-                                      ? "Fadder"
-                                      : "Fadderbarn"}
-                                  </button>
-                                ) : (
-                                  <span className="text-muted-foreground">—</span>
-                                )}
-                              </td>
-                              {/* Faddere betaler ikke. Utledes fra kullet, så
+                                            ? "bg-primary/10 text-primary hover:bg-primary/20"
+                                            : "bg-primary/10 text-primary hover:bg-primary/20"
+                                        }`}
+                                        title={
+                                          membership.role === "FADDER"
+                                            ? "Klikk for a endre til fadderbarn"
+                                            : "Klikk for a endre til fadder"
+                                        }
+                                      >
+                                        {membership.role === "FADDER"
+                                          ? "Fadder"
+                                          : "Fadderbarn"}
+                                      </button>
+                                    ) : (
+                                      <span className="text-muted-foreground">
+                                        —
+                                      </span>
+                                    )}
+                                  </td>
+                                  {/* Faddere betaler ikke. Utledes fra kullet, så
                                   denne bryteren er unntaket for tilfellene
                                   regelen ikke ser — og den låser valget. */}
-                              <td className="!px-4 !py-3">
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    fadderMutation.mutate({
-                                      userId: user.id,
-                                      isFadder: !user.isFadder,
-                                    })
-                                  }
-                                  disabled={fadderMutation.isPending}
-                                  className={`rounded-full !px-3 !py-1 text-xs font-semibold transition ${betalingsvisning(user).className}`}
-                                  title={betalingsvisning(user).hint}
-                                >
-                                  {betalingsvisning(user).label}
-                                </button>
-                                {/* Bare for de som ennå ikke er TIHLDE-
+                                  <td className="!px-4 !py-3">
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        fadderMutation.mutate({
+                                          userId: user.id,
+                                          isFadder: !user.isFadder,
+                                        })
+                                      }
+                                      disabled={fadderMutation.isPending}
+                                      className={`rounded-full !px-3 !py-1 text-xs font-semibold transition ${betalingsvisning(user).className}`}
+                                      title={betalingsvisning(user).hint}
+                                    >
+                                      {betalingsvisning(user).label}
+                                    </button>
+                                    {/* Bare for de som ennå ikke er TIHLDE-
                                     medlemmer. Forsvinner av seg selv når de har
                                     logget inn med TIHLDE, siden det nullstiller
                                     det lokale passordet. */}
-                                {user.harLokalKonto && (
-                                  <button
-                                    type="button"
-                                    onClick={() =>
-                                      aktiverMutation.mutate({ userId: user.id })
-                                    }
-                                    disabled={aktiverMutation.isPending}
-                                    className="bg-primary/10 text-primary hover:bg-primary/20 !ml-2 rounded-full !px-3 !py-1 text-xs font-semibold transition"
-                                    title="Oppretter TIHLDE-bruker på tihlde.org. Studenten setter selv passord med «glemt passord» der."
-                                  >
-                                    Aktiver
-                                  </button>
-                                )}
-                              </td>
-                              <td className="!px-4 !py-3 text-center">
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    adminMutation.mutate({
-                                      userId: user.id,
-                                      isAdmin: !user.isAdmin,
-                                    })
-                                  }
-                                  disabled={adminMutation.isPending}
-                                  className="inline-flex items-center justify-center rounded-lg !p-1.5 transition hover:bg-foreground/10"
-                                  title={
-                                    user.isAdmin
-                                      ? "Fjern admintilgang"
-                                      : "Gi admintilgang"
-                                  }
+                                    {user.harLokalKonto && (
+                                      <button
+                                        type="button"
+                                        onClick={() =>
+                                          aktiverMutation.mutate({
+                                            userId: user.id,
+                                          })
+                                        }
+                                        disabled={aktiverMutation.isPending}
+                                        className="bg-primary/10 text-primary hover:bg-primary/20 !ml-2 rounded-full !px-3 !py-1 text-xs font-semibold transition"
+                                        title="Oppretter TIHLDE-bruker på tihlde.org. Studenten setter selv passord med «glemt passord» der."
+                                      >
+                                        Aktiver
+                                      </button>
+                                    )}
+                                  </td>
+                                  <td className="!px-4 !py-3 text-center">
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        adminMutation.mutate({
+                                          userId: user.id,
+                                          isAdmin: !user.isAdmin,
+                                        })
+                                      }
+                                      disabled={adminMutation.isPending}
+                                      className="hover:bg-foreground/10 inline-flex items-center justify-center rounded-lg !p-1.5 transition"
+                                      title={
+                                        user.isAdmin
+                                          ? "Fjern admintilgang"
+                                          : "Gi admintilgang"
+                                      }
+                                    >
+                                      {user.isAdmin ? (
+                                        <Shield className="text-warning h-4 w-4" />
+                                      ) : (
+                                        <ShieldOff className="text-muted-foreground h-4 w-4" />
+                                      )}
+                                    </button>
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                            {usersInGroup.length === 0 && (
+                              <tr>
+                                <td
+                                  colSpan={8}
+                                  className="text-muted-foreground !px-4 !py-6 text-center"
                                 >
-                                  {user.isAdmin ? (
-                                    <Shield className="h-4 w-4 text-warning" />
-                                  ) : (
-                                    <ShieldOff className="h-4 w-4 text-muted-foreground" />
-                                  )}
-                                </button>
-                              </td>
-                            </tr>
-                          );
-                        })}
-                        {usersInGroup.length === 0 && (
-                          <tr>
-                            <td
-                              colSpan={8}
-                              className="!px-4 !py-6 text-center text-muted-foreground"
-                            >
-                              Ingen brukere funnet
-                            </td>
-                          </tr>
-                        )}
-                      </tbody>
-                    </table>
-                    </div>
-                  </motion.div>
-                )}
+                                  Ingen brukere funnet
+                                </td>
+                              </tr>
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
+                    </motion.div>
+                  )}
                 </AnimatePresence>
               </div>
             );
           })}
           {isSearching && studieretninger.length === 0 && (
-            <p className="rounded-xl border border-border bg-card !p-4 text-sm text-muted-foreground">
+            <p className="border-border bg-card text-muted-foreground rounded-xl border !p-4 text-sm">
               Ingen brukere funnet
             </p>
           )}

--- a/tests/integration/admin-router.test.ts
+++ b/tests/integration/admin-router.test.ts
@@ -98,6 +98,11 @@ describe("admin: brukere og grupper", () => {
     expect(
       (await db.user.findUniqueOrThrow({ where: { id: user.id } })).isVerified,
     ).toBe(true);
+    // «Uten gruppe»-knappen i Brukere-fanen går hit: verifiseringen skal stå
+    // på egne ben, uten å plassere noen i en faddergruppe.
+    expect(
+      await db.fadderGruppeMember.count({ where: { userId: user.id } }),
+    ).toBe(0);
   });
 
   it("nekter å slette verifiserte brukere", async () => {


### PR DESCRIPTION
## Hva

«Verifiser» i Brukere-fanen fungerer som før — den åpner gruppevalget — men der ligger nå en ekstra knapp: **«Uten gruppe»**.

Før var eneste vei gjennom `verifyAndAssign`, som gjør begge deler i én operasjon. Hadde man ingen faddergrupper enda, var flyten helt låst («Opprett en faddergruppe først»).

## Endringer

- `users-tab.tsx`: ny mutasjon mot det eksisterende `admin.setUserVerified`, med egen toast som sier at brukeren kan plasseres senere fra Faddergrupper-fanen. Knappen har stiplet kant så den skiller seg fra gruppeknappene, og alle knappene disables mens en mutasjon kjører.
- Beskjeden når det ikke finnes grupper er ikke lenger en rød blokkering, men peker på den nye knappen.
- `admin-router.test.ts`: testen for `setUserVerified` slår nå også fast at det ikke opprettes noe gruppemedlemskap.

Backend er uendret. `setUserVerified` fantes allerede og var testdekket, men ble ikke kalt fra noe UI. Tilstanden «verifisert uten gruppe» er allerede forventet andre steder: Faddergrupper-fanen lister nettopp disse som kandidater, og tilgangssjekken ser bare på `isVerified`/`hasPaid` — aldri på gruppemedlemskap.

## Verifisert

- `npm run check` — eslint (0 feil), `tsc --noEmit`, 233 tester grønne
- `npm run build` grønn

Ikke klikket gjennom i nettleser: den lokale dev-databasen er ute av synk med schemaet (`User.passwordHash` mangler en migrasjon), så admin-innlogging lokalt feiler. Uavhengig av denne endringen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)