### PR TITLE
Si fra til fadderbarn at faddergruppa kommer på mandag

### DIFF
--- a/src/app/(authenticated)/components/gruppe-notice.tsx
+++ b/src/app/(authenticated)/components/gruppe-notice.tsx
@@ -1,0 +1,66 @@
+import { Users } from "lucide-react";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { Card } from "~/components/ui/card";
+import { auth } from "~/server/auth/config";
+import { db } from "~/server/db";
+import {
+  areGrupperPublished,
+  canSeeGruppe,
+  GRUPPE_WAIT_DESCRIPTION,
+} from "~/server/gruppe-visibility";
+
+/**
+ * Fadderbarn som ikke har en gruppe å gå til lurer på om noe er galt med
+ * påmeldingen deres. De fant bare ut av det ved å klikke seg inn på
+ * /faddergruppe, så beskjeden ligger nå også på forsiden — der alle lander.
+ *
+ * Vises ikke til faddere og admins (de ser gruppene hele tiden), og forsvinner
+ * av seg selv når gruppene publiseres og fadderbarnet har et medlemskap.
+ */
+export default async function GruppeNotice() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  const user = session?.user;
+  // Faddere venter ikke på noe slipp, så beskjeden er ikke deres.
+  if (!user || user.isAdmin || user.isFadder) return null;
+
+  const membership = await db.fadderGruppeMember.findFirst({
+    where: { userId: user.id },
+    select: { role: true },
+  });
+
+  const published = await areGrupperPublished(db);
+  if (
+    membership &&
+    canSeeGruppe({
+      isAdmin: user.isAdmin,
+      role: membership.role,
+      published,
+    })
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="container mx-auto w-full px-4 pt-2 pb-10">
+      <Card className="flex-row items-start gap-4 px-5 py-5">
+        <Users className="text-muted-foreground mt-0.5 size-5 shrink-0" />
+        <div className="flex flex-col gap-1.5">
+          <p className="text-foreground font-medium">
+            Du har ikke fått faddergruppe enda
+          </p>
+          <p className="text-muted-foreground text-pretty">
+            {GRUPPE_WAIT_DESCRIPTION} Da finner du den under{" "}
+            <Link
+              href="/faddergruppe"
+              className="text-foreground underline underline-offset-4"
+            >
+              Min faddergruppe
+            </Link>
+            .
+          </p>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/faddergruppe/page.tsx
+++ b/src/app/(authenticated)/faddergruppe/page.tsx
@@ -4,7 +4,12 @@ import { PageHeader, PageShell } from "~/components/layout/page-shell";
 import { Card } from "~/components/ui/card";
 import { auth } from "~/server/auth/config";
 import { db } from "~/server/db";
-import { areGrupperPublished, canSeeGruppe } from "~/server/gruppe-visibility";
+import {
+  areGrupperPublished,
+  canSeeGruppe,
+  GRUPPE_RELEASE_LABEL,
+  GRUPPE_WAIT_DESCRIPTION,
+} from "~/server/gruppe-visibility";
 import { GroupView } from "./group-view";
 
 export default async function FaddergroupPage() {
@@ -44,8 +49,8 @@ export default async function FaddergroupPage() {
         <PageHeader
           centered
           className="max-w-md"
-          title="Ingen faddergruppe"
-          description="Du er ikke tildelt en faddergruppe enda. Kontakt en administrator for å bli lagt til i en gruppe."
+          title="Du har ikke fått faddergruppe enda"
+          description={`${GRUPPE_WAIT_DESCRIPTION} Kom tilbake hit da, så finner du gruppa di, fadderne dine og resten av gjengen.`}
         />
       </PageShell>
     );
@@ -66,8 +71,8 @@ export default async function FaddergroupPage() {
         <PageHeader
           centered
           className="max-w-md"
-          title="Faddergruppene slippes snart"
-          description="Vi holder fortsatt gruppene hemmelige. Så snart de er klare finner du gruppa di, fadderne dine og resten av gjengen her."
+          title={`Faddergruppene slippes ${GRUPPE_RELEASE_LABEL}`}
+          description={`Vi holder fortsatt gruppene hemmelige. Kom tilbake hit ${GRUPPE_RELEASE_LABEL}, så finner du gruppa di, fadderne dine og resten av gjengen.`}
         />
       </PageShell>
     );

--- a/src/app/(authenticated)/page.tsx
+++ b/src/app/(authenticated)/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import Countdown from "~/app/(authenticated)/components/countdown";
+import GruppeNotice from "~/app/(authenticated)/components/gruppe-notice";
 import Hero from "~/app/(authenticated)/components/hero";
 import HorizontalEventsList, {
   PLACEHOLDER_IMAGE,
@@ -26,6 +27,8 @@ export default async function Home() {
   return (
     <div className="relative flex w-full flex-1 flex-col overflow-hidden">
       <Hero />
+
+      <GruppeNotice />
 
       <div className="mt-auto flex flex-col gap-6 pb-8">
         {events[0] ? <Countdown activity={events[0]} /> : null}

--- a/src/server/gruppe-visibility.ts
+++ b/src/server/gruppe-visibility.ts
@@ -16,6 +16,17 @@ import type { MemberRole } from "@prisma/client";
 /** Primærnøkkelen til den ene raden i `AppSetting`. */
 export const APP_SETTING_ID = "singleton";
 
+/**
+ * Når fadderbarna får gruppene sine. Står ett sted fordi teksten gjentas på
+ * forsiden og på /faddergruppe — flytter slippet seg, endres begge her.
+ */
+export const GRUPPE_RELEASE_LABEL = "på mandag";
+
+/** Forklaringen fadderbarn får mens de venter, uansett hvor de leser den. */
+export const GRUPPE_WAIT_DESCRIPTION =
+  `Fadderkom setter fortsatt sammen gruppene, så du er ikke tildelt en ` +
+  `faddergruppe enda. Alle fadderbarn får gruppa si ${GRUPPE_RELEASE_LABEL}.`;
+
 type Db = Pick<PrismaClient, "appSetting">;
 
 /** Når gruppene ble publisert, eller `null` hvis de fortsatt er skjult. */


### PR DESCRIPTION
## Hva

Fadderbarn som ikke har fått faddergruppe enda får nå beskjed om at den kommer på mandag — både på forsiden og på /faddergruppe.

- **Nytt banner på forsiden** (`gruppe-notice.tsx`), rett under heroen: «Du har ikke fått faddergruppe enda … Alle fadderbarn får gruppa si på mandag.» med lenke til Min faddergruppe.
- **/faddergruppe**: begge tomme tilstander er skrevet om. «Ingen faddergruppe – kontakt en administrator» og «Faddergruppene slippes snart» sier nå når gruppa faktisk kommer.
- Teksten ligger som `GRUPPE_RELEASE_LABEL` og `GRUPPE_WAIT_DESCRIPTION` i `gruppe-visibility.ts`, ved siden av regelen den beskriver. Flytter slippet seg, endres én linje.

## Hvorfor

Fadderbarn uten gruppe fant det bare ut ved å klikke seg inn på /faddergruppe, og der sto det «kontakt en administrator» — som leses som at noe er galt med påmeldingen. Nå står beskjeden der alle lander.

## For reviewer

Banneret vises kun til fadderbarn som ikke kan se en gruppe enda — admins og faddere ser det aldri, og det forsvinner av seg selv når FadderKom trykker publiser. Det dekker begge ventetilstandene: ingen medlemskap i det hele tatt, og medlemskap som ennå ikke er publisert.

«på mandag» står uten dato. Si fra hvis dere heller vil ha «mandag 10. august».

## Testet

Kjørt lokalt mot dev-DB med en oppdiktet fadderbarn-bruker, verifisert i nettleseren på desktop og mobil (375px):

- forsiden uten gruppe → banner
- forsiden med gruppe, upublisert → banner
- forsiden etter publisering → banner borte
- /faddergruppe i begge ventetilstandene

`tsc --noEmit`, `eslint .` (0 errors) og `vitest run` (233 passerte) er grønne, og `next build` går gjennom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)